### PR TITLE
Generics <T extends EOEnterpriseObjects>

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObject.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObject.java
@@ -406,8 +406,8 @@ public interface ERXEnterpriseObject extends EOEnterpriseObject {
      * @param objects objects to add to both sides of the given relationship
      * @param key relationship key
      */
-    public abstract void addObjectsToBothSidesOfRelationshipWithKey(
-            NSArray<EOEnterpriseObject> objects, String key);
+    public abstract <T extends EOEnterpriseObject> void addObjectsToBothSidesOfRelationshipWithKey(
+            NSArray<T> objects, String key);
 
     /**
      * Removes a collection of objects to a given relationship by calling
@@ -416,8 +416,8 @@ public interface ERXEnterpriseObject extends EOEnterpriseObject {
      * @param objects objects to be removed from both sides of the given relationship
      * @param key relationship key
      */
-    public abstract void removeObjectsFromBothSidesOfRelationshipWithKey(
-            NSArray<EOEnterpriseObject> objects, String key);
+    public abstract <T extends EOEnterpriseObject> void removeObjectsFromBothSidesOfRelationshipWithKey(
+            NSArray<T> objects, String key);
 
     /**
      * Removes a collection of objects to a given relationship by calling
@@ -426,7 +426,7 @@ public interface ERXEnterpriseObject extends EOEnterpriseObject {
      * @param objects objects to be removed from both sides of the given relationship
      * @param key relationship key
      */
-    public abstract void removeObjectsFromPropertyWithKey(NSArray<EOEnterpriseObject> objects,
+    public abstract <T extends EOEnterpriseObject> void removeObjectsFromPropertyWithKey(NSArray<T> objects,
             String key);
 
     /**
@@ -519,7 +519,7 @@ public interface ERXEnterpriseObject extends EOEnterpriseObject {
      * @param eos array of EOs to local instance
      * @return array of EOs in the same editing context as the caller.
      */
-    public abstract NSArray<EOEnterpriseObject> localInstancesOf(NSArray<EOEnterpriseObject> eos);
+    public abstract <T extends EOEnterpriseObject> NSArray<T> localInstancesOf(NSArray<T> eos);
 
     /**
      * Computes the current set of changes that this object has from the

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -416,27 +416,27 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 		flushCaches();
 	}
 
-	public void addObjectsToBothSidesOfRelationshipWithKey(NSArray<EOEnterpriseObject> objects, String key) {
+	public <T extends EOEnterpriseObject> void addObjectsToBothSidesOfRelationshipWithKey(NSArray<T> objects, String key) {
 		if (objects != null && objects.count() > 0) {
-			NSArray<EOEnterpriseObject> objectsSafe = objects instanceof NSMutableArray ? objects.immutableClone() : objects;
+			NSArray<T> objectsSafe = objects instanceof NSMutableArray ? objects.immutableClone() : objects;
 			for (EOEnterpriseObject eo : objectsSafe) {
 				addObjectToBothSidesOfRelationshipWithKey(eo, key);
 			}
 		}
 	}
 
-	public void removeObjectsFromBothSidesOfRelationshipWithKey(NSArray<EOEnterpriseObject> objects, String key) {
+	public <T extends EOEnterpriseObject> void removeObjectsFromBothSidesOfRelationshipWithKey(NSArray<T> objects, String key) {
 		if (objects != null && objects.count() > 0) {
-			NSArray<EOEnterpriseObject> objectsSafe = objects instanceof NSMutableArray ? objects.immutableClone() : objects;
+			NSArray<T> objectsSafe = objects instanceof NSMutableArray ? objects.immutableClone() : objects;
 			for (EOEnterpriseObject eo : objectsSafe) {
 				removeObjectFromBothSidesOfRelationshipWithKey(eo, key);
 			}
 		}
 	}
 
-	public void removeObjectsFromPropertyWithKey(NSArray<EOEnterpriseObject> objects, String key) {
+	public <T extends EOEnterpriseObject> void removeObjectsFromPropertyWithKey(NSArray<T> objects, String key) {
 		if (objects != null && objects.count() > 0) {
-			NSArray<EOEnterpriseObject> objectsSafe = objects instanceof NSMutableArray ? objects.immutableClone() : objects;
+			NSArray<T> objectsSafe = objects instanceof NSMutableArray ? objects.immutableClone() : objects;
 			for (EOEnterpriseObject eo : objectsSafe) {
 				removeObjectFromPropertyWithKey(eo, key);
 			}
@@ -814,7 +814,7 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 		return ERXEOControlUtilities.localInstanceOfObject(ec, this);
 	}
 
-	public NSArray<EOEnterpriseObject> localInstancesOf(NSArray<EOEnterpriseObject> eos) {
+	public <T extends EOEnterpriseObject> NSArray<T> localInstancesOf(NSArray<T> eos) {
 		return ERXEOControlUtilities.localInstancesOfObjects(editingContext(), eos);
 	}
 


### PR DESCRIPTION
changed generics of NSArray in ERXGenericRecord|ERXEnterpriseObject.add/removeObjectsFromBothSidesOfRelationship/PropertyWithKey to <T extends EOEnterpriseObjects>, so you could use your arrays of subclassed EOEnterpriseObjects in these methods.
