### PR TITLE
ERXResponseRewriter fix for css loading

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
@@ -166,8 +166,14 @@ var AjaxOnDemand = {
 	},
 	
 	loadCSS: function(css) {
-		new Ajax.Request(css, { method: 'get', asynchronous: false, onComplete: AjaxOnDemand.loadedCSS });
-	},
+        var link=document.createElement("link");
+        link.setAttribute("rel", "stylesheet");
+        link.setAttribute("type", "text/css");
+        link.setAttribute("href", css);
+        if (typeof link!="undefined") {
+            document.getElementsByTagName("head")[0].appendChild(link);
+        }
+    },
 	
 	loadedCSS: function(request) {
 		var inlineStyle = new Element("style", {"type": "text/css"});

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXResponseRewriter.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXResponseRewriter.java
@@ -491,25 +491,21 @@ public class ERXResponseRewriter {
 		else {
 			cssEndTag = "\">";
 		}
-		// MS: It looks like all the browsers can load CSS inline, so we don't
-		// even need all this.
-		// String fallbackStartTag;
-		// String fallbackEndTag;
-		// if (ERXAjaxApplication.isAjaxRequest(context.request())) {
-		// fallbackStartTag = "<script>AOD.loadCSS('";
-		// fallbackEndTag = "')</script>";
-		// }
-		// else {
-		// fallbackStartTag = null;
-		// fallbackEndTag = null;
-		// }
-		// ERXResponseRewriter.addResourceInHead(response, context, framework,
-		// fileName, cssStartTag, cssEndTag, fallbackStartTag, fallbackEndTag,
-		// TagMissingBehavior.SkipAndWarn);
+		String fallbackStartTag = null;
+		String fallbackEndTag = null;
+
+		if (ERXAjaxApplication.isAjaxRequest(context.request()) && ERXProperties.booleanForKeyWithDefault("er.extensions.loadOnDemand", true)) {
+			if (ERXProperties.booleanForKeyWithDefault("er.extensions.loadOnDemandDuringReplace", false)) {
+				boolean appendTypeAttribute = ERXProperties.booleanForKeyWithDefault("er.extensions.ERXResponseRewriter.javascriptTypeAttribute", false);
+				fallbackStartTag = (appendTypeAttribute ? "<script type=\"text/javascript\">AOD.loadCSS('" : "<script>AOD.loadCSS('");
+				fallbackEndTag = "')</script>";
+			}
+		}
+		ERXResponseRewriter.addResourceInHead(response, context, framework, fileName, cssStartTag, cssEndTag, fallbackStartTag, fallbackEndTag, TagMissingBehavior.Inline);
 		
 		// Q: We use TagMissingBehaviour.Inline in case this is called from inside the 
 		// HEAD tag and there is no close tag yet
-		ERXResponseRewriter.addResourceInHead(response, context, framework, fileName, cssStartTag, cssEndTag, null, null, TagMissingBehavior.Inline);
+//		ERXResponseRewriter.addResourceInHead(response, context, framework, fileName, cssStartTag, cssEndTag, null, null, TagMissingBehavior.Inline);
 	}
 
 	/**


### PR DESCRIPTION
Attempt to fix a bug in ERXResponseRewriter : when re-showing a component that was previously hidden, its required css resources are not loaded. 
