### PR TITLE
Add boolean support to dynamic choice of navigation menus.

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationState.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationState.java
@@ -139,6 +139,9 @@ public class ERXNavigationState {
                         if (children == null)
                             log.warn("For nav core object: " + levelRoot + " and child binding: " + levelRoot.childrenBinding()
                                      + " couldn't find children for choice key: " + (String)o);
+                    } else if (o instanceof Boolean) {
+                    	String s = Boolean.toString((Boolean)o);
+                    	children = (NSArray)levelRoot.childrenChoices().objectForKey(s);
                     } else {
                         log.warn("For nav core object: " + levelRoot + " and child binding: " + levelRoot.childrenBinding()
                                  + " recieved binding object: " + o);


### PR DESCRIPTION
Currently, navigation menu child menus can be chosen statically or dynamically at runtime. The current ERXNavigationState looks for an array, then a string and then gives up. This patch simply adds a check for a boolean and then looks up that value in the array.
