### PR TITLE
ERXEnterpriseObjectCache should not cache objects before migrations have finished

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObjectCache.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObjectCache.java
@@ -353,6 +353,8 @@ public class ERXEnterpriseObjectCache<T extends EOEnterpriseObject> {
     */
     public void enableFetchingOfInitialValues(NSNotification n) {
         _applicationDidFinishInitialization = true;
+        NSNotificationCenter.defaultCenter().removeObserver(this,
+				ERXApplication.ApplicationDidFinishInitializationNotification, null);
     }
     
     /**


### PR DESCRIPTION
If you have ERXEnterpriseObjectCache objects in your code that are flagged to fetch initial values you can get exceptions if the entity to cache is not yet created in the database. This happens if you prepare some migrations adding new entities that should be cached. During the processing of migrations an editingContextDidSaveChanges notification is sent triggering the object cache to fetch its objects before everything is in place.
