### PR TITLE
Make AjaxDatePicker work with org.joda.time.LocalDate.

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDatePicker.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDatePicker.java
@@ -1,7 +1,6 @@
 package er.ajax;
 
 import java.text.Format;
-
 import java.text.SimpleDateFormat;
 
 import com.webobjects.appserver.WOActionResults;
@@ -14,6 +13,7 @@ import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSTimestampFormatter;
 
 import er.extensions.appserver.ERXResponseRewriter;
+import er.extensions.formatters.ERXJodaLocalDateFormatter;
 
 /**
  * Shameless port and adoption of Rails Date Kit.  This input understands the format symbols
@@ -118,6 +118,9 @@ public class AjaxDatePicker extends AjaxComponent {
     		}
     		else if (formatter instanceof SimpleDateFormat) {
     			format = ((SimpleDateFormat)formatter).toPattern();
+    		}
+    		else if (formatter instanceof ERXJodaLocalDateFormatter) {
+    			format = ((ERXJodaLocalDateFormatter)formatter).toPattern();
     		}
     		else {
     			throw new RuntimeException("Can't handle formatter of class " + formatter.getClass().getCanonicalName());

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/formatters/ERXJodaLocalDateFormatter.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/formatters/ERXJodaLocalDateFormatter.java
@@ -14,6 +14,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 public class ERXJodaLocalDateFormatter extends Format {
+	private final String patternUsed;
 	private final DateTimeFormatter formatter;
 
 	public ERXJodaLocalDateFormatter(String pattern) {
@@ -33,6 +34,7 @@ public class ERXJodaLocalDateFormatter extends Format {
 	}
 	
 	public ERXJodaLocalDateFormatter(String pattern, Chronology chronology, Locale locale, DateTimeZone zone) {
+		patternUsed = pattern;
 		DateTimeFormatter f = DateTimeFormat.forPattern(pattern);
 		if(chronology != null) { f = f.withChronology(chronology); }
 		if(locale != null) { f = f.withLocale(locale); }
@@ -58,4 +60,7 @@ public class ERXJodaLocalDateFormatter extends Format {
 		return ld;
 	}
 
+	public String toPattern() {
+		return patternUsed;
+	}
 }


### PR DESCRIPTION
I've modified both AjaxDatePicker to accept a ERXJodaLocalDateFormatter in the formatter binding. I had to modify the formatter to save the pattern in the init as I find no way to retrieve it latter.
Is this useful for anybody else?
