### PR TITLE
Don't throw an exception when discovering a "unknown version" browser string

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXBasicBrowser.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXBasicBrowser.java
@@ -20,55 +20,62 @@ import er.extensions.foundation.ERXStringUtilities;
  * information retrieved from HTTP request's <code>"user-agent"</code>
  * header, and such information includes web browser's name, version, Mozilla
  * compatible version and platform (OS). Also, a browser object can answer
- * boolean questions such as {@link #isIE},{@link #isOmniWeb},
- * {@link #isVersion5}and {@link #isMozilla40Compatible}, and even more
- * specific questions like {@link #isIFrameSupported}and
+ * boolean questions such as {@link #isIE},{@link #isOmniWeb}, 
+ * {@link #isVersion5} and {@link #isMozilla40Compatible}, and even more
+ * specific questions like {@link #isIFrameSupported} and
  * {@link #willRenderNestedTablesFast}.
  * <p>
  * <code>ERXBasicBrowser</code> is immutable and shared by different sessions
  * and direct actions. The shared instances are managed by
- * {@link ERXBrowserFactory}which is also responsible to parse <code>"user-agent"</code>
- * header in a {@link com.webobjects.appserver.WORequest WORequest}object and
+ * {@link ERXBrowserFactory} which is also responsible to parse <code>"user-agent"</code>
+ * header in a {@link com.webobjects.appserver.WORequest WORequest} object and
  * to get an appropriate browser object.
  * <p>
  * You can extends <code>ERXBasicBrowser</code> or its abstract parent <code>ERXBrowser</code>
- * to implement more specific questions for your application. One potencial
+ * to implement more specific questions for your application. One potential
  * example will be to have a question <code>isSupportedBrowser</code> that
  * checks if the client is using one of the supported browsers for your
  * application.
  * <p>
- * {@link ERXSession}holds a browser object that represent the web browser for
- * that session and {@link ERXSession#browser browser()}method returns the
+ * {@link ERXSession} holds a browser object that represent the web browser for
+ * that session and {@link ERXSession#browser browser()} method returns the
  * object.
  * <p>
  * To access <code>ERXBasicBrowser</code>'s boolean questions from <code>WOConditionals</code>
  * on a web component, set the key path like <code>"session.brower.isNetscape"</code>
  * to their condition bindings.
  * <p>
- * {@link ERXDirectAction}also holds a browser object for the current request.
- * Use its {@link ERXDirectAction#browser browser()}method to access the
+ * {@link ERXDirectAction} also holds a browser object for the current request.
+ * Use its {@link ERXDirectAction#browser browser()} method to access the
  * object from a session-less direct action.
  * 
  * 
- * Some browser user-agents: 
+ * <h3>Some browser user-agents</h3> 
  * 
- * IE 5.17 OS 9: 
+ * <p><strong>IE 5.17 OS 9</strong><br>
  * user-agent = (Mozilla/4.0 (compatible; MSIE 5.17; Mac_PowerPC)); ua-os = (MacOS); ua-cpu = (PPC);
+ * </p>
  * 
- * IE 5.0 OS 9: user-agent = (Mozilla/4.0 (compatible; MSIE 5.0; Mac_PowerPC));
+ * <p><strong>IE 5.0 OS 9</strong><br>
+ * user-agent = (Mozilla/4.0 (compatible; MSIE 5.0; Mac_PowerPC));
  * ua-os = (MacOS); ua-cpu = (PPC);
+ * </p>
  * 
- * FireFox OS X 10.3.3: 
+ * <p><strong>FireFox OS X 10.3.3</strong><br> 
  * user-agent = (Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.6) Gecko/20040206 Firefox/0.8);
+ * </p>
  * 
- * IE 5.2 MacOS X: 
+ * <p><strong>IE 5.2 MacOS X</strong><br> 
  * user-agent = (Mozilla/4.0 (compatible; MSIE 5.23; Mac_PowerPC)); ua-os = (MacOS); ua-cpu = (PPC);
+ * </p>
  * 
- * Safari: 
+ * <p><strong>Safari</strong><br> 
  * user-agent = ("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125.1");
+ * </p>
  * 
- * IE WIndows 6.02: 
+ * <p><strong>IE WIndows 6.02</strong><br> 
  * user-agent = (Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0));
+ * </p>
  *  
  */
 public class ERXBasicBrowser extends ERXBrowser {
@@ -186,12 +193,15 @@ public class ERXBasicBrowser extends ERXBrowser {
         if (majorVersion.indexOf(".") != -1) {
         	majorVersion = majorVersion.substring(0, majorVersion.indexOf("."));
         }
+        
+        Integer mj;
         try {
-        	_majorVersion = Integer.valueOf(majorVersion);
+        	mj = Integer.valueOf(majorVersion);
         } catch (NumberFormatException e) {
         	log.info("could not determine major version from '" + majorVersion + "'", e);
-        	throw e;
+        	mj = -1;
 		}
+        _majorVersion = mj;
     }
 
     public String browserName() {


### PR DESCRIPTION
ERXBasicBrowser throws an exception, when it can't determine the browser version number. This exception prevents any further processing of the request (see below).
A "unknown version" string is used in various places throughout ERXBrowserFactory, e.g. when there is no user-agent string. No user-agent string may be send, when curl or something alike is used.
I propose to use the number -1 instead of an exception, when there is a malformed version string.

java.lang.reflect.InvocationTargetException
    at com.webobjects.appserver._private.WOActionRequestHandler._handleRequest(WOActionRequestHandler.java:269)
    at com.webobjects.appserver._private.WOActionRequestHandler.handleRequest(WOActionRequestHandler.java:158)
    at er.extensions.appserver.ERXDirectActionRequestHandler.handleRequest(ERXDirectActionRequestHandler.java:126)
    at com.webobjects.appserver.WOApplication.dispatchRequest(WOApplication.java:1687)
    at er.extensions.appserver.ERXApplication.dispatchRequestImmediately(ERXApplication.java:2029)
    at er.extensions.appserver.ERXApplication.dispatchRequest(ERXApplication.java:1994)
    at com.cx.toolkit.application.wonder.CXERXApplication.dispatchRequest(CXERXApplication.java:94)
    at com.webobjects.appserver._private.WOWorkerThread.runOnce(WOWorkerThread.java:144)
    at com.webobjects.appserver._private.WOWorkerThread.run(WOWorkerThread.java:226)
    at java.lang.Thread.run(Thread.java:680)
Caused by: java.lang.NumberFormatException: For input string: "Unknown Version"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:48)
    at java.lang.Integer.parseInt(Integer.java:449)
    at java.lang.Integer.valueOf(Integer.java:554)
    at er.extensions.appserver.ERXBasicBrowser.<init>(ERXBasicBrowser.java:190)
    at er.extensions.appserver.ERXBrowserFactory.createBrowser(ERXBrowserFactory.java:287)
    at er.extensions.appserver.ERXBrowserFactory.getBrowserInstance(ERXBrowserFactory.java:246)
    at er.extensions.appserver.ERXBrowserFactory.browserMatchingRequest(ERXBrowserFactory.java:209)
    at er.extensions.appserver.ERXRequest.browser(ERXRequest.java:230)
    at er.extensions.appserver.ERXSession.browser(ERXSession.java:331)
    at er.extensions.appserver.ERXSession.setLanguages(ERXSession.java:252)
    at com.jip.prostata4.Session.setLanguages(Session.java:175)
    at com.webobjects.appserver.WOSession.languages(WOSession.java:1198)
    at com.jip.prostata4.Session.languages(Session.java:186)
    at er.extensions.appserver.ERXSession.localizer(ERXSession.java:182)
    at er.extensions.appserver.ERXSession.awake(ERXSession.java:425)
    at com.cx.toolkit.application.wonder.CXERXSession.awake(CXERXSession.java:94)
    at com.jip.prostata4.Session.awake(Session.java:120)
    at com.webobjects.appserver.WOSession._awakeInContext(WOSession.java:838)
    at com.webobjects.appserver.WOApplication._initializeSessionInContext(WOApplication.java:2120)
    at com.webobjects.appserver.WOContext.session(WOContext.java:369)
    at com.webobjects.appserver.WOAction.session(WOAction.java:165)
    at com.jip.prostata4.DirectAction.session(DirectAction.java:179)
    at com.jip.prostata4.DirectAction.loginUser(DirectAction.java:294)
    at com.jip.prostata4.DirectAction.checkeBerechtigung(DirectAction.java:463)
    at com.jip.prostata4.DirectAction.prepareLoginAction(DirectAction.java:555)
    at sun.reflect.GeneratedMethodAccessor1560.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at com.webobjects.appserver.WODirectAction.performActionNamed(WODirectAction.java:144)
    at er.extensions.appserver.ERXDirectAction.performActionNamed(ERXDirectAction.java:401)
    at com.webobjects.appserver._private.WOActionRequestHandler._handleRequest(WOActionRequestHandler.java:259)
    ... 9 more
