### PR TITLE
fetchBLOB must return NSData object

### DIFF
--- a/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
+++ b/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
@@ -39,6 +39,7 @@ import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSMutableSet;
 import com.webobjects.foundation.NSPropertyListSerialization;
+import com.webobjects.foundation.NSRange;
 import com.webobjects.foundation.NSSelector;
 import com.webobjects.foundation.NSTimeZone;
 
@@ -359,7 +360,8 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 			return blob;
 		else {
 			try {
-				return new NSData(blob.getBytes(1, (int) blob.length()));
+				byte[] bytes = blob.getBytes(1, (int) blob.length());
+				return new NSData(bytes, new NSRange(0, bytes.length), true);
 			}
 			catch (Exception ioexception) {
 				throw new JDBCAdaptorException(ioexception.getMessage(), null);


### PR DESCRIPTION
fetchBLOB must return NSData object as any blob attribute that has a valueFactoryMethod will cause an exception otherwise

The FrontBasePlugIn wrongly calls attribute.newValueForBytes that will transform the fetched bytes into a desired object type by calling the valueFactoryMethod (exemplarily the prototype mutableDictionary that will cause a transformation into an ERXMutableDictionary) and should return the bytes as an NSData object instead because if there is a valueFactoryMethod set for that attribute the JDBCColumn._fetchCorrectObject() method will then try to make the very same transformation again failing with an exception as it expects an NSData object.
