### PR TITLE
ERXDirectAction patch

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDirectAction.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDirectAction.java
@@ -53,13 +53,14 @@ public class ERXDirectAction extends WODirectAction {
     /** holds a reference to the current browser used for this session */
     private ERXBrowser browser;
 
-    /** Public constructor */
     public ERXDirectAction(WORequest r) { super(r); }
 
 
     /**
      * Checks if the action can be executed.
-     * @param passwordKey
+     * 
+     * @param passwordKey the password to test
+     * @return <code>true</code> if action is allowed to be invoked
      */
     protected boolean canPerformActionWithPasswordKey(String passwordKey) {
     	if(ERXApplication.isDevelopmentModeSafe()) {
@@ -126,6 +127,8 @@ public class ERXDirectAction extends WODirectAction {
 
     /**
      * Direct access to WOStats by giving over the password in the "pw" parameter.
+     * 
+     * @return statistics page
      */
     public WOActionResults statsAction() {
         WOStatsPage nextPage = pageWithName(ERXStatisticsPage.class);
@@ -137,6 +140,7 @@ public class ERXDirectAction extends WODirectAction {
      * Direct access to reset the stats by giving over the password in the "pw" parameter.  This
      * calls ERXStats.reset();
      * 
+     * @return statistics page
      */
     public WOActionResults resetStatsAction() {
         if (canPerformActionWithPasswordKey("WOStatisticsPassword")) {
@@ -151,6 +155,8 @@ public class ERXDirectAction extends WODirectAction {
     
     /**
      * Direct access to WOEventDisplay by giving over the password in the "pw" parameter.
+     * 
+     * @return event page
      */
     public WOActionResults eventsAction() {
         WOEventDisplayPage nextPage = pageWithName(WOEventDisplayPage.class);
@@ -163,6 +169,8 @@ public class ERXDirectAction extends WODirectAction {
     /**
      * Direct access to WOEventDisplay by giving over the password in the "pw" 
      * parameter and turning on all events.
+     * 
+     * @return event setup page
      */
     public WOActionResults eventsSetupAction() {
         WOEventSetupPage nextPage = pageWithName(WOEventSetupPage.class);
@@ -350,6 +358,8 @@ public class ERXDirectAction extends WODirectAction {
      * Returns a list of the traces of open editing context locks.  This is only useful if
      * er.extensions.ERXApplication.traceOpenEditingContextLocks is enabled and 
      * er.extensions.ERXOpenEditingContextLocksPassword is set.
+     * 
+     * @return list of lock traces
      */
     public WOActionResults showOpenEditingContextLockTracesAction() {
       if (canPerformActionWithPasswordKey("er.extensions.ERXOpenEditingContextLockTracesPassword")) {
@@ -371,6 +381,11 @@ public class ERXDirectAction extends WODirectAction {
       return forbiddenResponse();
     }
 
+    /**
+     * Will terminate an existing session and redirect to the default action.
+     * 
+     * @return redirect to default action
+     */
     public WOActionResults logoutAction() {
         if (existingSession()!=null) {
             existingSession().terminate();
@@ -398,6 +413,7 @@ public class ERXDirectAction extends WODirectAction {
         return browser; 
     }
 
+    @Override
     public WOActionResults performActionNamed(String actionName) {
         WOActionResults actionResult = super.performActionNamed(actionName);
         if (browser != null) 
@@ -449,6 +465,8 @@ public class ERXDirectAction extends WODirectAction {
     
     /**
      * Opens the localizer edit page if the app is in development mode.
+     * 
+     * @return localizer editor
      */
     public WOActionResults editLocalizedFilesAction() {
     	if (ERXApplication.isDevelopmentModeSafe()) {
@@ -457,7 +475,12 @@ public class ERXDirectAction extends WODirectAction {
 		return null;
     }
     
-    
+    /**
+     * Will dump all created keys of the current localizer via log4j and
+     * returns an empty response.
+     * 
+     * @return empty response
+     */
     public WOActionResults dumpCreatedKeysAction() {
     	if (ERXApplication.isDevelopmentModeSafe()) {
     		session();
@@ -501,6 +524,11 @@ public class ERXDirectAction extends WODirectAction {
       return (T) super.pageWithName(componentClass.getName());
     }
 
+    /**
+     * Terminates the application when in development.
+     * 
+     * @return "OK" if application has been shut down
+     */
 	public WOActionResults stopAction() {
     	ERXResponse response = new ERXResponse();
     	response.setHeader("text/plain", "Content-Type");


### PR DESCRIPTION
This patch changes ERXDirectAction to use Wonder classes instead of the WO classes where possible:
- pageWithName(String) -> pageWithName(Class)
- WOResponse -> ERXResponse
- WORedirect -> ERXRedirect

Last one ensures that the redirections will stay https if the request was secure which is most annoying in the logoutAction.

Many of the direct actions check via canPerformActionWithPasswordKey() if the user is allowed to call that action. Instead of returning an empty response a 403 Forbidden should be returned. Last but not least all direct actions should have WOActionResults as return type instead of WOComponent. This could break code if someone overrode the methods in question but then to override those methods probably is very uncommon.
