### PR TITLE
AjaxFlickrBatchNavigation should offer 'batchSizes' and 'showBatchSizes' bindings

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxFlickrBatchNavigation.api
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlickrBatchNavigation.api
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <wodefinitions>
 	<wo class="AjaxFlickrBatchNavigation" wocomponentcontent="false">
 		<binding name="displayGroup"/>
@@ -34,5 +34,7 @@
 	    <binding name="parentActionName"/>
 	    <binding name="maxNumberOfObjects"/>
 	    <binding name="numberOfObjectsPerBatch"/>
+    <binding name="batchSizes"/>
+    <binding name="showBatchSizes"/>
     </wo>
 </wodefinitions>

--- a/Frameworks/Ajax/Ajax/Components/AjaxFlickrBatchNavigation.wo/AjaxFlickrBatchNavigation.html
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlickrBatchNavigation.wo/AjaxFlickrBatchNavigation.html
@@ -1,10 +1,10 @@
-<div class = "paginatorContainer">
-	<webobject name = "HasMultiplePagesConditional">
+<webobject name = "HasMultiplePagesConditional">
+	<div class = "paginatorContainer">
 		<div class = "paginator">
 			<webobject name = "HasPreviousPageConditional">
 				<webobject name = "PreviousPageAction">&lt;<webobject name="PreviousLabel"/></webobject>
 			</webobject>
-			<webobject name = "HasNoPreviousPageConditional"><span class="paginatorAtStart">&lt;<webobject name="PreviousLabel"/></span></webobject>
+			<webobject name = "HasNoPreviousPageConditional"><webobject name = "ShowLabels"><span class="paginatorAtStart">&lt;<webobject name="PreviousLabel"/></span></webobject></webobject>
 			<webobject name = "PageNumberRepetition">
 				<webobject name = "IsCurrentPageNumberConditional"><span class="paginatorCurrentPage"><webobject name = "PageNumber"/></span></webobject>
 				<webobject name = "IsNotCurrentPageNumberConditional">
@@ -17,8 +17,9 @@
 			<webobject name = "HasNextPageConditional">
 				<webobject name = "NextPageAction"><webobject name="NextLabel"/>&gt;</webobject>
 			</webobject>
-			<webobject name = "HasNoNextPageConditional"><span class="paginatorAtEnd"><webobject name="NextLabel"/>&gt;</span></webobject>
+			<webobject name = "HasNoNextPageConditional"><webobject name = "ShowLabels"><span class="paginatorAtEnd"><webobject name="NextLabel"/>&gt;</span></webobject></webobject>
 		</div>
-	</webobject>
-	<div class="paginatorResults">(<webobject name = "ShowPageRange"><webobject name = "FirstIndex"/>&#8211;<webobject name = "LastIndex"/> <webobject name = "OfLabel"/> </webobject><webobject name = "DisplayName"/>)</div>
-</div>
+		<div class="paginatorResults">(<webobject name = "ShowPageRange"><webobject name = "FirstIndex"/>&#8211;<webobject name = "LastIndex"/> <webobject name = "OfLabel"/> </webobject><webobject name = "DisplayName"/>)</div>
+	<webobject name = "ShowBatchSizes"><div class="paginatorBatchSizes"> <webobject name = "ShowLabel"/> <span class="paginatorBatchSizeList"><webobject name = "BatchSizes"><webobject name = "SelectBatchSize"></webobject> </webobject></span> <webobject name = "DisplayName2"/> <webobject name = "PerPageLabel"/></div></webobject>
+	</div>
+</webobject>

--- a/Frameworks/Ajax/Ajax/Components/AjaxFlickrBatchNavigation.wo/AjaxFlickrBatchNavigation.wod
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlickrBatchNavigation.wo/AjaxFlickrBatchNavigation.wod
@@ -23,6 +23,17 @@ PreviousPageAction : AjaxUpdateLink {
 	updateContainerID = updateContainerID;
 }
 
+PreviousLabel : ERXLocalizedString {
+	value = "ERXFlickrBatchNavigation.previous";
+}
+
+ShowLabel : ERXLocalizedString {
+	value = "ERXFlickrBatchNavigation.show";
+}
+
+PerPageLabel : ERXLocalizedString {
+	value = "ERXFlickrBatchNavigation.page";
+}
 HasNextPageConditional : WOConditional {
 	condition = hasNextPage;
 }
@@ -37,6 +48,10 @@ NextPageAction : AjaxUpdateLink {
 	class = "paginatorNext";
 	onClick = ^onClick;
 	updateContainerID = updateContainerID;
+}
+
+NextLabel : ERXLocalizedString {
+	value = "ERXFlickrBatchNavigation.next";
 }
 
 SelectPageAction : AjaxUpdateLink {
@@ -79,17 +94,38 @@ LastIndex : WOString {
 	value = lastIndex;
 }
 
+ShowLabels : WOConditional {
+	condition = showLabels;
+}
+
 DisplayName : ERXPluralString {
 	count = displayNameCount;
 	value = displayName;
 }
 
-NextLabel : ERXLocalizedString {
-	value = "ERXFlickrBatchNavigation.next";
+
+DisplayName2 : ERXPluralString {
+	count = displayNameCount;
+	value = displayName;
+	showNumber = false;
 }
 
-PreviousLabel : ERXLocalizedString {
-	value = "ERXFlickrBatchNavigation.previous";
+BatchSizes : WORepetition {
+	list = possibleBatchSizes;
+	item = currentBatchSize;
+}
+
+SelectBatchSize : AjaxUpdateLink {
+	action = selectBatchSize;
+	string = currentBatchSizeString;
+	disabled = isCurrentBatchSizeSelected;
+	class = "selectBatchSize";
+	onClick = ^onClick;
+	updateContainerID = updateContainerID;
+}
+
+ShowBatchSizes : WOConditional {
+  condition = showBatchSizes;
 }
 
 OfLabel : ERXLocalizedString {

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlickrBatchNavigation.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlickrBatchNavigation.java
@@ -19,6 +19,8 @@ import er.extensions.batching.ERXFlickrBatchNavigation;
  * @binding onClick an optional JavaScript String to bind to the previous, next, and select page AjaxUpdateLinks.
  * @binding updateContainerID (optional) the id of the container to refresh (defaults to the nearest parent)
  * @binding showPageRange if true, the page of items on the page is shown, for example "(1-7 of 200 items)" 
+ * @binding showBatchSizes if <code>true</code>, a menu to change the items per page is shown "Show: (10) 20 (100) (All) items per page"
+ * @binding batchSizes can be either a string or an NSArray of numbers that define the batch sizes to chose from. The number "0" provides an "All" items batch size. For example "10,20,30" or "10,50,100,0"
  * @binding small if true, a compressed page count style is used 
  * 
  * @binding parentActionName (if you don't provide a displayGroup) the action to be executed on the parent component to get the next batch of items.


### PR DESCRIPTION
`AjaxFlickrBatchNavigation` is a subclass of `ERXFlickrBatchNavigation` but drops support for a couple of handy bindings from its parent. This patch makes the template look much more like that of  `ERXFlickrBatchNavigation`.

The result should be almost indistinguishable from the current `AjaxFlickrBatchNavigation` if you don't use those bindings, except in the case where the entire list fits on a single page. This patch reverts to the behaviour of `ERXFlickrBatchNavigation`, which avoids displaying any content at all for this component in that case. This change is fairly arbitrary, and might not be to everyone's taste, but it does make it more consistent with the behaviour of `ERXFlickrBatchNavigation`.

Template code was provided to the wonder-disc list by Ted Archibald.
