### PR TITLE
Fixes error flagged by IE7, IE8 and Chrome under Windows

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/prototype.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/prototype.js
@@ -609,7 +609,7 @@ Object.extend(String.prototype, (function() {
   }
 
   function evalScripts() {
-    return this.extractScripts().map(function(script) { return eval(script) });
+    return this.extractScripts().map(function(script) { return eval(script); });
   }
 
   function escapeHTML() {


### PR DESCRIPTION
Apparently IE (IE8 confirmed, but possibly also other versions) and
Chrome are sticklers for the semi-colon at the end of the return
statement on line 612. (Safari is happy to live without it.) To
reproduce, put an AjaxFlexibleFileUpload on a page and view with one
of those browsers: the error is flagged, and the component will not
work. Adding the semi-colon allows the component to function.

(Ideally, I suppose, we would make this fix upstream, but we are
running the latest release of Prototype (1.7) as it is, and the last
release was November 2010. It certainly seems pragmatic to fix it here
and now.)
