### PR TITLE
add encoding utf8 param to wocompile definition

### DIFF
--- a/Build/build/generic.xml
+++ b/Build/build/generic.xml
@@ -267,7 +267,7 @@ There are many ways to use this script:
          
        <antcall target="${before.compile}" />
 
-       <wocompile srcdir="${project.sources.dir}" destdir="${build.classes}" debug="on" optimize="off" deprecation="off" source="${compiler.source}" target="${compiler.target}" includeantruntime="false" >
+       <wocompile srcdir="${project.sources.dir}" destdir="${build.classes}" debug="on" optimize="off" deprecation="off" source="${compiler.source}" target="${compiler.target}" includeantruntime="false" encoding="utf-8">
            <!-- compilerarg value="-Xlint:unchecked" -->
            <exclude name="**/Tests/**" /> <!-- perhaps not necessary, but will not hurt. -rrk -->
            <exclude name="${classes.exclude.0}" />


### PR DESCRIPTION
One of the problems that occurs especially when trying to compile Wonder with JDK 7 is that implied ASCII encodings don't work with japanese Javadoc and stuff.

(Why there has to be japanese javadoc at all that nobody except one can update to match code changes is another question.)

So, assuming that all sources is UTF-8 anyway, this adds the parameter to the ant wocompile job definition that makes it explicit and fixes the problem.
