### PR TITLE
ERXEnterpriseObjectArrayCache#isNotFound

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObjectArrayCache.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObjectArrayCache.java
@@ -210,7 +210,7 @@ public class ERXEnterpriseObjectArrayCache<T extends EOEnterpriseObject> {
     }
 
 	protected boolean isNotFound(NSArray<EOGlobalID> gids) {
-		return gids != null ? NotFoundArray.class == gids.getClass() : gids == null;
+		return gids != null ? NotFoundArray.class == gids.getClass() : false;
 	}
   
     /**


### PR DESCRIPTION
ERXEnterpriseObjectArrayCache#isNotFound(null) was returning true causing handleUnsuccessfullQueryForKey() never beeing called
