### PR TITLE
ERAttachment Migrations Fix

### DIFF
--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/migrations/ERAttachment0.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/migrations/ERAttachment0.java
@@ -40,7 +40,6 @@ public class ERAttachment0 extends ERXMigrationDatabase.Migration {
     attachmentTable.newIntegerColumn("attachmentDataID", true);
     attachmentTable.newStringColumn("filesystemPath", 255, true);
     attachmentTable.newStringColumn("s3Path", 1000, true);
-    attachmentTable.newStringColumn("cfPath", 1000, true);
     attachmentTable.create();
     attachmentTable.setPrimaryKey("id");
     attachmentTable.addUniqueIndex("ERAttachmentWebPath", "webPath", 1000);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/migrations/ERAttachment2.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/migrations/ERAttachment2.java
@@ -1,0 +1,33 @@
+
+package er.attachment.migrations;
+
+import com.webobjects.eocontrol.EOEditingContext;
+
+import er.extensions.migration.ERXMigrationDatabase;
+import er.extensions.migration.ERXMigrationTable;
+
+public class ERAttachment2 extends
+                          ERXMigrationDatabase.Migration {
+
+	private static final String ER_ATTACHMENT_TABLE_NAME = "ERAttachment";
+	private static final String CF_PATH_COLUMN_NAME = "cfPath";
+
+
+	@Override
+    public void downgrade(EOEditingContext editingContext,
+                          ERXMigrationDatabase database) throws Throwable {
+		ERXMigrationTable attachmentTable = database.existingTableNamed(ERAttachment2.ER_ATTACHMENT_TABLE_NAME);
+		attachmentTable.existingColumnNamed(CF_PATH_COLUMN_NAME).delete();
+	    
+    }
+
+
+	@Override
+	public void upgrade(EOEditingContext editingContext,
+	                    ERXMigrationDatabase database) throws Throwable {
+		ERXMigrationTable attachmentTable = database.existingTableNamed(ERAttachment2.ER_ATTACHMENT_TABLE_NAME);
+		attachmentTable.newStringColumn(CF_PATH_COLUMN_NAME, 1000, true);
+
+	}
+
+}


### PR DESCRIPTION
Commit 71f46ad6021e7a18cb5372fa20e43553249900b4 modified the ERAttachment0 migration class by adding a new column. **That change breaks any WebObjects Applications already using ERAttachment** because ERAttachment0 will NOT be executed again.

I just moved the change from ERAttachmet0 to a new ERAttachment2 class.
