### PR TITLE
ERXWOForm preventIncompleteSubmit binding

### DIFF
--- a/Frameworks/Core/ERExtensions/Components/ERXWOForm.api
+++ b/Frameworks/Core/ERExtensions/Components/ERXWOForm.api
@@ -15,6 +15,7 @@
         <binding name="method"/>
         <binding name="disabled"/>
         <binding name="fragmentIdentifier"/>
+        <binding name="preventIncompleteSubmit"/>
 	<validation message="Either one of 'action' or 'href' may be bound, or either or both of 'actionClass' and 'directActionName' may be bound">
 		<count test=">1">
 			<bound name="action"/>


### PR DESCRIPTION
I've added a binding to ERXWOForm which when true, will append a hidden field to the end of the form. If this field is not present in the request, it can be assumed that the entire form wasn't finished loading in the browser before submission, and will therefore bypass takeValuesFromRequest to avoid data loss.

It will fall back to normal behaviour for partial ajax submits (not sure if i'm detecting this properly).

This is my first patch and git experience, I've tried to follow all rules I could find, apologies in advance if I've missed something.

Cheers!
