### PR TITLE
Changes needed to allow deletion of instances in JavaMonitor

### DIFF
--- a/Applications/JavaMonitor/Sources/com/webobjects/monitor/application/WOTaskdHandler.java
+++ b/Applications/JavaMonitor/Sources/com/webobjects/monitor/application/WOTaskdHandler.java
@@ -187,7 +187,7 @@ public class WOTaskdHandler {
     /* ******* */
 
     /* ******** REMOVING (UPDATE) ********* */
-    protected void sendRemoveInstancesToWotaskds(NSArray exInstanceArray, NSArray wotaskdArray) {
+    public void sendRemoveInstancesToWotaskds(NSArray exInstanceArray, NSArray wotaskdArray) {
         WOResponse[] responses = sendRequest(
                 createUpdateRequestDictionary(null, null, null, exInstanceArray, "remove"), wotaskdArray, true);
         NSDictionary[] responseDicts = generateResponseDictionaries(responses);

--- a/Applications/JavaMonitor/Sources/com/webobjects/monitor/rest/JavaMonitorController.java
+++ b/Applications/JavaMonitor/Sources/com/webobjects/monitor/rest/JavaMonitorController.java
@@ -10,17 +10,20 @@ import er.rest.routes.ERXDefaultRouteController;
 
 public class JavaMonitorController extends ERXDefaultRouteController {
 
+    private WOTaskdHandler _handler;
+
 	public JavaMonitorController(WORequest request) {
 		super(request);
+		_handler = new WOTaskdHandler(mySession());
 	}
 		
-    protected MSiteConfig siteConfig() {
-        return WOTaskdHandler.siteConfig();
-    }
+	protected MSiteConfig siteConfig() {
+		return WOTaskdHandler.siteConfig();
+	}
 
-    public WOTaskdHandler handler() {
-    	return new WOTaskdHandler(mySession());
-    }
+	public WOTaskdHandler handler() {
+		return _handler;
+	}
     
     public Session mySession() {
         return (Session) super.session();

--- a/Applications/JavaMonitor/Sources/com/webobjects/monitor/rest/MApplicationController.java
+++ b/Applications/JavaMonitor/Sources/com/webobjects/monitor/rest/MApplicationController.java
@@ -2,6 +2,7 @@ package com.webobjects.monitor.rest;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WORequest;
+import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.monitor._private.MApplication;
 import com.webobjects.monitor._private.MHost;
@@ -112,7 +113,15 @@ public class MApplicationController extends JavaMonitorController {
 
 	private void deleteInstance(MApplication application, Integer instanceId) {
 		final MInstance instance = application.instanceWithID(instanceId);
-		siteConfig().removeInstance_M(instance);
+		handler().startWriting();
+		try {
+			siteConfig().removeInstance_M(instance);
+			if (siteConfig().hostArray().count() != 0) {
+				handler().sendRemoveInstancesToWotaskds(new NSArray(instance), siteConfig().hostArray());
+			}
+		} finally {
+			handler().endWriting();
+		}
 	}
 
 	private void deleteApplication(MApplication application) {


### PR DESCRIPTION
Changes needed to allow deletion of instances. Previously an instance was only removed from what JavaMonitor showed on the web pages. Changes were not written to the SiteConfig.xml file.
- Made a singleton out of handle() in JavaMonitorController.java.
- Made sendRemoveInstancesToWotaskds in WOTaskdHandler.java public from protected. 
- Finally made changes to MApplicationController.java to properly remove an instance from the site.
