### PR TITLE
add support for NSSet and java.util.Set to ERXWORepetition

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWORepetition.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWORepetition.java
@@ -119,18 +119,18 @@ public class ERXWORepetition extends WODynamicGroup {
 	 * WOElements must be reentrant, so we need a context object or will have to add the parameters to every method.
 	 * Note that it's OK to have no object at all.
 	 */
-		protected NSArray nsarray;
-		protected List list;
 	protected static class Context {
+		protected NSArray<Object> nsarray;
+		protected List<Object> list;
 		protected Object[] array;
 
 		public Context(Object object) {
 			if (object != null) {
 				if (object instanceof NSArray) {
-					nsarray = (NSArray) object;
+					nsarray = (NSArray<Object>) object;
 				}
 				else if (object instanceof List) {
-					list = (List) object;
+					list = (List<Object>) object;
 				}
 				else if (object instanceof Set) {
 					if (object instanceof NSSet) {
@@ -151,6 +151,8 @@ public class ERXWORepetition extends WODynamicGroup {
 
 		/**
 		 * Gets the number of elements from any object.
+		 * 
+		 * @return size of the list
 		 */
 		protected int count() {
 			if (nsarray != null) {
@@ -167,6 +169,9 @@ public class ERXWORepetition extends WODynamicGroup {
 
 		/**
 		 * Gets the object at the given index from any object.
+		 * 
+		 * @param i index
+		 * @return object at index
 		 */
 		protected Object objectAtIndex(int i) {
 			if (nsarray != null) {
@@ -182,21 +187,27 @@ public class ERXWORepetition extends WODynamicGroup {
 		}
 	}
 
-	/** Designated Constructor. Gets called by the template parser. Checks if the bindings are valid. */
-	public ERXWORepetition(String string, NSDictionary associations, WOElement woelement) {
+	/**
+	 * Designated Constructor. Gets called by the template parser. Checks if the bindings are valid.
+	 *  
+	 * @param string 
+	 * @param associations 
+	 * @param woelement
+	 **/
+	public ERXWORepetition(String string, NSDictionary<String, WOAssociation> associations, WOElement woelement) {
 		super(null, null, woelement);
 
-		_list = (WOAssociation) associations.objectForKey("list");
-		_item = (WOAssociation) associations.objectForKey("item");
-		_count = (WOAssociation) associations.objectForKey("count");
-		_index = (WOAssociation) associations.objectForKey("index");
-		_uniqueKey = (WOAssociation) associations.objectForKey("uniqueKey");
-		_checkHashCodes = (WOAssociation) associations.objectForKey("checkHashCodes");
-		_raiseOnUnmatchedObject = (WOAssociation) associations.objectForKey("raiseOnUnmatchedObject");
-		_debugHashCodes = (WOAssociation) associations.objectForKey("debugHashCodes");
-		_eoSupport = (WOAssociation) associations.objectForKey("eoSupport");
-		_batchFetch = (WOAssociation) associations.objectForKey("batchFetch");
-		_notFoundMarker = (WOAssociation) associations.objectForKey("notFoundMarker");
+		_list = associations.objectForKey("list");
+		_item = associations.objectForKey("item");
+		_count = associations.objectForKey("count");
+		_index = associations.objectForKey("index");
+		_uniqueKey = associations.objectForKey("uniqueKey");
+		_checkHashCodes = associations.objectForKey("checkHashCodes");
+		_raiseOnUnmatchedObject = associations.objectForKey("raiseOnUnmatchedObject");
+		_debugHashCodes = associations.objectForKey("debugHashCodes");
+		_eoSupport = associations.objectForKey("eoSupport");
+		_batchFetch = associations.objectForKey("batchFetch");
+		_notFoundMarker = associations.objectForKey("notFoundMarker");
 		
 		if (_list == null && _count == null) {
 			_failCreation("Missing 'list' or 'count' attribute.");
@@ -218,12 +229,17 @@ public class ERXWORepetition extends WODynamicGroup {
 		}
 	}
 
-	/** Utility to throw an exception if the bindings are incomplete. */
+	/**
+	 * Utility to throw an exception if the bindings are incomplete.
+	 * 
+	 * @param message 
+	 **/
 	protected void _failCreation(String message) {
 		throw new WODynamicElementCreationException("<" + this.getClass().getName() + "> " + message);
 	}
 
 	/** Human readable description. */
+	@Override
 	public String toString() {
 		return ("<" + this.getClass().getName() + " list: " + (_list != null ? _list.toString() : "null") + " item: " + (_item != null ? _item.toString() : "null") + " count: " + (_count != null ? _count.toString() : "null") + " index: " + (_index != null ? _index.toString() : "null") + ">");
 	}
@@ -280,7 +296,11 @@ public class ERXWORepetition extends WODynamicGroup {
 	/**
 	 * Prepares the WOContext for the loop iteration.
 	 * 
-	 * @param checkHashCodes
+	 * @param context 
+	 * @param index 
+	 * @param wocontext 
+	 * @param wocomponent 
+	 * @param checkHashCodes 
 	 */
 	protected void _prepareForIterationWithIndex(Context context, int index, WOContext wocontext, WOComponent wocomponent, boolean checkHashCodes) {
 		Object object = null;
@@ -328,7 +348,13 @@ public class ERXWORepetition extends WODynamicGroup {
 		}
 	}
 
-	/** Cleans the WOContext after the loop iteration. */
+	/**
+	 * Cleans the WOContext after the loop iteration.
+	 * 
+	 * @param i 
+	 * @param wocontext 
+	 * @param wocomponent 
+	 **/
 	protected void _cleanupAfterIteration(int i, WOContext wocontext, WOComponent wocomponent) {
 		if (_item != null) {
 			_item._setValueNoValidation(null, wocomponent);
@@ -340,7 +366,13 @@ public class ERXWORepetition extends WODynamicGroup {
 		wocontext.deleteLastElementIDComponent();
 	}
 
-	/** Fills the context with the object given in the "list" binding. */
+	/**
+	 * Fills the context with the object given in the "list" binding.
+	 * 
+	 * @param senderID 
+	 * @param elementID 
+	 * @return index string
+	 **/
 	protected String _indexStringForSenderAndElement(String senderID, String elementID) {
 		int dotOffset = elementID.length() + 1;
 		int nextDotOffset = senderID.indexOf('.', dotOffset);
@@ -401,6 +433,7 @@ public class ERXWORepetition extends WODynamicGroup {
 		return new Context(list);
 	}
 
+	@Override
 	public void takeValuesFromRequest(WORequest worequest, WOContext wocontext) {
 		WOComponent wocomponent = wocontext.component();
 		Context context = createContext(wocomponent);
@@ -419,6 +452,7 @@ public class ERXWORepetition extends WODynamicGroup {
 		}
 	}
 
+	@Override
 	public WOActionResults invokeAction(WORequest worequest, WOContext wocontext) {
 		WOComponent wocomponent = wocontext.component();
 		Context repetitionContext = createContext(wocomponent);
@@ -540,6 +574,7 @@ public class ERXWORepetition extends WODynamicGroup {
 		return _eoSupportDefault;
 	}
 	
+	@Override
 	public void appendToResponse(WOResponse woresponse, WOContext wocontext) {
 		WOComponent wocomponent = wocontext.component();
 		Context context = createContext(wocomponent);


### PR DESCRIPTION
Currently ERXWORepetition allows only NSArray, java.uitl.List or Object[] as list. This patch adds support for NSSet and java.util.Set types if you want to output those (but keeping in mind that the order of a Set is not deterministic).
