### PR TITLE
FrontBase should set default for primary key

### DIFF
--- a/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
+++ b/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
@@ -1932,7 +1932,7 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 		 * helps <code>FrontbaseExpression</code> to assemble
 		 * the correct join clause.
 		 */
-		public class JoinClause {
+		public static class JoinClause {
 			String table1;
 			String op;
 			String table2;


### PR DESCRIPTION
The primary key of a table should have a default value (taken from the internal table counter) to match the behavior of the PostgreSQL plugin that uses the associated sequence to set a default value if none passed.

Besides this two variables were not used at all in _FrontBasePlugIn.java as well as the inner class JoinClause can be changed to static.
