### PR TITLE
AjaxFlexibleFileUpload.java enabled feature clearUploadProgressOnSuccess.

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
@@ -108,7 +108,8 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
 
 	private Boolean _autoSubmit;
 	private Boolean _allowCancel;
-	
+	private Boolean _clearUploadProgressOnSuccess;
+
 	public boolean testFlag = false;
 	public enum UploadState { DORMANT, STARTED, INPROGRESS, CANCELED, FAILED, SUCCEEDED, FINISHED }
 	public UploadState state = UploadState.DORMANT;
@@ -223,7 +224,8 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
     	NSMutableArray<String> _options = new NSMutableArray<String>(String.format("refreshtime:%s", refreshTime()));
     	_options.addObject("autosubmit:" + autoSubmit());
     	_options.addObject("allowcancel:" + valueForBinding(Keys.allowCancel));
-    	
+      _options.add("clearUploadProgressOnSuccess:" + clearUploadProgressOnSuccess());
+
     	String startedFunction = (String)this.valueForBinding(Keys.startedFunction);
     	if (startedFunction != null) _options.addObject(String.format("startedFunction:%s", startedFunction));
     	
@@ -239,9 +241,9 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
     	String succeededFunction = (String)this.valueForBinding(Keys.succeededFunction);
     	if (succeededFunction != null) _options.addObject(String.format("succeededFunction:%s", succeededFunction));
     	
-    	String clearedFunction = (String)this.valueForBinding(Keys.clearedFunction);
-    	if (clearedFunction != null) _options.addObject(String.format("clearedFunction:%s", clearedFunction));
-    	
+      String clearedFunction = (String)this.valueForBinding(Keys.clearedFunction);
+      if (clearedFunction != null) _options.addObject(String.format("clearedFunction:%s", clearedFunction));
+      
     	return _options;
     }
     
@@ -588,13 +590,21 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
 	 * 
 	 * @return value for 'autoSubmit' binding
 	 */
-	public Boolean autoSubmit() {
-		if (_autoSubmit == null) {
-			_autoSubmit = ERXValueUtilities.BooleanValueWithDefault(valueForBinding(Keys.autoSubmit), Boolean.TRUE);
-		}
-		return _autoSubmit;
-	}
-	
+  public Boolean autoSubmit() {
+    if (_autoSubmit == null) {
+      _autoSubmit = ERXValueUtilities.BooleanValueWithDefault(valueForBinding(Keys.autoSubmit), Boolean.TRUE);
+    }
+    return _autoSubmit;
+  }
+  
+  public Boolean clearUploadProgressOnSuccess() {
+    if (_clearUploadProgressOnSuccess == null) {
+      _clearUploadProgressOnSuccess = ERXValueUtilities.BooleanValueWithDefault(valueForBinding(Keys.clearUploadProgressOnSuccess), Boolean.FALSE);
+      System.out.println("clearUploadProgressOnSuccess: " + _clearUploadProgressOnSuccess);
+    }
+    return _clearUploadProgressOnSuccess;
+  }
+  
 	public Boolean allowCancel() {
 		if (_allowCancel == null) {
 			_allowCancel = ERXValueUtilities.BooleanValueWithDefault(valueForBinding(Keys.allowCancel), Boolean.FALSE);

--- a/Frameworks/Ajax/Ajax/WebServerResources/default_ajaxupload.css
+++ b/Frameworks/Ajax/Ajax/WebServerResources/default_ajaxupload.css
@@ -52,6 +52,11 @@
 	text-shadow: #405882 0px -1px 0px;
 }
 
+.AjaxFlexibleFileUpload a.Button,
+.ERAttachmentFlexibleEditor a.Button {
+	text-decoration: none;
+}
+
 .AjaxFlexibleFileUpload .ClearUploadObjButton {
 	background-image: url(btn_del.png);
 	height: 23px;

--- a/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
@@ -1190,7 +1190,12 @@ var AjaxUploadClient = Class.create({
 		    	this.options.succeededFunction(this.id);
 			if (this.options.finishedFunction)
 				this.options.finishedFunction(this.id);
-			$('AFUClearButton' + this.id).show();
+			if (this.options.clearUploadProgressOnSuccess) {
+				$('AFUFileObject' + this.id).hide();
+				$('AFUSelectFileButtonWrapper' + this.id).show();
+			} else {
+				$('AFUClearButton' + this.id).show();
+			}
 			this.previousState = this.STATE.SUCCEEDED;
 			break;
 		case this.STATE.FINISHED:


### PR DESCRIPTION
Modified AjaxFlexibleFileUpload.java and wonder.js so that the option clearUploadProgressOnSuccess="true" will work. Also updated default_ajaxupload.css to remove underline in the upload button
