### PR TITLE
use correct browser version string as browser object for Safari uses app 

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
@@ -450,11 +450,11 @@ public class ERXWOForm extends com.webobjects.appserver._private.WOHTMLDynamicEl
 				if (_multipleSubmit != null && _multipleSubmit.booleanValueInComponent(context.component())) {
 					if (_addDefaultSubmitButton != null && _addDefaultSubmitButton.booleanValueInComponent(context.component()) || (_addDefaultSubmitButton == null && addDefaultSubmitButtonDefault)) {
 						ERXBrowser browser = ERXBrowserFactory.factory().browserMatchingRequest(context.request());
-						boolean useDisplayNone = !(browser.isSafari() && browser.version().compareTo("522") > 0);
+						boolean useDisplayNone = !(browser.isSafari() && browser.version().compareTo("3.0.3") > 0);
 						if(useDisplayNone) {
 							response._appendContentAsciiString("<div style=\"position: absolute; left: -10000px; display: none;\"><input type=\"submit\" name=\"WOFormDummySubmit\" value=\"WOFormDummySubmit\" /></div>");
 						} else {
-							response._appendContentAsciiString("<div style=\"position: absolute; left: -10000px; \"><input type=\"submit\" name=\"WOFormDummySubmit\" value=\"WOFormDummySubmit\" /></div>");
+							response._appendContentAsciiString("<div style=\"position: absolute; left: -10000px; visibility: hidden\"><input type=\"submit\" name=\"WOFormDummySubmit\" value=\"WOFormDummySubmit\" /></div>");
 						}
 					}
 				}


### PR DESCRIPTION
The defaultSubmitButton binding checks if the submit button should have the style 'display:none' as Safari will ignore hidden submit buttons in contrast to other browsers.
The browser object changed a while back and extracts now the app version of Safari from the user agent string instead of the WebKit version. This makes the version comparison in ERXWOForm choose 'display:none' for Safari too breaking the default submit behavior.
Additionally we can add a 'visibility:none' for Safari to be sure that the submit button is not visible.
