### PR TITLE
ERXWOTestInterface is checking to see if Logging is enabled instead of the Test Interface

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/testrunner/ERXWOTestInterface.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/testrunner/ERXWOTestInterface.java
@@ -192,11 +192,11 @@ public class ERXWOTestInterface extends WOComponent implements ERXTestListener {
     }
 
     public void appendToResponse(WOResponse r, WOContext c) {
-    	if (session().objectForKey("ERXLog4JConfiguration.enabled") != null) {
+    	if (session().objectForKey("ERXWOTestInterface.enabled") != null) {
     		super.appendToResponse(r, c);
     	}
     	else {
-    		r.appendContentString("please use the ERXDirectAction log4jAction to login first!");
+    		r.appendContentString("please use the ERXDirectAction testAction to login first!");
     	}
     }
 }


### PR DESCRIPTION
It doesn't make sense to have the testing interface dependent on the logging configuration interface being enabled.

I believe this is just a copy-paste error that has never been fixed.

Dave
