### PR TITLE
ERXFetchSpecification fetchRange support

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXFetchSpecification.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXFetchSpecification.java
@@ -15,6 +15,7 @@ import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSPropertyListSerialization;
+import com.webobjects.foundation.NSRange;
 
 import er.extensions.crypting.ERXCrypto;
 import er.extensions.qualifiers.ERXQualifierTraversal;
@@ -40,6 +41,7 @@ public class ERXFetchSpecification<T extends EOEnterpriseObject> extends EOFetch
 
 	private NSMutableDictionary _userInfo;
 	private boolean _includeEditingContextChanges;
+	private NSRange _fetchRange;
 	
 	public ERXFetchSpecification(String entityName, EOQualifier qualifier, NSArray<EOSortOrdering> sortOrderings, boolean usesDistinct, boolean isDeep, NSDictionary hints) {
 		super(entityName, qualifier, sortOrderings, usesDistinct, isDeep, hints);
@@ -57,12 +59,13 @@ public class ERXFetchSpecification<T extends EOEnterpriseObject> extends EOFetch
 		setRawRowKeyPaths(spec.rawRowKeyPaths());
 		setPromptsAfterFetchLimit(spec.promptsAfterFetchLimit());
 		setRefreshesRefetchedObjects(spec.refreshesRefetchedObjects());
-		setPrefetchingRelationshipKeyPaths(spec.prefetchingRelationshipKeyPaths());  
+		setPrefetchingRelationshipKeyPaths(spec.prefetchingRelationshipKeyPaths());
 	}
 
 	public ERXFetchSpecification(ERXFetchSpecification<T> spec) {
 		this((EOFetchSpecification)spec);
 		_userInfo = spec.userInfo().count() > 0 ? null : spec.userInfo().mutableClone();
+		_fetchRange = spec.fetchRange();
 	}
 
 	/**
@@ -121,6 +124,20 @@ public class ERXFetchSpecification<T extends EOEnterpriseObject> extends EOFetch
 	 */
 	public NSDictionary userInfo() {
 		return _userInfo == null ? NSDictionary.EmptyDictionary : _userInfo.immutableClone(); 
+	}
+	
+	public NSRange fetchRange() {
+		return _fetchRange;
+	}
+	
+	/**
+	 * Defines a batch range that should be applied to the SQL statement. Only useful if the database plugin supports it and as an alternative to fetchLimit.
+	 * The SQL generation behavior when both a fetchLimit and a fetchRange are specified is undefined and dependent on the individual database plugin.
+	 * 
+	 * @param range
+	 */
+	public void setFetchRange(NSRange range) {
+		_fetchRange = range;
 	}
 	
 	/**
@@ -188,7 +205,11 @@ public class ERXFetchSpecification<T extends EOEnterpriseObject> extends EOFetch
 	
 	@Override
 	public Object clone() {
-		return fetchSpec((EOFetchSpecification) super.clone());
+		ERXFetchSpecification<T> fs = fetchSpec((EOFetchSpecification) super.clone());
+		fs._fetchRange = _fetchRange;
+		fs._userInfo = _userInfo == null ? null : _userInfo.mutableClone();
+		fs._includeEditingContextChanges = _includeEditingContextChanges;
+		return fs;
 	}
 	
 	/**

--- a/Frameworks/PlugIns/MySQLPlugIn/Sources/com/webobjects/jdbcadaptor/_MySQLPlugIn.java
+++ b/Frameworks/PlugIns/MySQLPlugIn/Sources/com/webobjects/jdbcadaptor/_MySQLPlugIn.java
@@ -3,6 +3,7 @@ package com.webobjects.jdbcadaptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -29,6 +30,8 @@ import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSProperties;
 import com.webobjects.foundation.NSPropertyListSerialization;
+import com.webobjects.foundation.NSRange;
+import com.webobjects.foundation.NSSelector;
 import com.webobjects.foundation._NSStringUtilities;
 
 public class _MySQLPlugIn extends JDBCPlugIn {
@@ -75,6 +78,9 @@ public class _MySQLPlugIn extends JDBCPlugIn {
 
 		private int _fetchLimit;
 		
+		private NSRange _fetchRange;
+		private final NSSelector<NSRange> _fetchRangeSelector = new NSSelector<NSRange>("fetchRange");
+		
 		/**
 		 * Holds array of join clause definitions
 		 */
@@ -107,14 +113,30 @@ public class _MySQLPlugIn extends JDBCPlugIn {
 		}
 
 		/**
-		 * Overriding super here so we can grab a fetch limit if specified in the EOFetchSpecification.
+		 * Overriding super here so we can grab a fetch range or fetch limit if specified in the EOFetchSpecification. If a fetchRange method
+		 * returning an NSRange exists in the EOFetchSpecification subclass being passed in, the the fetchLimit will be ignored.
 		 *
 		 * @see com.webobjects.jdbcadaptor.JDBCExpression#prepareSelectExpressionWithAttributes(NSArray, boolean, EOFetchSpecification)
 		 */
 		@Override
 		public void prepareSelectExpressionWithAttributes(NSArray<EOAttribute> attributes, boolean lock,
 				EOFetchSpecification fetchSpec) {
-			if (!fetchSpec.promptsAfterFetchLimit()) {
+			try {
+				_fetchRange = _fetchRangeSelector.invoke(fetchSpec);
+				// We will get an error when not using our custom ERXFetchSpecification subclass
+				// We could have added ERExtensions to the classpath and checked for instanceof, but I thought
+				// this is a little cleaner since people may be using this PlugIn and not Wonder in some legacy apps.
+			} catch (IllegalArgumentException e) {
+				;
+			} catch (IllegalAccessException e) {
+				;
+			} catch (InvocationTargetException e) {
+				;
+			} catch (NoSuchMethodException e) {
+				;
+			}
+			// Only check for fetchLimit of fetchRange is not provided.
+			if (_fetchRange == null && !fetchSpec.promptsAfterFetchLimit()) {
 				_fetchLimit = fetchSpec.fetchLimit();
 			}
 			super.prepareSelectExpressionWithAttributes(attributes, lock, fetchSpec);
@@ -155,7 +177,11 @@ public class _MySQLPlugIn extends JDBCPlugIn {
 
 			// If necessary, create LIMIT clause and add to buffer size
 			String limitClause = null;
-			if (_fetchLimit > 0) {
+			// fetchRange override fetchLimit
+			if (_fetchRange != null) {
+				limitClause = _fetchRange.location() + ", " + _fetchRange.length();
+				size += CONFIG.LIMIT_LENGTH + limitClause.length();
+			} else if (_fetchLimit > 0) {
 				limitClause = Integer.toString(_fetchLimit);
 				size += CONFIG.LIMIT_LENGTH + limitClause.length();
 			}


### PR DESCRIPTION
Don't actually pull this into integration. The objective of this pull request is to get feedback on whether this is fundamentally something we should even consider doing in public Wonder. Is it something useful?

Setting an NSRange of { 100, 50 } on an ERXFetchSpecification and fetching will generate SQL something like this in MySQL

SELECT ..... LIMIT 100, 50;

.. that is, return the 50 records from record 101 thru 150 in what would otherwise have been a large resultset.

Implementing this in other PlugIns should be pretty easy for databases that support. The intent is not to replace ERXFetchSpecificationBatchIterator but to have another mechanism available to directly batch in SQL if desired.

Comments, opinions, criticism on its usefulness and whether we should include this in Wonder is welcome :-)
## Commit comments:

Adds fetchRange option to ERXFetchSpecification and fetchRange support to _MySQL.Plugin.MySQLExpression.

ERXFetchSpecificationBatchIterator in its current incarnation works fine for batching where a reference to the
batch iterator is maintained. However in direct actions, as used inside current ERXRestFetchSpecification.results(...)
method, a new ERXFetchSpecificationBatchIterator is created on each request resulting in the entire population
of primary keys being fetched and then the batch of EOEnterpriseObjects for the primary key range is fetched.

Having a fetchRange option in ERXFetchSpecification, with support in SQL PlugIns, enables the same range of objects
to be returned in one fetch in a stateless request. This is useful for stateless requests that request a range of
a huge population of objects. This feature may also not have the ERXFetchSpecificationBatchIterator
limitation of not supporting multi-column primary keys. Another advantage is that it has no limit to the total count of
the population of objects form which the range if fetched whereas ERXFetchSpecificationBatchIterator does have a practical
limit associated with ther total number of primary keys that can or should be fetched.

A disadvantage of direct SQL batch fetch is that for some complex qualifiers that return duplicate rows, the DISTINCT property
must be set to true to get accurate results. Having DISTINCT and ORDER BY in the same SQL statement apparently causes
problems in some database platforms such as Oracle that is taken into account by ERXFetchSpecificationBatchIterator
(see ERXSQLHelper.newSQLHelper(entity).shouldPerformDistinctInMemory(pkFetchSpec)) reference in primaryKeys() method
of ERXFetchSpecificationBatchIterator.
