### PR TITLE
Fixed Apache 2.2 adaptor code that copies the server port header 

### DIFF
--- a/Utilities/Adaptors/Apache2.2/mod_WebObjects.c
+++ b/Utilities/Adaptors/Apache2.2/mod_WebObjects.c
@@ -357,7 +357,7 @@ static void copyHeaders(request_rec *r, HTTPRequest *req) {
 
     port = (char *)WOMALLOC(32);
     if (port) {
-        apr_snprintf(port, sizeof(port), "%u", s->port);
+        apr_snprintf(port, sizeof(port), "%d", ap_get_server_port(r));
         req_addHeader(req, "SERVER_PORT", port, STR_FREEVALUE);
     }
 


### PR DESCRIPTION
Fixed Apache 2.2 adaptor code that copies the server port header into the request that gets passed on to the instance. Original fix was provided by Anjo.

This fix is important because many hardware load balancers provide 'SSL offloading'. In some cases the only way that an application can check that the request was originally SSL is by checking the server_port header to see if it was forwarded to a special port by the load balancer. For example, in my company's environment it goes like this:

SSL request (443)  --> Load-balancer --> Unwraps SSL --> Forwards plain HTTP request to Apache (81)

Project Wonder even provides a 'secure port' system property to be used by the ERXWORequest 'isSecure' method.
