### PR TITLE
NSArray & NSDictionary valueForKey Genericizificationating

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
@@ -1077,20 +1077,32 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 	}
 	
 	/**
-	 * A type-safe wrapper for {@link #valueForKeyPath(String)}.
-	 * @param <T> the type of elements in the returned NSArray
+	 * A type-safe wrapper for {@link #valueForKeyPath(String)} that simply
+	 * calls {@code valueForKeyPath(erxKey.key())} and attempts to cast the
+	 * result to {@code NSArray<T>}. If the value returned cannot be cast it
+	 * will throw a {@code ClassCastException}.
+	 * 
+	 * @param <T>
+	 *            the Type of elements in the returned {@code NSArray}
 	 * @param erxKey
-	 * @return an NSArray of T objects.
+	 * @return an {@code NSArray} of {@code T} objects.
+	 * @author David Avendasora
 	 */
 	public <T> NSArray<T> valueForKeyPath(ERXKey<T> erxKey) {
 		return (NSArray<T>) valueForKeyPath(erxKey.key());
 	}
-	
+
 	/**
-	 * A type-safe wrapper for {@link #valueForKey(String)}
-	 * @param <T> the type of elements in the returned NSArray
+	 * A type-safe wrapper for {@link #valueForKey(String)} that simply calls
+	 * {@code valueForKey(erxKey.key())} and attempts to cast the result to
+	 * {@code NSArray<T>}. If the value returned cannot be cast it will throw a
+	 * {@code ClassCastException}.
+	 * 
+	 * @param <T>
+	 *            the Type of elements in the returned {@code NSArray}
 	 * @param erxKey
-	 * @return an NSArray of T objects.
+	 * @return an {@code NSArray} of {@code T} objects.
+	 * @author David Avendasora
 	 */
 	public <T> NSArray<T> valueForKey(ERXKey<T> erxKey) {
 		return (NSArray<T>) valueForKey(erxKey.key());

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSDictionary.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSDictionary.java
@@ -15,6 +15,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import er.extensions.eof.ERXKey;
+
 /**
  * NSDictionary reimplementation to support JDK 1.5 templates. Use with
  * 
@@ -701,4 +703,64 @@ public class NSDictionary<K, V> implements Cloneable, Serializable, NSCoding, NS
 	public static final boolean CheckForNull = true;
 	public static final boolean IgnoreNull = true;
 	private static final ObjectStreamField[] serialPersistentFields = { new ObjectStreamField(SerializationKeysFieldKey, _objectArrayClass), new ObjectStreamField(SerializationValuesFieldKey, _objectArrayClass) };
+
+	/**
+	 * A type-safe wrapper for {@link #valueForKeyPath(String)} that simply
+	 * calls {@code valueForKeyPath(erxKey.key())} and attempts to cast the
+	 * result to {@code V}. If the value returned cannot be cast it will throw a
+	 * {@code ClassCastException}.
+	 * 
+	 * @param erxKey
+	 * @return an object of Type {@code V}
+	 * @author David Avendasora
+	 */
+	public V valueForKeyPath(ERXKey<V> erxKey) {
+		return (V) valueForKeyPath(erxKey.key());
+	}
+
+	/**
+	 * A type-safe wrapper for {@link #valueForKey(String)} that simply
+	 * calls {@code valueForKeyPath(erxKey.key())} and attempts to cast the
+	 * result to {@code V}. If the value returned cannot be cast it will throw a
+	 * {@code ClassCastException}.
+	 * 
+	 * @param erxKey
+	 * @return an object of Type {@code V}
+	 * @see #objectForKey(Object)
+	 * @author David Avendasora
+	 */
+	public V valueForKey(ERXKey<V> erxKey) {
+		return (V) valueForKey(erxKey.key());
+	}
+
+	/**
+	 * A type-safe wrapper for {@link #takeValueForKey(Object, String)} that
+	 * ensures the {@code value} matches the {@code key}'s Type. The key is the
+	 * {@code String} returned by {@link ERXKey#key()} so values can be
+	 * retrieved using either {@link #valueForKey(String)} or
+	 * {@link #valueForKey(ERXKey)}.
+	 * 
+	 * @param value
+	 * @param erxKey
+	 * @author David Avendasora
+	 */
+	public void takeValueForKey(V value, ERXKey<V> erxKey) {
+		takeValueForKey(value, erxKey.key());
+	}
+
+	/**
+	 * A type-safe wrapper for {@link #takeValueForKeyPath(Object, String)} that
+	 * ensures the {@code value} matches the {@code key}'s Type. The keyPath is
+	 * the {@code String} returned by {@link ERXKey#key()} so values can be
+	 * retrieved using either {@link #valueForKey(String)} or
+	 * {@link #valueForKey(ERXKey)}.
+	 * 
+	 * @param value
+	 * @param erxKey
+	 * @author David Avendasora
+	 */
+	public void takeValueForKeyPath(V value, ERXKey<V> erxKey) {
+		takeValueForKeyPath(value, erxKey.key());
+	}
+
 }


### PR DESCRIPTION
Wraps EOF-standard valueForKey(String) with a Type-safe call passing an ERXKey instead of a String key. This allows requesting valueForKey on an array of objects without needing to cast the result and then suppress warnings for unchecked casting thereby simplifying code and removing compiler directives and/or warnings.

For example:

<pre><code>@SuppressWarnings("unchecked")
NSArray<Question> questions = (NSArray<Question>) answers.valueForKey(Answer.QUESTION_KEY);</code></pre>


Becomes:

<pre><code>NSArray<Question> questions = answers.valueForKey(Answer.QUESTION);</code></pre>


PRIMARY DISCUSSION POINT: This changes the API for NSArray. It is NOT a subclass. It modifies Wonder's re-implementation of NSArray.
