### PR TITLE
ERXBrowserFactory.parseVersion will not always return a number

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXBrowserFactory.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXBrowserFactory.java
@@ -425,6 +425,14 @@ public class ERXBrowserFactory {
             if (st.hasMoreTokens()) 
                 version = st.nextToken();  // Will return "5.21" portion of "5.21; Mac_PowerPC)"
         }
+		// Test if we got a real number
+		try {
+	        String normalizedVersion = ERXStringUtilities.removeExtraDotsFromVersionString(version);
+			Double.parseDouble(normalizedVersion);
+		}
+		catch (NumberFormatException e) {
+			version = ERXBrowser.UNKNOWN_VERSION;
+		}
         return version;
     }
 


### PR DESCRIPTION
The contents of some user-agent that  can't be parsed.

"Mozilla/5.0 (compatible; MJ12bot/v1.4.1;http://www.majestic12.co.uk/bot.php?+)"
"SonyEricssonJ20i/R7BA Browser/NetFront/3.5 Profile/MIDP-2.1Configuration/CLDC-1.1 JavaPlatform/JP-8.5.2"
