### PR TITLE
Prevent possible NPE in ERMD2WEditRelationshipHeader.java

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/header/ERMD2WEditRelationshipHeader.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/header/ERMD2WEditRelationshipHeader.java
@@ -33,12 +33,12 @@ public class ERMD2WEditRelationshipHeader extends ERMD2WHeader {
     // FIXME switch to using a localized template
     public String headerString() {
     	if (_headerString == null) {
-    		D2WContext tempContext = new D2WContext();
-			tempContext.setEntity(EOUtilities.entityNamed(object().editingContext(),object().entityName()));
-			tempContext.setPropertyKey(key());
-			tempContext.setTask("editRelationship");
-    		String key = (String)tempContext.valueForKey(Keys.displayKeyForEntity);
-    		if (object() != null) {
+    	    if (object() != null) {
+    	        D2WContext tempContext = new D2WContext();
+    	        tempContext.setEntity(EOUtilities.entityNamed(object().editingContext(),object().entityName()));
+    	        tempContext.setPropertyKey(key());
+    	        tempContext.setTask("editRelationship");
+    	        String key = (String)tempContext.valueForKey(Keys.displayKeyForEntity);
     			if (key.equals("entity.name")) {
     				_headerString = localizedValueForDisplayNameOfKeyPath(key, object());
     			} else {


### PR DESCRIPTION
Moved null check on object() to prevent NPE on access to object methods.

Signed-off-by: David LeBer dleber@codeferous.com
