### PR TITLE
Integer caching in ERXConstant

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXConstant.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXConstant.java
@@ -21,6 +21,7 @@ import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSPropertyListSerialization;
 
 import er.extensions.foundation.ERXArrayUtilities;
+import er.extensions.foundation.ERXStringUtilities;
 
 /**
  * General purpose constant class, useful when you want reference object that are not
@@ -491,8 +492,10 @@ public abstract class ERXConstant {
      * @throws NumberFormatException forwarded from the
      *		parseInt method off of Integer
      * @return potentially cache Integer for a given String
+     * 
+     * @deprecated use {@link ERXStringUtilities#integerWithString(String)}
      */
-    // MOVEME: ERXStringUtilities
+    @Deprecated
     public static Integer integerForString(String s) throws NumberFormatException {
         return integerForInt(Integer.parseInt(s));
     }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXStringUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXStringUtilities.java
@@ -408,8 +408,9 @@ public class ERXStringUtilities {
      */
     public static Integer integerWithString(String s) {
         try {
-            return ERXConstant.integerForString(s);
-        } catch (Exception e) {
+            return ERXConstant.integerForInt(Integer.parseInt(s));
+        } catch (NumberFormatException e) {
+        	// ignore
         }
         return null;
     } 


### PR DESCRIPTION
ERXConstant should use Integer.valueOf instead of new Integer() for its cached integer values.
