### PR TITLE
Changed code in JavaMonitor to properly read the id from a delete instance REST call

### DIFF
--- a/Applications/JavaMonitor/Sources/com/webobjects/monitor/rest/MApplicationController.java
+++ b/Applications/JavaMonitor/Sources/com/webobjects/monitor/rest/MApplicationController.java
@@ -3,7 +3,6 @@ package com.webobjects.monitor.rest;
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WORequest;
 import com.webobjects.foundation.NSMutableArray;
-import com.webobjects.foundation.NSNumberFormatter;
 import com.webobjects.monitor._private.MApplication;
 import com.webobjects.monitor._private.MHost;
 import com.webobjects.monitor._private.MInstance;


### PR DESCRIPTION
The change is in com/webobjects/monitor/rest/MApplicationController.java: deleteInstanceAction(). It's now using Integer.valueOf(request().stringFormValueForKey("id"))
