### PR TITLE
ERMD2WEditToOneTypeAhead conditional show of 'new' and 'inspect'

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WEditToOneTypeAhead.wo/ERMD2WEditToOneTypeAhead.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WEditToOneTypeAhead.wo/ERMD2WEditToOneTypeAhead.html
@@ -5,9 +5,13 @@
 </div>
 <div class="ActionCell">
 <ul class="ObjActionList RtObjActionList">
-    <li><webobject name = "NewObjectButton"/></li>
+    <webobject name = "ShowNewButton">
+         <li><webobject name = "NewObjectButton"/></li>
+    </webobject>
     <webobject name = "ERXNonNullConditional">
-        <li><webobject name = "InspectObjectButton"/></li>
+         <webobject name = "ShowInspectButton">
+             <li><webobject name = "InspectObjectButton"/></li>
+        </webobject>
         <li><webobject name = "RemoveObjectButton"/></li>
     </webobject>
 </ul>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WEditToOneTypeAhead.wo/ERMD2WEditToOneTypeAhead.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WEditToOneTypeAhead.wo/ERMD2WEditToOneTypeAhead.wod
@@ -34,3 +34,11 @@ RemoveObjectButton : ERMDRemoveRelatedButton {
 ERXNonNullConditional : ERXNonNullConditional {
   condition = currentSelection;
 }
+
+ShowNewButton: WOConditional {
+	condition = isEntityCreatable;
+}
+
+ShowInspectButton: WOConditional {
+	condition = isEntityInspectable;
+}

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/relationships/ERMD2WEditToOneTypeAhead.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/relationships/ERMD2WEditToOneTypeAhead.java
@@ -417,5 +417,16 @@ public class ERMD2WEditToOneTypeAhead extends ERDCustomEditComponent {
 	public String searchTermSelectedFunction() {
 		return "function(e) { " + searchTermSelectedFunctionName() + "(); }";
 	}
-	
+    
+	/** Should the 'new' button be displayed? */
+	public boolean isEntityCreatable() {
+		return ERXValueUtilities.booleanValueWithDefault(d2wContext()
+				.valueForKey("isDestinationEntityCreatable"), true);
+	}
+
+	/** Should the 'inspect' button be displayed? */
+	public boolean isEntityInspectable() {
+		return ERXValueUtilities.booleanValueWithDefault(d2wContext()
+				.valueForKey("isDestinationEntityInspectable"), true);
+	}
 }


### PR DESCRIPTION
Allow setting by rules if ERMD2WEditToOneTypeAhead should show the 'new' or 'inspect' button.
