### PR TITLE
correct output file format argument for sips

### DIFF
--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/thumbnail/SipsImageProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/thumbnail/SipsImageProcessor.java
@@ -42,8 +42,8 @@ public class SipsImageProcessor extends ERImageProcessor {
       
       if (outputMimeType != null) {
         commands.add("--setProperty");
-        commands.add("typeIdentifier");
-        commands.add(outputMimeType.uti());
+        commands.add("format");
+        commands.add(outputMimeType.subtype());
       }
       
       if (compressionQuality != -1) {


### PR DESCRIPTION
When specifying a certain output mime type the correct sips property key is 'format' followed by the subtype instead of the current 'typeIdentifier' which is a read-only property (at least as of OS X 10.6).
