### PR TITLE
remove unnecessary super keyword when calling appendChildrenToResponse

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWORepetition.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWORepetition.java
@@ -544,7 +544,7 @@ public class ERXWORepetition extends WODynamicGroup {
 
 		for (int index = 0; index < count; index++) {
 			_prepareForIterationWithIndex(context, index, wocontext, wocomponent, checkHashCodes);
-			super.appendChildrenToResponse(woresponse, wocontext);
+			appendChildrenToResponse(woresponse, wocontext);
 		}
 		if (count > 0) {
 			_cleanupAfterIteration(count, wocontext, wocomponent);


### PR DESCRIPTION
remove unnecessary super keyword that makes it impossible to override appendChildrenToResponse in a subclass
