### PR TITLE
fix WOCookie class

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/appserver/WOCookie.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/appserver/WOCookie.java
@@ -5,285 +5,276 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.text.DateFormatSymbols;
+import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 import com.webobjects.foundation.NSKeyValueCoding;
 import com.webobjects.foundation.NSKeyValueCodingAdditions;
 import com.webobjects.foundation.NSTimeZone;
 import com.webobjects.foundation.NSTimestamp;
-import com.webobjects.foundation.NSTimestampFormatter;
 
+public class WOCookie implements NSKeyValueCoding, com.webobjects.foundation.NSKeyValueCoding.ErrorHandling,
+		NSKeyValueCodingAdditions, Serializable {
 
-public class WOCookie
-        implements
-        NSKeyValueCoding,
-        com.webobjects.foundation.NSKeyValueCoding.ErrorHandling,
-        NSKeyValueCodingAdditions,
-        Serializable {
+	static final long serialVersionUID = 310727495L;
+	String _name;
+	String _value;
+	String _domain;
+	String _path;
+	boolean _isSecure;
+	NSTimestamp _expires;
+	int _timeout;
+	boolean _isHttpOnly;
+	static final SimpleDateFormat TheDateFormat;
 
-    static final long                 serialVersionUID = 310727495L;
-    String                            _name;
-    String                            _value;
-    String                            _domain;
-    String                            _path;
-    boolean                           _isSecure;
-    NSTimestamp                       _expires;
-    int                               _timeout;
-    boolean                           _isHttpOnly;
-    static final NSTimestampFormatter TheDateFormat;
+	static {
+		TheDateFormat = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss 'GMT'", new DateFormatSymbols(Locale.US));
+		TheDateFormat.setTimeZone(NSTimeZone.timeZoneWithName("GMT", true));
+	}
 
-    static {
-        DateFormatSymbols dateformatsymbols = new DateFormatSymbols(Locale.US);
-        dateformatsymbols.setZoneStrings(NSTimestampFormatter._getDefaultZoneStrings());
-        TheDateFormat = new NSTimestampFormatter("%a, %d-%b-%Y %H:%M:%S GMT", dateformatsymbols);
-        TheDateFormat.setDefaultFormatTimeZone(NSTimeZone.timeZoneWithName("GMT", true));
-    }
+	@Deprecated
+	public static WOCookie cookieWithName(final String name, final String value, final String path,
+			final String domain, final NSTimestamp expires, final boolean isSecure) {
+		return new WOCookie(name, value, path, domain, expires, isSecure);
+	}
 
-    /**
-     * @deprecated Method cookieWithName is deprecated
-     */
+	@Deprecated
+	public static WOCookie cookieWithName(final String name, final String value, final String path,
+			final String domain, final int timeout, final boolean isSecure) {
+		return new WOCookie(name, value, path, domain, timeout, isSecure);
+	}
 
-    @Deprecated
-    public static WOCookie cookieWithName(final String name, final String value, final String path, final String domain, final NSTimestamp expires, final boolean isSecure) {
-        return new WOCookie(name, value, path, domain, expires, isSecure);
-    }
+	@Deprecated
+	public static WOCookie cookieWithName(final String name, final String value) {
+		return new WOCookie(name, value);
+	}
 
-    /**
-     * @deprecated Method cookieWithName is deprecated
-     */
+	public WOCookie(final String name, final String value, final String path, final String domain,
+			final NSTimestamp expires, final boolean isSecure) {
+		this(name, value, path, domain, expires, isSecure, false);
+	}
 
-    @Deprecated
-    public static WOCookie cookieWithName(final String name, final String value, final String path, final String domain, final int timeout, final boolean isSecure) {
-        return new WOCookie(name, value, path, domain, timeout, isSecure);
-    }
+	public WOCookie(final String name, final String value, final String path, final String domain,
+			final NSTimestamp expires, final boolean isSecure, final boolean httpOnly) {
+		if (name == null) {
+			throw new IllegalArgumentException("Cookie may not have null name.");
+		} else {
+			_name = name;
+			_value = value;
+			_path = path;
+			_domain = domain;
+			_expires = expires;
+			_isSecure = isSecure;
+			_isHttpOnly = httpOnly;
+			setTimeOut(-1);
+			return;
+		}
+	}
 
-    /**
-     * @deprecated Method cookieWithName is deprecated
-     */
+	public WOCookie(final String name, final String value, final String path, final String domain, final int timeout,
+			final boolean isSecure) {
+		this(name, value, path, domain, timeout, isSecure, false);
+	}
 
-    @Deprecated
-    public static WOCookie cookieWithName(final String name, final String value) {
-        return new WOCookie(name, value);
-    }
+	public WOCookie(final String name, final String value, final String path, final String domain, final int timeout,
+			final boolean isSecure, final boolean httpOnly) {
+		if (name == null) {
+			throw new IllegalArgumentException("Cookie may not have null name.");
+		} else {
+			_name = name;
+			_value = value;
+			_path = path;
+			_domain = domain;
+			setTimeOut(timeout);
+			_isSecure = isSecure;
+			_isHttpOnly = httpOnly;
+			return;
+		}
+	}
 
-    public WOCookie(final String name, final String value, final String path, final String domain,
-            final NSTimestamp expires, final boolean isSecure) {
-        this(name, value, path, domain, expires, isSecure, false);
-    }
+	public WOCookie(final String name, final String value) {
+		this(name, value, null, null, -1, false);
+	}
 
-    public WOCookie(final String name, final String value, final String path, final String domain,
-            final NSTimestamp expires, final boolean isSecure, final boolean httpOnly) {
-        if (name == null) {
-            throw new IllegalArgumentException("Cookie may not have null name.");
-        } else {
-            _name = name;
-            _value = value;
-            _path = path;
-            _domain = domain;
-            _expires = expires;
-            _isSecure = isSecure;
-            _isHttpOnly = httpOnly;
-            setTimeOut(-1);
-            return;
-        }
-    }
+	@Override
+	public String toString() {
+		String expiresString = _expires != null ? (new StringBuilder()).append(" expires=")
+				.append(TheDateFormat.format(_expires)).toString() : "";
+		String expires = _timeout < 0 ? "" : (new StringBuilder()).append(" max-age=").append(_timeout).toString();
 
-    public WOCookie(final String name, final String value, final String path, final String domain, final int timeout,
-            final boolean isSecure) {
-        this(name, value, path, domain, timeout, isSecure, false);
-    }
+		return (new StringBuilder()).append("<").append(getClass().getName()).append(" name=").append(_name)
+				.append(" value=").append(_value).append(" path=").append(_path).append(" domain=").append(_domain)
+				.append(expiresString).append(expires).append(" isSecure=").append(_isSecure ? "true" : "false")
+				.append(" isHttpOnly=").append(_isHttpOnly ? "true" : "false").append(">").toString();
+	}
 
-    public WOCookie(final String name, final String value, final String path, final String domain, final int timeout,
-            final boolean isSecure, final boolean httpOnly) {
-        if (name == null) {
-            throw new IllegalArgumentException("Cookie may not have null name.");
-        } else {
-            _name = name;
-            _value = value;
-            _path = path;
-            _domain = domain;
-            setTimeOut(timeout);
-            _isSecure = isSecure;
-            _isHttpOnly = httpOnly;
-            return;
-        }
-    }
+	public String headerString() {
+		return _headerString(false);
+	}
 
-    public WOCookie(final String name, final String value) {
-        this(name, value, null, null, -1, false);
-    }
+	String _headerString(final boolean isRequest) {
+		StringBuffer header = new StringBuffer(140);
+		header.append(_name);
+		header.append('=');
+		if (_value != null && _value.indexOf(' ') != -1 && (!_value.startsWith("\"") || !_value.endsWith("\""))) {
+			header.append("\"");
+			header.append(_value);
+			header.append("\"");
+		} else if (_value == null) {
+			header.append(" ");
+		} else {
+			header.append(_value);
+		}
+		if (!isRequest) {
+			NSTimestamp localExpires = _expires;
 
-    @Override
-    public String toString() {
-        String s = _expires != null ? " expires=" + TheDateFormat.format(_expires) : "";
-        String s1 = _timeout < 0 ? "" : " max-age=" + _timeout;
-        return "<" + getClass().getName() + " name=" + _name + " value=" + _value + " path=" + _path + " domain="
-                + _domain + s + s1 + " isSecure=" + (_isSecure ? "true" : "false") + " isHttpOnly="
-                + (_isHttpOnly ? "true" : "false") + ">";
-    }
+			header.append("; version=\"1\"");
+			if (_timeout >= 0) {
+				header.append("; max-age=");
+				header.append(_timeout);
+				if (_timeout == 0) {
+					localExpires = new NSTimestamp(0L);
+				} else {
+					localExpires = new NSTimestamp(System.currentTimeMillis() + (_timeout * 1000));
+				}
+			}
+			if (_expires != null) {
+				header.append("; expires=");
+				header.append(TheDateFormat.format(localExpires));
+			}
+			if (_path != null) {
+				header.append("; path=");
+				header.append(_path);
+			}
+			if (_domain != null) {
+				header.append("; domain=");
+				header.append(_domain);
+			}
+			if (_isSecure) {
+				header.append("; secure");
+			}
+			if (_isHttpOnly) {
+				header.append("; HttpOnly");
+			}
+		}
+		return new String(header);
+	}
 
-    public String headerString() {
-        return _headerString(false);
-    }
+	public String name() {
+		return _name;
+	}
 
-    String _headerString(final boolean flag) {
-        StringBuffer header = new StringBuffer(140);
-        header.append(_name);
-        header.append('=');
-        if (_value != null && _value.indexOf(' ') != -1 && (!_value.startsWith("\"") || !_value.endsWith("\""))) {
-            header.append("\"");
-            header.append(_value);
-            header.append("\"");
-        } else
-            if (_value == null) {
-                header.append(" ");
-            } else {
-                header.append(_value);
-            }
-        if (!flag) {
-            header.append("; version=\"1\"");
-            if (_timeout >= 0) {
-                header.append("; max-age=");
-                header.append(_timeout);
-            }
-            if (_expires != null) {
-                header.append("; expires=");
-                header.append(TheDateFormat.format(_expires));
-            }
-            if (_path != null) {
-                header.append("; path=");
-                header.append(_path);
-            }
-            if (_domain != null) {
-                header.append("; domain=");
-                header.append(_domain);
-            }
-            if (_isSecure) {
-                header.append("; secure");
-            }
-            if (_isHttpOnly) {
-                header.append("; HttpOnly");
-            }
-        }
-        return new String(header);
-    }
+	public void setName(final String name) {
+		_name = name;
+	}
 
-    public String name() {
-        return _name;
-    }
+	public String value() {
+		return _value;
+	}
 
-    public void setName(final String s) {
-        _name = s;
-    }
+	public void setValue(final String value) {
+		_value = value;
+	}
 
-    public String value() {
-        return _value;
-    }
+	public String domain() {
+		return _domain;
+	}
 
-    public void setValue(final String s) {
-        _value = s;
-    }
+	public void setDomain(final String domain) {
+		_domain = domain;
+	}
 
-    public String domain() {
-        return _domain;
-    }
+	public String path() {
+		return _path;
+	}
 
-    public void setDomain(final String s) {
-        _domain = s;
-    }
+	public void setPath(final String path) {
+		_path = path;
+	}
 
-    public String path() {
-        return _path;
-    }
+	public NSTimestamp expires() {
+		return _expires;
+	}
 
-    public void setPath(final String s) {
-        _path = s;
-    }
+	public void setExpires(final NSTimestamp expires) {
+		_expires = expires;
+	}
 
-    public NSTimestamp expires() {
-        return _expires;
-    }
+	public void setTimeOut(final int timeout) {
+		_timeout = timeout;
+	}
 
-    public void setExpires(final NSTimestamp nstimestamp) {
-        _expires = nstimestamp;
-    }
+	public int timeOut() {
+		return _timeout;
+	}
 
-    public void setTimeOut(final int i) {
-        _timeout = i;
-    }
+	public boolean isSecure() {
+		return _isSecure;
+	}
 
-    public int timeOut() {
-        return _timeout;
-    }
+	public void setIsSecure(final boolean isSecure) {
+		_isSecure = isSecure;
+	}
 
-    public boolean isSecure() {
-        return _isSecure;
-    }
+	public boolean isHttpOnly() {
+		return _isHttpOnly;
+	}
 
-    public void setIsSecure(final boolean flag) {
-        _isSecure = flag;
-    }
+	public void setIsHttpOnly(final boolean isHttpOnly) {
+		_isHttpOnly = isHttpOnly;
+	}
 
-    public boolean isHttpOnly() {
-        return _isHttpOnly;
-    }
+	public static boolean canAccessFieldsDirectly() {
+		return true;
+	}
 
-    public void setIsHttpOnly(final boolean flag) {
-        _isHttpOnly = flag;
-    }
+	public Object valueForKey(final String key) {
+		return com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.valueForKey(this, key);
+	}
 
-    public static boolean canAccessFieldsDirectly() {
-        return true;
-    }
+	public void takeValueForKey(final Object value, final String key) {
+		com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.takeValueForKey(this, value, key);
+	}
 
-    public Object valueForKey(final String s) {
-        return com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.valueForKey(this, s);
-    }
+	public Object handleQueryWithUnboundKey(final String key) {
+		return com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.handleQueryWithUnboundKey(this, key);
+	}
 
-    public void takeValueForKey(final Object obj, final String s) {
-        com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.takeValueForKey(this, obj, s);
-    }
+	public void handleTakeValueForUnboundKey(final Object value, final String key) {
+		com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.handleTakeValueForUnboundKey(this, value, key);
+	}
 
-    public Object handleQueryWithUnboundKey(final String s) {
-        return com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.handleQueryWithUnboundKey(this, s);
-    }
+	public void unableToSetNullForKey(final String key) {
+		com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.unableToSetNullForKey(this, key);
+	}
 
-    public void handleTakeValueForUnboundKey(final Object obj, final String s) {
-        com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.handleTakeValueForUnboundKey(this, obj, s);
-    }
+	public Object valueForKeyPath(final String key) {
+		return com.webobjects.foundation.NSKeyValueCodingAdditions.DefaultImplementation.valueForKeyPath(this, key);
+	}
 
-    public void unableToSetNullForKey(final String s) {
-        com.webobjects.foundation.NSKeyValueCoding.DefaultImplementation.unableToSetNullForKey(this, s);
-    }
+	public void takeValueForKeyPath(final Object value, final String key) {
+		com.webobjects.foundation.NSKeyValueCodingAdditions.DefaultImplementation.takeValueForKeyPath(this, value, key);
+	}
 
-    public Object valueForKeyPath(final String s) {
-        return com.webobjects.foundation.NSKeyValueCodingAdditions.DefaultImplementation.valueForKeyPath(this, s);
-    }
+	public void writeObject(final ObjectOutputStream out) throws IOException {
+		out.writeInt(_timeout);
+		out.writeUTF(_name);
+		out.writeUTF(_value);
+		out.writeUTF(_domain);
+		out.writeUTF(_path);
+		out.writeBoolean(_isSecure);
+		out.writeObject(_expires);
+		out.writeBoolean(_isHttpOnly);
+	}
 
-    public void takeValueForKeyPath(final Object obj, final String s) {
-        com.webobjects.foundation.NSKeyValueCodingAdditions.DefaultImplementation.takeValueForKeyPath(this, obj, s);
-    }
-
-    public void writeObject(final ObjectOutputStream objectoutputstream) throws IOException {
-        objectoutputstream.writeInt(_timeout);
-        objectoutputstream.writeUTF(_name);
-        objectoutputstream.writeUTF(_value);
-        objectoutputstream.writeUTF(_domain);
-        objectoutputstream.writeUTF(_path);
-        objectoutputstream.writeBoolean(_isSecure);
-        objectoutputstream.writeObject(_expires);
-        objectoutputstream.writeBoolean(_isHttpOnly);
-    }
-
-    public void readObject(final ObjectInputStream objectinputstream) throws IOException, ClassNotFoundException {
-        _timeout = objectinputstream.readInt();
-        _name = objectinputstream.readUTF();
-        _value = objectinputstream.readUTF();
-        _domain = objectinputstream.readUTF();
-        _path = objectinputstream.readUTF();
-        _isSecure = objectinputstream.readBoolean();
-        _expires = (NSTimestamp) objectinputstream.readObject();
-        _isHttpOnly = objectinputstream.readBoolean();
-    }
-
+	public void readObject(final ObjectInputStream out) throws IOException, ClassNotFoundException {
+		_timeout = out.readInt();
+		_name = out.readUTF();
+		_value = out.readUTF();
+		_domain = out.readUTF();
+		_path = out.readUTF();
+		_isSecure = out.readBoolean();
+		_expires = (NSTimestamp) out.readObject();
+		_isHttpOnly = out.readBoolean();
+	}
 }


### PR DESCRIPTION
The WOCookie class that was introduced for supporting the httpOnly flag is breaking requests because the type of TheDateFormat was changed from SimpleDateFormat to NSTimestampFormatter. Additionally the logic to use a specific expires timestamp when a timeout has been set was dropped - this patch reintroduces that part.
