### PR TITLE
translate BOOLEAN jdbc type into external type 'boolean' for FrontBase

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2111,6 +2111,28 @@ public class ERXSQLHelper {
 		protected int maximumElementPerInClause(EOEntity entity) {
 			return 15000;
 		}
+		
+		/**
+		 * For BOOLEAN we take 'boolean' as external type. For any other
+		 * case, we pass it up to the default impl.
+		 * 
+		 * @param adaptor
+		 *            the adaptor to retrieve an external type for
+		 * @param jdbcType
+		 *            the JDBC type number
+		 * @return a guess at the external type name to use
+		 */
+		@Override
+		public String externalTypeForJDBCType(JDBCAdaptor adaptor, int jdbcType) {
+			String externalType;
+			if (jdbcType == Types.BOOLEAN) {
+				externalType = "boolean";
+			}
+			else {
+				externalType = super.externalTypeForJDBCType(adaptor, jdbcType);
+			}
+			return externalType;
+		}
 	}
 
 	public static class MySQLSQLHelper extends ERXSQLHelper {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationTable.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationTable.java
@@ -733,7 +733,8 @@ public class ERXMigrationTable {
 
 	/**
 	 * Returns a new flag boolean column.  See newColumn(..) for the full docs.
-	 * This might or might not work with your database, it's only tested with PostgreSQL.
+	 * This might or might not work with your database, it's only tested with PostgreSQL
+	 * and FrontBase.
 	 * 
 	 * @param name the name of the column
 	 * @param allowsNull if true, the column will allow null values
@@ -746,7 +747,8 @@ public class ERXMigrationTable {
 
 	/**
 	 * Returns a new flag boolean column.  See newColumn(..) for the full docs.
-	 * This might or might not work with your database, it's only tested with PostgreSQL.
+	 * This might or might not work with your database, it's only tested with PostgreSQL
+	 * and FrontBase.
 	 * 
 	 * @param name the name of the column
 	 * @param allowsNull if true, the column will allow null values


### PR DESCRIPTION
For PostgreSQL there is a migration method ERXMigrationTable.newFlagBooleanColumn() that creates a true bool column in the database. This method will fail for FrontBase as the method JDBCAdaptor.stringRepresentationForJDBCType(jdbcType) does not recognize the boolean type. The FrontBaseSQLHelper now checks for that specific type as the PostgresqlSQLHelper does.
