### PR TITLE
ERXDatabaseContextDelegate patch

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
@@ -545,7 +545,7 @@ public class ERXDatabaseContextDelegate {
     /**
      * Refreshes the fetch timestamp for the fetched objects.
      * @param eos
-     * @param ec
+     * @param timestamp
      */
 	private void freshenFetchTimestamps(NSArray eos, long timestamp) {
 		for(Object eo: eos) {
@@ -625,15 +625,15 @@ public class ERXDatabaseContextDelegate {
 						long timestamp = ((AutoBatchFaultingEnterpriseObject) source).batchFaultingTimeStamp();
 						NSMutableArray<EOEnterpriseObject> eos = new NSMutableArray<EOEnterpriseObject>();
 						NSMutableArray faults = new NSMutableArray();
-						for (Object o : candidates) {
-							if (o instanceof AutoBatchFaultingEnterpriseObject) {
-								AutoBatchFaultingEnterpriseObject eo = (AutoBatchFaultingEnterpriseObject) o;
-								if (eo.batchFaultingTimeStamp() == timestamp || fromThreadStorage) {
-									if (!EOFaultHandler.isFault(eo) && eo.classDescription() == source.classDescription()) {
-										Object fault = eo.storedValueForKey(key);
+						for (EOEnterpriseObject current : candidates) {
+							if (current instanceof AutoBatchFaultingEnterpriseObject) {
+								AutoBatchFaultingEnterpriseObject currentEO = (AutoBatchFaultingEnterpriseObject) current;
+								if (currentEO.batchFaultingTimeStamp() == timestamp || fromThreadStorage) {
+									if (!EOFaultHandler.isFault(currentEO) && currentEO.classDescription() == source.classDescription()) {
+										Object fault = currentEO.storedValueForKey(key);
 										if (EOFaultHandler.isFault(fault)) {
 											faults.addObject(fault);
-											eos.addObject(eo);
+											eos.addObject(currentEO);
 											if (eos.count() == autoBatchFetchSize()) {
 												break;
 											}
@@ -677,7 +677,7 @@ public class ERXDatabaseContextDelegate {
 	 * 
 	 * @param dbc
 	 *            database context
-	 * @param obj
+	 * @param eo
 	 *            to-one fault
 	 * @return true if it's still a fault.
 	 */


### PR DESCRIPTION
The methods batchFetchToOneFault and batchFetchToManyFault are checking first if there is an array of objects in the thread storage for the key 'ERXBatching'. To check if that array is good for processing the last object is checked for its type.
In special cases you can have different types of objects in the array so the type of the last one could differ from part of the rest of the array. In the following for loop those items will be cast to EOEnterpriseObject which can cause class cast exceptions.

The patch will go through the array from the thread storage and pick only the items that are of type AutoBatchFaultingEnterpriseObject as only those will be processed later on anyway. Should there be no items left then it falls back to ec.registeredObjects().
