### PR TITLE
ERXEnterpriseObjectCache Improvement when Qualifying

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObjectCache.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObjectCache.java
@@ -666,6 +666,7 @@ public class ERXEnterpriseObjectCache<T extends EOEnterpriseObject> {
      * @return all objects currently in the cache and unexpired
      */
     public NSArray<T> allObjects(EOEditingContext ec, EOQualifier additionalQualifier) {
+		additionalQualifier = ERXEOControlUtilities.localInstancesInQualifier(ec, additionalQualifier);
     	ERXExpiringCache<Object, EORecord<T>> cache = cache();
     	NSArray allKeys = cache.allKeys();
     	NSMutableArray allObjects = new NSMutableArray(allKeys.count());


### PR DESCRIPTION
I added a call to <code>ERXEOControlUtilities#localInstancesInQualifier(EOEditingContext, EOQualifier)</code> to fault any EOs that are in the qualifier into the same EC as the cached objects that they are being compared to. 

This change is required because the filtering being done by <code>ERXEnterpriseObjectCache#allObjects(EOEditingContext, EOQualifier)</code> is done in-memory and therefor any potential comparisons of EOs will not be valid unless they are in the same EC.
