### PR TITLE
add action and function for clear button

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.api
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.api
@@ -33,5 +33,7 @@
         <binding name="finishedFunction"/>
     <binding defaults="Boolean" name="clearUploadProgressOnSuccess"/>
     <binding name="mimeType"/>
+    <binding name="clearedFunction"/>
+        <binding name="clearedAction"/>
     </wo>
 </wodefinitions>

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
@@ -34,12 +34,14 @@ import er.extensions.localization.ERXLocalizer;
  * @binding startedFunction the javascript function to execute when the progress is started
  * @binding canceledFunction the javascript function to execute when the upload is canceled
  * @binding succeededFunction the javascript function to execute when the upload succeeds
+ * @binding clearedFunction the javascript function to execute when the clear button is clicked
  * @binding failedFunction the javascript function to execute when the upload fails
  * @binding finishedFunction the javascript function to execute when the upload finishes (succeeded, failed, or
  *          canceled)
  * @binding finishedAction the action to fire when the upload finishes (cancel, failed, or succeeded)
  * @binding canceledAction the action to fire when the upload is canceled
  * @binding succeededAction the action to fire when the upload succeeded
+ * @binding clearedAction the action to fire when the clear button is clicked
  * @binding failedAction the action to fire when the upload fails
  * @binding data the NSData that will be bound with the contents of the upload
  * @binding inputStream will be bound to an input stream on the contents of the upload
@@ -85,6 +87,7 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
 		public static final String finishedFunction = "finishedFunction";
 		public static final String failedFunction = "failedFunction";
 		public static final String succeededFunction = "succeededFunction";
+		public static final String clearedFunction = "clearedFunction";
 		public static final String selectFileButtonClass = "selectFileButtonClass";
 		public static final String uploadButtonClass = "uploadButtonClass";
 		public static final String cancelButtonClass = "cancelButtonClass";
@@ -235,6 +238,9 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
     	
     	String succeededFunction = (String)this.valueForBinding(Keys.succeededFunction);
     	if (succeededFunction != null) _options.addObject(String.format("succeededFunction:%s", succeededFunction));
+    	
+    	String clearedFunction = (String)this.valueForBinding(Keys.clearedFunction);
+    	if (clearedFunction != null) _options.addObject(String.format("clearedFunction:%s", clearedFunction));
     	
     	return _options;
     }
@@ -514,9 +520,12 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
 	/**
 	 * Action called by the clear button, resets the uploader for a new file selection
 	 * 
+	 * @return results of action
 	 */
-	public void clearFileResults() {
+	public WOActionResults clearFileResults() {
 		clearUploadProgress();
+		WOActionResults results = (WOActionResults) valueForBinding("clearedAction");
+		return results;
 	}
 	
 	/**

--- a/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
@@ -1114,6 +1114,8 @@ var AjaxUploadClient = Class.create({
 		$('AFUSelectFileButtonWrapper' + this.id).show();
 		$('AFUClearButton' + this.id).hide();
 		$('AFUFileObject' + this.id).hide();
+		if (this.options.clearedFunction)
+			this.options.clearedFunction(this.id);
 	},
 	cancel: function() {
 		$('AFUFileNameWrapper' + this.id).update(this.labels.upload_canceling);


### PR DESCRIPTION
The AjaxFlexibleFileUpload component lacks an optional action and function binding for the clear button. This enables to remove/delete any information/data that has been created during a prior succeededAction.
