### PR TITLE
'ClickToOpen' command-click menu items not working

### DIFF
--- a/Frameworks/Misc/WOLips/Sources/er/wolips/WOLipsUtilities.java
+++ b/Frameworks/Misc/WOLips/Sources/er/wolips/WOLipsUtilities.java
@@ -50,7 +50,7 @@ public class WOLipsUtilities {
       urlBuffer.append(URLEncoder.encode(password, "UTF-8"));
       if (params != null && !params.isEmpty()) {
         for (Object key : params.allKeys()) {
-          urlBuffer.append("&amp;");
+          urlBuffer.append("&");
           urlBuffer.append(URLEncoder.encode(key.toString(), "UTF-8"));
           urlBuffer.append("=");
           Object value = params.objectForKey(key);


### PR DESCRIPTION
Don't escape the ampersands in the query string of the 'ClickToOpen' URL that is generated for the 'command-click' menu. This menu was not working for me whereas the regular HTML link in the ClickToOpen toolbar was. Tested in Safari 5.1.1 on Mac OS X Lion.
