### PR TITLE
Javadoc changes to clarify the behaviour of capitalize(String) and capitalizeAllWords(String).

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXStringUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXStringUtilities.java
@@ -1084,7 +1084,11 @@ public class ERXStringUtilities {
     }
 
     /**
-     * Capitalizes a given string.
+     * Capitalizes a given string. That is, the first character of the returned
+     * string will be upper case, and other characters will be unchanged. For
+     * example, for the input string "{@code you have a dog}", this method would
+     * return "{@code You have a dog}".
+     * 
      * @param value to be capitalized
      * @return capitalized string
      */
@@ -1126,7 +1130,14 @@ public class ERXStringUtilities {
     }
     
     /**
-     * Capitalizes all the strings in a given string.
+     * Capitalizes all the strings in a given string. That is, the first
+     * character of each (whitespace-delimited) word in the input string will be
+     * upper case, and other characters will be unchanged. Additionally, each
+     * region of contiguous whitespace in the original string is converted to a
+     * single space in the result. For example, for the input string
+     * "{@code you  have  a  dog}" (with two spaces between each word), this
+     * method would return "{@code You Have A Dog}".
+     * 
      * @param value to be capitalized
      * @return capitalized string
      */    


### PR DESCRIPTION
I've just added a few lines of Javadoc comments to each of those methods to make their behaviour quite clear.
