### PR TITLE
add support for some adaptor actions to Derby plugin

### DIFF
--- a/Frameworks/PlugIns/DerbyPlugIn/Sources/com/webobjects/jdbcadaptor/ERDerbyPlugIn.java
+++ b/Frameworks/PlugIns/DerbyPlugIn/Sources/com/webobjects/jdbcadaptor/ERDerbyPlugIn.java
@@ -222,6 +222,17 @@ public class ERDerbyPlugIn extends JDBCPlugIn {
 		}
 
 		@Override
+		public String _columnCreationClauseForAttribute(EOAttribute attribute) {
+			return addCreateClauseForAttribute(attribute).toString();
+		}
+		
+		public StringBuffer addCreateClauseForAttribute(EOAttribute attribute) {
+			EOSQLExpression expression = _expressionForEntity(attribute.entity());
+			expression.addCreateClauseForAttribute(attribute);
+			return new StringBuffer(expression.listString());
+		}
+		
+		@Override
 		public NSArray<EOSQLExpression> _statementsToDropPrimaryKeyConstraintsOnTableNamed(final String tableName) {
 			return new NSArray<EOSQLExpression>(_expressionForString("alter table " + formatTableName(tableName) + " drop primary key"));
 		}


### PR DESCRIPTION
This patch adds methods to the ERDerbyPlugIn to support
- add/drop NOT NULL constraints
- table rename
- column rename
