### PR TITLE
AjaxFlexibleUpload: "Cancel" button shown although it shouldn't

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.wo/AjaxFlexibleFileUpload.wod
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.wo/AjaxFlexibleFileUpload.wod
@@ -80,6 +80,7 @@ CancelButton : WOHyperlink {
   onclick = cancelUploadFunction;
   id = cancelButtonId;
   class = cancelButtonClass;
+  style = "display:none";
 }
 
 CancelLabel : WOString {


### PR DESCRIPTION
Problem: Although the binding "allowCancel" is set to false (or not provided at all), a "Cancel" button is shown during the first uploading process. During subsequent uploads it is correctly hidden.

Solution: Hide "Cancel" button initially. The JS code in wonder.js already takes care of showing it if necessary (see AjaxUploadClient.start) and hiding it afterwards (that's why subsequent upload already work fine).
