### PR TITLE
fix mistakes / omissions in some lesser used prototypes

### DIFF
--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCAccessPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCAccessPrototypes.plist
@@ -55,6 +55,7 @@
             name = date; 
             userInfo = {modificationDate = "2002-07-21 21:47:29 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = dateTime; 
@@ -62,6 +63,7 @@
             name = dateTime; 
             userInfo = {modificationDate = "2002-06-04 14:00:54 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = doubleNumber; 
@@ -97,7 +99,7 @@
             externalType = TEXT; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             valueType = c; 
             width = 255; 
@@ -216,7 +218,7 @@
             columnName = mutableArray; 
             externalType = "OLE Object"; 
             name = mutableArray; 
-            valueClassName = "er.extensions.ERXMutableArray"; 
+            valueClassName = "er.extensions.foundation.ERXMutableArray"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDB2Prototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDB2Prototypes.plist
@@ -60,6 +60,7 @@
             name = date; 
             userInfo = {modificationDate = "2002-07-21 21:47:29 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = dateTime; 
@@ -67,6 +68,7 @@
             name = dateTime; 
             userInfo = {modificationDate = "2002-06-04 14:00:54 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = doubleNumber; 
@@ -102,7 +104,7 @@
             externalType = VARCHAR; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             valueType = c; 
             width = 255; 
@@ -220,7 +222,7 @@
             columnName = mutableArray; 
             externalType = BLOB; 
             name = mutableArray; 
-            valueClassName = "er.extensions.ERXMutableArray"; 
+            valueClassName = "er.extensions.foundation.ERXMutableArray"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDBasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDBasePrototypes.plist
@@ -60,13 +60,15 @@
             name = date; 
             userInfo = {modificationDate = "2002-07-21 21:47:29 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = dateTime; 
             externalType = DATETIME; 
             name = dateTime; 
             userInfo = {modificationDate = "2002-06-04 14:00:54 +0200"; }; 
-            valueClassName = NSCalendarDate; 
+            valueClassName = NSCalendarDate;
+            valueType = T;  
         }, 
         {
             columnName = doubleNumber; 
@@ -102,7 +104,7 @@
             externalType = CHARACTER; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             valueType = c; 
             width = 255; 
@@ -221,7 +223,7 @@
             columnName = mutableArray; 
             externalType = MEMO; 
             name = mutableArray; 
-            valueClassName = "er.extensions.ERXMutableArray"; 
+            valueClassName = "er.extensions.foundation.ERXMutableArray"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDerbyPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDerbyPrototypes.plist
@@ -52,12 +52,14 @@
             externalType = TIMESTAMP; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 
             externalType = TIMESTAMP; 
             name = dateTime; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = ""; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFrontBasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFrontBasePrototypes.plist
@@ -52,12 +52,14 @@
             externalType = DATE; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 
             externalType = TIMESTAMP; 
             name = dateTime; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = ""; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCH2Prototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCH2Prototypes.plist
@@ -52,12 +52,14 @@
             externalType = DATE; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 
             externalType = TIMESTAMP; 
             name = dateTime; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = ""; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCInterbasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCInterbasePrototypes.plist
@@ -60,6 +60,7 @@
             name = date; 
             userInfo = {modificationDate = "2002-07-21 21:47:29 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = dateTime; 
@@ -67,6 +68,7 @@
             name = dateTime; 
             userInfo = {modificationDate = "2002-06-04 14:00:54 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = doubleNumber; 
@@ -102,7 +104,7 @@
             externalType = VARCHAR; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             valueType = c; 
             width = 255; 
@@ -221,7 +223,7 @@
             columnName = mutableArray; 
             externalType = BLOB; 
             name = mutableArray; 
-            valueClassName = "er.extensions.ERXMutableArray"; 
+            valueClassName = "er.extensions.foundation.ERXMutableArray"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCMySQLPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCMySQLPrototypes.plist
@@ -57,12 +57,14 @@
             externalType = DATE; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 
             externalType = DATETIME; 
             name = dateTime; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = ""; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCOraclePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCOraclePrototypes.plist
@@ -52,6 +52,7 @@
             externalType = DATE; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCSQLServerPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCSQLServerPrototypes.plist
@@ -60,6 +60,7 @@
             name = date; 
             userInfo = {modificationDate = "2002-07-21 21:47:29 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = dateTime; 
@@ -67,6 +68,7 @@
             name = dateTime; 
             userInfo = {modificationDate = "2002-06-04 14:00:54 +0200"; }; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = doubleNumber; 
@@ -102,7 +104,7 @@
             externalType = varchar; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             valueType = c; 
             width = 255; 
@@ -221,7 +223,7 @@
             columnName = mutableArray; 
             externalType = binary; 
             name = mutableArray; 
-            valueClassName = "er.extensions.ERXMutableArray"; 
+            valueClassName = "er.extensions.foundation.ERXMutableArray"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOMemoryPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOMemoryPrototypes.plist
@@ -52,12 +52,14 @@
             externalType = TIMESTAMP; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 
             externalType = TIMESTAMP; 
             name = dateTime; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = ""; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EORESTPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EORESTPrototypes.plist
@@ -52,12 +52,14 @@
             externalType = TIMESTAMP; 
             name = date; 
             valueClassName = NSCalendarDate; 
+            valueType = D; 
         }, 
         {
             columnName = ""; 
             externalType = TIMESTAMP; 
             name = dateTime; 
             valueClassName = NSCalendarDate; 
+            valueType = T; 
         }, 
         {
             columnName = ""; 


### PR DESCRIPTION
fix mistakes / omissions in some lesser used prototypes 
1) incorrect package name for ERXKeyGlobalID 
2) incorrect package name for ERXMutableArray 
3) missing valueType for date and dateTime prototypes
