### PR TITLE
Make AjaxDatePicker accept an ERXJodaLocalDateFormatter.

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDatePicker.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDatePicker.java
@@ -14,6 +14,7 @@ import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSTimestampFormatter;
 
 import er.extensions.appserver.ERXResponseRewriter;
+import er.extensions.formatters.ERXJodaLocalDateFormatter;
 
 /**
  * Shameless port and adoption of Rails Date Kit.  This input understands the format symbols
@@ -119,6 +120,9 @@ public class AjaxDatePicker extends AjaxComponent {
     		else if (formatter instanceof SimpleDateFormat) {
     			format = ((SimpleDateFormat)formatter).toPattern();
     		}
+			else if (formatter instanceof ERXJodaLocalDateFormatter) {
+				format = ((ERXJodaLocalDateFormatter) formatter).toPattern();
+			}
     		else {
     			throw new RuntimeException("Can't handle formatter of class " + formatter.getClass().getCanonicalName());
     		}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/formatters/ERXJodaLocalDateFormatter.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/formatters/ERXJodaLocalDateFormatter.java
@@ -71,4 +71,7 @@ public class ERXJodaLocalDateFormatter extends Format {
 		return ld;
 	}
 
+	public String toPattern() {
+		return _pattern;
+	}
 }


### PR DESCRIPTION
This is a very small change that does not introduce new dependencies, that allows the use of JodaLocalDate on an AjaxDatePicker with a ERXJodaLocalDateFormatter.
