### PR TITLE
Flatten valueForKeyPath result if QualifierOperatorContains selector for in-memory evaluateObject

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXKeyValueQualifier.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXKeyValueQualifier.java
@@ -2,11 +2,18 @@ package er.extensions.qualifiers;
 
 import com.webobjects.eocontrol.EOKeyValueQualifier;
 import com.webobjects.eocontrol.EOQualifier;
+import com.webobjects.eocontrol.EOQualifierVariable;
+import com.webobjects.eocontrol.EOQualifier.ComparisonSupport;
 import com.webobjects.foundation.NSArray;
+import com.webobjects.foundation.NSKeyValueCoding;
+import com.webobjects.foundation.NSKeyValueCodingAdditions;
 import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSSelector;
+import com.webobjects.foundation._NSStringUtilities;
 
 import er.extensions.eof.ERXQ;
+import er.extensions.foundation.ERXArrayUtilities;
+import er.extensions.foundation.ERXProperties;
 
 /**
  * ERXKeyValueQualifier is a chainable extension of EOKeyValueQualifier.
@@ -20,6 +27,11 @@ public class ERXKeyValueQualifier extends EOKeyValueQualifier implements IERXCha
 	 * <a href="http://java.sun.com/j2se/1.4/pdf/serial-spec.pdf">Java Object Serialization Spec</a>
 	 */
 	private static final long serialVersionUID = 1L;
+	
+	// Lazy static initialization
+	private static class PROPERTIES {
+		static boolean shouldFlattenValueObject = ERXProperties.booleanForKeyWithDefault("er.extensions.ERXKeyValueQualifier.Contains.flatten", true);
+	}
 
 	public ERXKeyValueQualifier(String key, NSSelector selector, Object value) {
 		super(key, selector, value);
@@ -61,5 +73,33 @@ public class ERXKeyValueQualifier extends EOKeyValueQualifier implements IERXCha
 
 	public <T> T requiredOne(NSArray<T> array) {
 		return ERXQ.requiredOne(array, this);
+	}
+	
+	/**
+	 * Overridden to handle case of in-memory evaluation of QualifierOperatorContains selector and a keyPath that has multiple toMany and/or manyToMany-flattened relationships resulting in arrays of arrays rather than
+	 * an array of discrete objects. In that case the object is evaluated against a flattened array which gives the same result as SQL evaluation.
+	 * 
+	 * Since legacy code may depend on workarounds to the incorrect behavior, this patch can be disabled by setting the property <code>er.extensions.ERXKeyValueQualifier.Contains.flatten</code> to <code>false</code>
+	 */
+	@Override
+	public boolean evaluateWithObject(Object object) {
+		Object objectValue = NSKeyValueCodingAdditions.Utility.valueForKeyPath(object, _key);
+
+		if (_value instanceof EOQualifierVariable) {
+			throw new IllegalStateException("Error evaluating qualifier with key " + _key + ", selector " + _selector + ", value " + _value + " - value must be substitued for variable before evaluating");
+		}
+
+		if (_selector.equals(EOQualifier.QualifierOperatorCaseInsensitiveLike)) {
+			if (_lowercaseCache == null) {
+				_lowercaseCache = (_value != NSKeyValueCoding.NullValue) ? (_value.toString()).toLowerCase() : "";
+			}
+			return _NSStringUtilities.stringMatchesPattern(((objectValue != null) && (objectValue != NSKeyValueCoding.NullValue)) ? objectValue.toString() : "", _lowercaseCache, true);
+		}
+		
+		// Flatten in case we have array of arrays
+		if (_selector.equals(EOQualifier.QualifierOperatorContains) && PROPERTIES.shouldFlattenValueObject && objectValue != null && objectValue instanceof NSArray) {
+			objectValue = ERXArrayUtilities.flatten((NSArray<?>) objectValue);
+		}
+		return ComparisonSupport.compareValues((objectValue != null) ? objectValue : NSKeyValueCoding.NullValue, _value, _selector);
 	}
 }


### PR DESCRIPTION
Ensure in-memory evaluation of QualifierOperatorContains selector has the same result as generated SQL fetch.

When using EOQualifier.QualifierOperatorContains selector with a keyPath that has multiple manyToMany and/or toMany keys
the in-Memory evaluation will incorrectly return false in the cases where the result of the keyPath is nested arrays rather
than a flattened array that represents the effective SQL evaluation for the same qualifier. Thus in-Memory evaluation does
not match the behavior of SQL evaluation in this scenario.

This fix flattens the array object resulting from the valueForKeyPath so that the qualifier will correctly evaluate to true
when checking if the flattened array contains the object being evaluated.

This commit changes the current (incorrect) default behavior, however, just in case someone was working around that default behavior and wants to keep the old behavior, a boolean property `er.extensions.ERXKeyValueQualifier.Contains.flatten` can be added to Properties and set to false to revert to old behavior.
