### PR TITLE
AjaxDefaultSubmitButton doesn't work in IE < 9

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDefaultSubmitButton.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDefaultSubmitButton.java
@@ -10,6 +10,7 @@ import com.webobjects.foundation.NSMutableDictionary;
 
 import er.extensions.appserver.ERXBrowser;
 import er.extensions.appserver.ERXBrowserFactory;
+import er.extensions.components._private.ERXWOForm;
 
 /**
  * Invisible form submit button that can be included as the first element in an Ajax submitted form so that hitting
@@ -166,20 +167,30 @@ public class AjaxDefaultSubmitButton extends AjaxSubmitButton
         	appendTagAttributeToResponse(response, "class", valueForBinding("class", component));
         }
         
-        // Force in a default style to hide the button
-        String style;
-        ERXBrowser browser = ERXBrowserFactory.factory().browserMatchingRequest(context.request());
-        boolean useDisplayNone = !(browser.isSafari() && browser.version().compareTo("3.0.3") > 0);
-        if (useDisplayNone) {
-        	style = "position: absolute; left: -10000px; display: none;";
-        } else {
-        	style = "position: absolute; left: -10000px; visibility: hidden;";
-        }
-        appendTagAttributeToResponse(response, "style", style);
+        appendTagAttributeToResponse(response, "style", "position:absolute;left:-10000px");
         appendTagAttributeToResponse(response, "id", valueForBinding("id", component));
         appendTagAttributeToResponse(response, "onclick", onClickBuffer.toString());
 
         response.appendContentString(" />");
-    }
 
+        // fix for IE < 9 that deactivates the standard submit routine of the form and
+        // triggers the onClick handler of this submit element instead if the return key
+        // is pressed within a textfield, radiobutton, checkbox or select
+        ERXBrowser browser = ERXBrowserFactory.factory().browserMatchingRequest(context.request());
+        if (browser.isIE() && browser.majorVersion().compareTo(Integer.valueOf(9)) < 0) {
+            if (!hasBinding("formName")) {
+                formName = ERXWOForm.formName(context, "");
+            }
+            AjaxUtils.appendScriptHeader(response);
+            response.appendContentString("\nEvent.observe(document." + formName + ", 'keypress', function(e){");
+            response.appendContentString("if(e.keyCode==13){"); // return key
+            response.appendContentString("var shouldFire=false;var t=e.target;var tn=t.tagName.toLowerCase();");
+            response.appendContentString("if(tn==='select'){shouldFire=true;}");
+            response.appendContentString("else if(tn==='input'){var ty=t.type.toLowerCase();");
+            response.appendContentString("if(ty==='text' || ty==='radio' || ty==='checkbox'){shouldFire=true;}}");
+            response.appendContentString("if(shouldFire){$$('[name=" + name + "]')[0].fireEvent('onClick');e.returnValue=false;}");
+            response.appendContentString("}});");
+            AjaxUtils.appendScriptFooter(response);
+        }
+    }
 }


### PR DESCRIPTION
This patch steps in only on IE < 9 by observing keydown events within a form. If the return key is pressed within a textfield, radio button, checkbox or select then according to normal behavior of Safari, Chrome, Firefox, IE > 8, … the ajax action of the AjaxDefaultSubmitButton is triggered.

Older IE versions have a bug by triggering the action of the form element instead of the first submit button. That results in a component action instead of an ajax one.
