### PR TITLE
Add location header to REST response...

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
@@ -1674,22 +1674,22 @@ public class ERXRouteController extends WODirectAction {
 				boolean completeURLs = context.doesGenerateCompleteURLs();
 				if (!completeURLs) {
 					context.generateCompleteURLs();
-					try {
-						NSMutableDictionary<String, Object> queryDict = new NSMutableDictionary<String, Object>();
-						if (context.hasSession()) {
-							queryDict.takeValueForKey(session().sessionID(), WOApplication.application().sessionIdKey());
-						}
-						boolean isSecure = ERXRequest.isRequestSecure(context.request());
-						Object entityID = IERXRestDelegate.Factory.delegateForEntityNamed(entityName()).primaryKeyForObject(createdObject, restContext());
-						
-						String url = actionUrlForEntity(context(), entityName(), entityID, locationActionName(), format().name(), queryDict, isSecure, true);
-						
-						_setHeaderForActionResults(url, "Location", results);
+				}
+				try {
+					NSMutableDictionary<String, Object> queryDict = new NSMutableDictionary<String, Object>();
+					if (context.hasSession()) {
+						queryDict.takeValueForKey(session().sessionID(), WOApplication.application().sessionIdKey());
 					}
-					finally {
-						if (!completeURLs) {
-							context.generateRelativeURLs();
-						}
+					boolean isSecure = ERXRequest.isRequestSecure(context.request());
+					Object entityID = IERXRestDelegate.Factory.delegateForEntityNamed(entityName()).primaryKeyForObject(createdObject, restContext());
+					
+					String url = actionUrlForEntity(context(), entityName(), entityID, locationActionName(), format().name(), queryDict, isSecure, true);
+					
+					_setHeaderForActionResults(url, "Location", results);
+				}
+				finally {
+					if (!completeURLs) {
+						context.generateRelativeURLs();
 					}
 				}
 			}


### PR DESCRIPTION
...after creating a new object.

This fixes https://github.com/projectwonder/wonder/issues/216

When using any ERXRouteController.create(…) method or calling ERXRouteController.registerCreatedObject(…) the REST response will get a location header pointing to the URL to show the newly created object. As default the showAction will be used for that unless another action name was set via setLocationActionName.
