### PR TITLE
Postgres IN(...) clause bind variables

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2252,20 +2252,6 @@ public class ERXSQLHelper {
 		protected String sqlForGetNextValFromSequencedNamed(String sequenceName) {
 			return "select NEXTVAL('" + sequenceName + "') as key"; 
 		}
-		
-		@Override
-		protected String formatValueForAttribute(EOSQLExpression expression, Object value, EOAttribute attribute, String key) {
-			// The Postgres Expression has a problem using bind variables so we
-			// have to get the formatted
-			// SQL string for a value instead. All Apple provided plugins must
-			// use the bind variables
-			// however. Frontbase can go either way
-			// MS: is expression always instanceof PostgresExpression for
-			// postgres?
-			// boolean isPostgres =
-			// e.getClass().getName().equals("com.webobjects.jdbcadaptor.PostgresqlExpression");
-			return expression.formatValueForAttribute(value, attribute);
-		}
 
 		@Override
 		public String limitExpressionForSQL(EOSQLExpression expression, EOFetchSpecification fetchSpecification, String sql, long start, long end) {


### PR DESCRIPTION
In the past for Postgres bind variables were fairly problematic in general (all situations)
in older versions of Postgres because the types of values was not determined well and that
often prevented it from properly utilizing indices when it should have.  This problem was
eventually lessened by adding explicit type-casts to the binding values and then by
Postgres itself fixing the problem directly in the database.  So this is what was meant by
the comment "The Postgres Expression has a problem using bind variables" in
PostgresqlSQLHelper.formatValueForAttribute.  This problem is no longer present in
Postgres, so it's totally safe to change this so that bind variables will be used
(if configured) by removing the override of formatValueForAttribute.

Links to relevant changes in SVN history:

http://wonder.svn.sourceforge.net/viewvc/wonder/trunk/Wonder/Common/Frameworks/ERExtensions/Sources/er/extensions/ERXEOAccessUtilities.java?r1=2875&r2=2913&pathrev=7103

http://wonder.svn.sourceforge.net/viewvc/wonder/trunk/Wonder/Common/Frameworks/ERExtensions/Sources/er/extensions/ERXEOAccessUtilities.java?r1=3191&r2=3219&pathrev=7103

http://wonder.svn.sourceforge.net/viewvc/wonder/trunk/Wonder/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java?revision=7710&view=markup

http://wonder.svn.sourceforge.net/viewvc/wonder/trunk/Wonder/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlExpression.java?view=log&pathrev=7700
