### PR TITLE
Parsing error in ERFileAttachmentProcessor

### DIFF
--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERFileAttachmentProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERFileAttachmentProcessor.java
@@ -92,7 +92,7 @@ public class ERFileAttachmentProcessor extends ERAttachmentProcessor<ERFileAttac
       String desiredFileName = desiredFilesystemPath.getName();
       String actualFileName = actualFilesystemPath.getName();
       // in case the name was not unique and changed, we need to update webPath ...
-      webPath = webPath.replaceAll(desiredFileName + "$", actualFileName);
+      webPath = webPath.replaceAll("\\Q" + desiredFileName + "\\E$", actualFileName);
 
       attachment.setWebPath(webPath);
       attachment.setFilesystemPath(actualFilesystemPath.getAbsolutePath());


### PR DESCRIPTION
Can't just use some random unknown string as a regex pattern and not expect problems. There will still be an error if the filename being parsed contains \E.

Signed-off-by: David Holt dholt@cscw.ca
