### PR TITLE
Integration

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -1092,10 +1092,13 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	public ERXApplication() {
 		super();
 		
-		// ERXComponentRequestHandler is a pathed verson of the original WOComponentRequestHandler
-		// Will patch the direct component access security hole
-		ERXComponentRequestHandler erComponentRequestHandler = new ERXComponentRequestHandler();
-		registerRequestHandler(erComponentRequestHandler, this.componentRequestHandlerKey());
+		// ERXComponentRequestHandler is a patched verson of the original WOComponentRequestHandler
+		// This method will tell Application to used the patched, the pathed version will disallow direct component access by name
+		// If you want to use the unpatched version set the property ERXDirectComponentAccessAllowed to true
+		if (!ERXProperties.booleanForKeyWithDefault("ERXDirectComponentAccessAllowed", false)) {
+			ERXComponentRequestHandler erComponentRequestHandler = new ERXComponentRequestHandler();
+			registerRequestHandler(erComponentRequestHandler, this.componentRequestHandlerKey());
+		}
 		
 		ERXStats.initStatisticsIfNecessary();
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXComponentRequestHandler.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXComponentRequestHandler.java
@@ -2,7 +2,7 @@ package er.extensions.appserver;
 
 /**
  * Patched to fix the security hole about direct access of components
- * use ERXDirectComponentAccessAllowed=false to block direct access to components
+ * use ERXDirectComponentAccessAllowed=true to restore the original behaviour (direct access to components by name in URL)
  */
 
 import com.webobjects.appserver.WOActionResults;
@@ -19,7 +19,8 @@ import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSLog;
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSNotificationCenter;
-import com.webobjects.foundation.NSProperties;
+
+import er.extensions.foundation.ERXProperties;
 
 public class ERXComponentRequestHandler extends WORequestHandler
 {
@@ -27,7 +28,7 @@ public class ERXComponentRequestHandler extends WORequestHandler
 
 	public ERXComponentRequestHandler() {
 		super();
-		setDirectComponentAccessAllowed(NSProperties.booleanForKeyWithDefault("ERXDirectComponentAccessAllowed", true));
+		setDirectComponentAccessAllowed(ERXProperties.booleanForKeyWithDefault("ERXDirectComponentAccessAllowed", false));
 	}
 
 	public static NSDictionary requestHandlerValuesForRequest(WORequest aRequest) {


### PR DESCRIPTION
Added patched WOComponentRequestHandler to prevent component direct access by URL,

Use property ERXDirectComponentAccessAllowed=false to avoid direct component access

Signed-off-by: Amedeo Mantica amedeo.mantica@insigno.it
