### PR TITLE
check for null or kaboom...

### DIFF
--- a/Frameworks/Misc/ERPDFGeneration/Sources/er/pdf/builder/FlyingSaucerMetadataCreationListener.java
+++ b/Frameworks/Misc/ERPDFGeneration/Sources/er/pdf/builder/FlyingSaucerMetadataCreationListener.java
@@ -99,7 +99,9 @@ public class FlyingSaucerMetadataCreationListener extends DefaultPDFCreationList
 		if (this.headMetaTags.getProperty("title") == null) {
 			Element titleTag =
 					(Element) headTag.getElementsByTagName("title").item(0);
-			this.headMetaTags.setProperty("title", titleTag.getTextContent());
+			if (titleTag != null) {
+				this.headMetaTags.setProperty("title", titleTag.getTextContent());
+			}
 		}
 
 		return;


### PR DESCRIPTION
The last commit for the FlyingSaucer implementation implies that you have a title tag in the pages head tag. There has to be a null check to prevent a NPE if there is no such tag present.
