### PR TITLE
ERXRouteController: compile errors with javac1.7

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
@@ -230,6 +230,10 @@ public class ERXRouteController extends WODirectAction {
 	protected void checkAccess() throws SecurityException {
 	}
 
+	public void _setEditingContent(EOEditingContext ec) {
+		_editingContext = ec;
+	}
+
 	/**
 	 * The controller maintains an editing context for the duration of the request. The first time you call this method,
 	 * you will get a new EOEditingContext. Subsequent calls will return the same instance. This makes it a little more
@@ -1800,11 +1804,11 @@ public class ERXRouteController extends WODirectAction {
 	public <T extends ERXRouteController> T controller(Class<T> controllerClass) {
 		try {
 			T controller = requestHandler().controller(controllerClass, request(), context());
-			controller._route = _route;
-			controller._editingContext = _editingContext;
-			controller._routeKeys = _routeKeys;
-			controller._objects = _objects;
-			controller._options = _options;
+			controller._setRoute(_route);
+			controller._setEditingContent(_editingContext);
+			controller._setRouteKeys(_routeKeys);
+			controller._setRouteObjects(_objects);
+			controller.setOptions(_options);
 			return controller;
 		}
 		catch (Exception e) {


### PR DESCRIPTION
From Eclipse Problems view:
The field ERXRouteController._options is not visible ERXRouteController.java /ERRest/Sources/er/rest/routes line 1807 Java Problem
The field ERXRouteController._routeKeys is not visible ERXRouteController.java /ERRest/Sources/er/rest/routes line 1805 Java Problem
The field ERXRouteController._objects is not visible ERXRouteController.java /ERRest/Sources/er/rest/routes line 1806 Java Problem
The field ERXRouteController._editingContext is not visible ERXRouteController.java /ERRest/Sources/er/rest/routes line 1804 Java Problem
The field ERXRouteController._route is not visible ERXRouteController.java /ERRest/Sources/er/rest/routes line 1803 Java Problem

Messages with ant on command line similar. Explanations to this javac6 bug:
http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6711619
http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7022052
