### PR TITLE
Use the right amount of closing tags in AjaxTree when showRoot is false

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxTree.wo/AjaxTree.html
+++ b/Frameworks/Ajax/Ajax/Components/AjaxTree.wo/AjaxTree.html
@@ -8,5 +8,5 @@
 			<webobject name = "IsExpandedConditional"><webobject name = "NodeItem"/><webobject name = "CollapseAction"><webobject name = "ExpandedImage"/></webobject><webobject name = "TreeNodeRenderer"/><webobject name = "OpenUL"/></webobject>
 		</webobject>
 	</webobject>
-	<webobject name = "CloseCountRepetition"><webobject name = "CloseULLI"/></webobject>
+	<webobject name = "LastCloseCountRepetition"><webobject name = "CloseULLI"/></webobject>
 </webobject>

--- a/Frameworks/Ajax/Ajax/Components/AjaxTree.wo/AjaxTree.wod
+++ b/Frameworks/Ajax/Ajax/Components/AjaxTree.wo/AjaxTree.wod
@@ -30,6 +30,10 @@ CloseCountRepetition : WORepetition {
 	count = closeCount;
 }
 
+LastCloseCountRepetition: WORepetition {
+    count = lastCloseCount;
+}
+
 TreeNodeRepetition : WORepetition {
 	list = nodes;
 	item = item;

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxTree.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxTree.java
@@ -1,5 +1,7 @@
 package er.ajax;
 
+import org.apache.log4j.Logger;
+
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -44,6 +46,7 @@ import er.extensions.appserver.ERXWOContext;
  * @author mschrag
  */
 public class AjaxTree extends WOComponent {
+	private static final Logger log = Logger.getLogger(AjaxTree.class);
 	private AjaxTreeModel _treeModel;
 
 	private NSArray _nodes;
@@ -150,6 +153,7 @@ public class AjaxTree extends WOComponent {
 			else {
 				level = _level;
 			}
+			
 			if (_level > level) {
 				_closeCount = (_level - level);
 			}
@@ -159,6 +163,9 @@ public class AjaxTree extends WOComponent {
 			_lastParent = parent;
 			_level = level;
 			_item = item;
+			if (log.isDebugEnabled()) {
+				log.debug("AjaxTree item at level "+_level+" with close count "+_closeCount+": "+_item);
+			}
 			setValueForBinding(item, "item");
 		}
 	}
@@ -177,6 +184,23 @@ public class AjaxTree extends WOComponent {
 
 	public int _closeCount() {
 		return _closeCount;
+	}
+	
+	/**
+	 * Count of /ul /li close elements at the end of the tree.
+	 * If showRoot is "false" all displayed nodes have an internal "level" one greater than is really displayed,
+	 * e.g. the first level after the root has a level of "1", but is displayed at level "0". CloseCount is used
+	 * to close any open elements. When showRoot is "false" the jump from level 1 to level 0 at the end would compute 
+	 * to a closeCount of 1, but the last close is not necessary (as we are really displaying at level 0) and must be 
+	 * avoided.     
+	 * @return the last close count
+	 */
+	public int lastCloseCount()	{
+		if (AjaxUtils.booleanValueForBinding("showRoot", true, _keyAssociations, parent()) || _closeCount < 1) {
+			return _closeCount;
+		}
+
+		return _closeCount - 1;
 	}
 
 	public void setTreeModel(AjaxTreeModel treeModel) {


### PR DESCRIPTION
The AjaxTree generates a superfluous "/ul /li" pair at the end of the AjaxTree, when showRoot is false.

When the showRoot option for an AjaxTree is set to "false", the first level after the root node is displayed as the root list of the tree. The root node itself has still the internal level 0, while the first level after root has level 1. When closing the last level, a "closeCount" number is calculated, as the difference between the last displayed level and the root level.

Example:

DEBUG er.ajax.AjaxTree  - AjaxTree item at level 0 with close count 0: com.cx.minikiswrapper.TreeModelCodeDelegate$RootCodeTreeNode@74d4db38
DEBUG er.ajax.AjaxTree  - AjaxTree item at level 1 with close count 0: N41.0 - Akute Prostatitis 
DEBUG er.ajax.AjaxTree  - AjaxTree item at level 1 with close count 0: N41.1 - Chronische Prostatitis 
DEBUG er.ajax.AjaxTree  - AjaxTree item at level 0 with close count 1: null
DEBUG er.ajax.AjaxTree  - AjaxTree item at level 0 with close count 0: com.cx.minikiswrapper.TreeModelCodeDelegate$RootCodeTreeNode@74d4db38

The first and last line come from AjaxTree.resetTree(). The culprit is line 4. It calculates the amount of close tags to generate at the end of the tree. When the root is displayed this is correct, but there is nothing to close, when it is hidden, as we are still displaying the first level.

A solution is to check for showRoot = false and then subtract one for the last closeCount.
