### PR TITLE
check if param is null and use default value then

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/localization/ERXLocalizer.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/localization/ERXLocalizer.java
@@ -287,10 +287,20 @@ public class ERXLocalizer implements NSKeyValueCoding, NSKeyValueCodingAdditions
 
 	private static NSArray _languagesWithoutPluralForm = new NSArray(new Object[] { "Japanese" });
 
+	/**
+	 * Get a localizer for a specific language. If none could be found or language
+	 * is <code>null</code> a localizer for the {@link #defaultLanguage()} is returned.
+	 * 
+	 * @param language name of the requested language
+	 * @return localizer
+	 */
 	public static ERXLocalizer localizerForLanguage(String language) {
 		if (!isLocalizationEnabled)
 			return createLocalizerForLanguage("Nonlocalized", false);
 
+		if (language == null) {
+			language = defaultLanguage();
+		}
 		ERXLocalizer l = null;
 		l = (ERXLocalizer) localizers.objectForKey(language);
 		if (l == null) {
@@ -319,6 +329,7 @@ public class ERXLocalizer implements NSKeyValueCoding, NSKeyValueCodingAdditions
 	 * Returns the default language (English) or the contents of the
 	 * <code>er.extensions.ERXLocalizer.defaultLanguage</code> property.
 	 * 
+	 * @return default language name
 	 */
 	public static String defaultLanguage() {
 		if (defaultLanguage == null) {


### PR DESCRIPTION
ERXLocalizer.localizerForLanguage will throw an exception when the given parameter is null. It correctly creates a localizer for the default language in that case but when storing that localizer in the local static dictionary it fails because a dictionary key must not be null.
