### PR TITLE
Tidies up Javadocs and some whitespace. #296

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartial.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartial.java
@@ -1,8 +1,6 @@
-/**
- * 
- */
 package er.extensions.partials;
 
+import com.webobjects.eoaccess.EOEntity;
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
 import com.webobjects.eocontrol.EORelationshipManipulation;
@@ -14,52 +12,71 @@ import er.extensions.eof.ERXGenericRecord;
 
 /**
  * <p>
- * For overview information on partials, read the package.html in er.extensions.partials.
+ * For overview information on partials, read the {@code package.html} in
+ * {@code er.extensions.partials}.
  * </p>
  * 
  * <p>
- * ERXPartial is the superclass of all partial entity implementations.  ERXPartial is not
- * itself an EO, but is acts as a partial typesafe wrapper around an existing base EO (which must
- * extend ERXPartialGenericRecord).  For instance, the base entity might be Person, but the partial 
- * may be CalendarPerson which might have expose like calendarPerson.scheduledEvents().
+ * {@code ERXPartial} is the superclass of all partial entity implementations.
+ * {@code ERXPartial} is not itself an EO, but is acts as a partial typesafe
+ * wrapper around an existing base EO (which must extend
+ * {@link ERXPartialGenericRecord}). For instance, the base entity might be
+ * {@code Person}, but the partial may be {@code CalendarPerson} which might
+ * expose methods like {@code calendarPerson.scheduledEvents()}.
  * </p>
  * 
  * <p>
- * To obtain a partial, you request an instance from a base EO.  Take the Person example from above.  You
- * can access the interface of the CalendarPerson partial in two ways:
- * </p>
+ * To obtain a partial, you request an instance from a base EO. Take the
+ * {@code Person} example from above. You can access the interface of the
+ * {@code CalendarPerson} partial in two ways:
  * 
- * <code>
- * Person person = ...;
- * CalendarPerson calendarPerson = person.partialForClass(CalendarPerson.class);
- * </code>
+ * <pre>
+ * <code>Person person = ...;
+ * CalendarPerson calendarPerson = person.partialForClass(CalendarPerson.class);</code>
+ * </pre>
  * 
  * or
  * 
- * <code>
- * Person person = ...;
- * CalendarPerson calendarPerson = person.valueForKey("@CalendarPerson");
- * </code>
+ * <pre>
+ * <code>Person person = ...;
+ * CalendarPerson calendarPerson = person.valueForKey("@CalendarPerson");</code>
+ * </pre>
  * 
- * which allows easy use of the partial entities in component bindings, like "person.@CalendarPerson.scheduledEvents".
+ * which allows easy use of the partial entities in component bindings, like
+ * {@code person.@CalendarPerson.scheduledEvents}.
+ * </p>
  * 
  * @author mschrag
- *
- * @param <T> the EO class that this is a partial of
+ * @param <T>
+ *            the EO class that this is a partial of
  */
 public class ERXPartial<T extends ERXGenericRecord> {
+	/**
+	 * This partial's primary EO
+	 */
 	private T _primaryEO;
-	
+
+	/**
+	 * Sets this partial's primary EO.
+	 *
+	 * @param primaryEO the primary EO
+	 */
 	public void setPrimaryEO(T primaryEO) {
 		_primaryEO = primaryEO;
 	}
-	
+
+	/**
+	 * Returns this partial's primary EO.
+	 *
+	 * @return primary EO
+	 */
 	public T primaryEO() {
 		return _primaryEO;
 	}
 	
 	/**
-	 * When partial entities are initialized the EOEntity is removed from the model making it impossible to query attributs and relationships later.
+	 * When partial entities are initialized the {@link EOEntity} is removed from the
+	 * model, making it impossible to query attributes and relationships later.
 	 * 
 	 * @return array of String keys for the partial entity attributes
 	 */
@@ -68,7 +85,8 @@ public class ERXPartial<T extends ERXGenericRecord> {
 	}
 
 	/**
-	 * When partial entities are initialized the EOEntity is removed from the model making it impossible to query attributs and relationships later.
+	 * When partial entities are initialized the {@link EOEntity} is removed from the
+	 * model making it impossible to query attributes and relationships later.
 	 * 
 	 * @return array of String keys for the partial entity relationships
 	 */
@@ -77,22 +95,28 @@ public class ERXPartial<T extends ERXGenericRecord> {
 	}
 
 	/**
-	 * When partial entities are initialized the EOEntity is removed from the model making it impossible to query attributs and relationships later.
+	 * When partial entities are initialized the {@link EOEntity} is removed
+	 * from the model making it impossible to query attributes and relationships
+	 * later.
 	 * 
-	 * @return array of String keys for the partial entity attributes and relationships
+	 * @return array of String keys for the partial entity attributes and
+	 *         relationships
 	 */
 	public static NSArray<String> partialProperties() {
 		return partialAttributes().arrayByAddingObjectsFromArray(partialRelationships());
 	}
 
 	/**
-	 * Tests the given keypath to see if it is a valid attribute or relationship for this partial
-	 * 
-	 * @return true if the keypath matches an attribute or relationship
+	 * Tests the given keypath to see if it is a valid attribute or relationship
+	 * for this partial.
+	 *
+	 * @param keypath a keypath
+	 * @return {@code true} if {@code keypath} matches an attribute or
+	 *         relationship
 	 */
 	public boolean isPartialKeypath(String keypath) {
 		for (String key : partialProperties()) {
-			if ( key.equals(keypath) == true ) {
+			if (key.equals(keypath) == true) {
 				return true;
 			}
 		}
@@ -100,68 +124,103 @@ public class ERXPartial<T extends ERXGenericRecord> {
 	}
 
 	/**
-	 * Returns primaryEO.editingContext.
+	 * Returns the primary EO's {@link EOEditingContext}.
 	 * 
-	 * @return primaryEO.editingContext
+	 * @return primary EO's {@link EOEditingContext}
 	 */
 	public EOEditingContext editingContext() {
 		return _primaryEO.editingContext();
 	}
 	
 	/**
-	 * Returns primaryEO.storedValueForKey.
+	 * Returns {@code _primaryEO.storedValueForKey(key)}.
 	 * 
-	 * @return primaryEO.storedValueForKey
+	 * @param key
+	 *            a key
+	 * @return {@code _primaryEO.storedValueForKey(key)}
 	 */
     public Object storedValueForKey(String key) {
     	return _primaryEO.storedValueForKey(key);
     }
 
 	/**
-	 * Calls primaryEO.takeStoredValueForKey.
+	 * Calls {@code _primaryEO.takeStoredValueForKey(value, key)}.
+	 * 
+	 * @param value
+	 *            a value
+	 * @param key
+	 *            a key
 	 */
     public void takeStoredValueForKey(Object value, String key) {
     	_primaryEO.takeStoredValueForKey(value, key);
     }
 
 	/**
-	 * Calls primaryEO.includeObjectIntoPropertyWithKey.
+	 * Calls {@code _primaryEO.includeObjectIntoPropertyWithKey(value, key)}.
+	 * 
+	 * @param value
+	 *            a value
+	 * @param key
+	 *            a key
 	 */
-    public void includeObjectIntoPropertyWithKey(Object value, String key) {
-    	_primaryEO.includeObjectIntoPropertyWithKey(value, key);
-    }
+	public void includeObjectIntoPropertyWithKey(Object value, String key) {
+		_primaryEO.includeObjectIntoPropertyWithKey(value, key);
+	}
     
 	/**
-	 * Calls primaryEO.excludeObjectFromPropertyWithKey.
+	 * Calls {@code _primaryEO.excludeObjectFromPropertyWithKey(value, key)}.
+	 * 
+	 * @param value
+	 *            a value
+	 * @param key
+	 *            a key
 	 */
-    public void excludeObjectFromPropertyWithKey(Object value, String key) {
-    	_primaryEO.excludeObjectFromPropertyWithKey(value, key);
-    }
+	public void excludeObjectFromPropertyWithKey(Object value, String key) {
+		_primaryEO.excludeObjectFromPropertyWithKey(value, key);
+	}
     
 	/**
-	 * Calls primaryEO.addObjectToBothSidesOfRelationshipWithKey.
+	 * Calls
+	 * {@code _primaryEO.addObjectToBothSidesOfRelationshipWithKey(eo, key)}.
+	 * 
+	 * @param eo
+	 *            an {@link EORelationshipManipulation}
+	 * @param key
+	 *            a key
 	 */
-    public void addObjectToBothSidesOfRelationshipWithKey(EORelationshipManipulation eo, String key) {
-    	_primaryEO.addObjectToBothSidesOfRelationshipWithKey(eo, key);
-    }
+	public void addObjectToBothSidesOfRelationshipWithKey(EORelationshipManipulation eo, String key) {
+		_primaryEO.addObjectToBothSidesOfRelationshipWithKey(eo, key);
+	}
 
 	/**
-	 * Calls primaryEO.removeObjectFromBothSidesOfRelationshipWithKey.
+	 * Calls
+	 * {@code _primaryEO.removeObjectFromBothSidesOfRelationshipWithKey(eo, key)}.
+	 * 
+	 * @param eo
+	 *            an {@link EORelationshipManipulation}
+	 * @param key
+	 *            a key
 	 */
-    public void removeObjectFromBothSidesOfRelationshipWithKey(EORelationshipManipulation eo, String key) {
-    	_primaryEO.removeObjectFromBothSidesOfRelationshipWithKey(eo, key);
-    }
+	public void removeObjectFromBothSidesOfRelationshipWithKey(EORelationshipManipulation eo, String key) {
+		_primaryEO.removeObjectFromBothSidesOfRelationshipWithKey(eo, key);
+	}
     
-    /**
-     * Delegated from the base entity.
-     */
+	/**
+	 * Delegated from the base entity.
+	 * 
+	 * @param editingContext
+	 *            this object's {@link EOEditingContext}
+	 */
     public void awakeFromInsertion(EOEditingContext editingContext) {
     	// DO NOTHING
     }
     
-    /**
-     * Delegated from the base entity.
-     */
+	/**
+	 * Delegated from the base entity.
+	 * 
+	 * @param editingContext
+	 *            this object's {@link EOEditingContext}
+	 */
     public void awakeFromFetch(EOEditingContext editingContext) {
     	// DO NOTHING
     }
@@ -180,16 +239,22 @@ public class ERXPartial<T extends ERXGenericRecord> {
     	// DO NOTHING
     }
 
-    /**
-     * Delegated from the base entity.
-     */
+	/**
+	 * Delegated from the base entity.
+	 * 
+	 * @throws NSValidation.ValidationException
+	 *             in the case of a validation failure
+	 */
     public void willDelete() throws NSValidation.ValidationException {
     	// DO NOTHING
     }
     
-    /**
-     * Delegated from the base entity.
-     */
+	/**
+	 * Delegated from the base entity.
+	 * 
+	 * @param ec
+	 *            this object's {@link EOEditingContext}
+	 */
     public void didDelete(EOEditingContext ec) {
     	// DO NOTHING
     }
@@ -231,6 +296,9 @@ public class ERXPartial<T extends ERXGenericRecord> {
 
     /**
      * Delegated from the base entity.
+	 * 
+	 * @param ec
+	 *            this object's {@link EOEditingContext}
      */
     public void didRevert(EOEditingContext ec) {
     	// DO NOTHING
@@ -238,13 +306,19 @@ public class ERXPartial<T extends ERXGenericRecord> {
 
     /**
      * Delegated from the base entity.
+	 * 
+	 * @throws NSValidation.ValidationException
+	 *             in the case of a validation failure
      */
-    public void validateForSave() throws NSValidation.ValidationException {
-    	// DO NOTHING
-    }
+	public void validateForSave() throws NSValidation.ValidationException {
+		// DO NOTHING
+	}
 
     /**
      * Delegated from the base entity.
+	 * 
+	 * @throws NSValidation.ValidationException
+	 *             in the case of a validation failure
      */
     public void validateForInsert() throws NSValidation.ValidationException {
     	// DO NOTHING
@@ -252,27 +326,46 @@ public class ERXPartial<T extends ERXGenericRecord> {
     
     /**
      * Delegated from the base entity.
+	 * 
+	 * @throws NSValidation.ValidationException
+	 *             in the case of a validation failure
      */
     public void validateForUpdate() throws NSValidation.ValidationException {
     	// DO NOTHING
     }
 
-    /**
-     * Delegated from the base entity.
-     */
-    public Object validateTakeValueForKeyPath(Object value, String keyPath) throws ValidationException {
-    	return com.webobjects.foundation.NSValidation.DefaultImplementation.validateTakeValueForKeyPath(this, value, keyPath);
-    }
+	/**
+	 * Delegated from the base entity.
+	 * 
+	 * @param value
+	 *            a value
+	 * @param keyPath
+	 *            a keypath
+	 * @return the destination object
+	 * @throws ValidationException
+	 *             in the case of a validation failure
+	 */
+	public Object validateTakeValueForKeyPath(Object value, String keyPath) throws ValidationException {
+		return com.webobjects.foundation.NSValidation.DefaultImplementation.validateTakeValueForKeyPath(this, value, keyPath);
+	}
     
-    /**
-     * Delegated from the base entity.
-     */
-    public Object validateValueForKey(Object value, String key) throws NSValidation.ValidationException {
-    	try {
-    		return com.webobjects.foundation.NSValidation.DefaultImplementation._validateValueForKey(this, value, key, EOEnterpriseObject._CLASS);
-    	}
-    	catch (com.webobjects.foundation.NSValidation.ValidationException exception) {
-    		throw exception.exceptionWithObjectAndKey(this, key);
-    	}
-    }
+	/**
+	 * Delegated from the base entity.
+	 * 
+	 * @param value
+	 *            a value
+	 * @param key
+	 *            a key
+	 * @return the destination object
+	 * @throws NSValidation.ValidationException
+	 *             in the case of a validation failure
+	 */
+	public Object validateValueForKey(Object value, String key) throws NSValidation.ValidationException {
+		try {
+			return com.webobjects.foundation.NSValidation.DefaultImplementation._validateValueForKey(this, value, key, EOEnterpriseObject._CLASS);
+		}
+		catch (com.webobjects.foundation.NSValidation.ValidationException exception) {
+			throw exception.exceptionWithObjectAndKey(this, key);
+		}
+	}
 }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialGenericRecord.java
@@ -14,14 +14,15 @@ import er.extensions.eof.ERXGenericRecord;
 
 /**
  * <p>
- * For overview information on partials, read the package.html in er.extensions.partials.
+ * For overview information on partials, read the {@code package.html} in
+ * {@code er.extensions.partials}.
  * </p>
  * 
  * <p>
- * ERXPartialGenericRecord is the base class of any entity that allows itself to be extended
- * with partials.
+ * {@code ERXPartialGenericRecord} is the base class of any entity that allows
+ * itself to be extended with partials.
  * </p>
- *  
+ * 
  * @author mschrag
  */
 public class ERXPartialGenericRecord extends ERXGenericRecord {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialInitializer.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialInitializer.java
@@ -23,11 +23,17 @@ import er.extensions.eof.ERXModelGroup;
 import er.extensions.foundation.ERXProperties;
 
 /**
- * ERXPartialInitializer is registered at startup and is responsible for merging
- * partial entities together into a single entity.
+ * <p>
+ * For overview information on partials, read the {@code package.html} in
+ * {@code er.extensions.partials}.
+ * </p>
+ * 
+ * <p>
+ * {@code ERXPartialInitializer} is registered at startup and is responsible for
+ * merging partial entities together into a single entity.
+ * </p>
  * 
  * @property er.extensions.partials.enabled
- *
  * @author mschrag
  */
 public class ERXPartialInitializer {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/package.html
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/package.html
@@ -1,155 +1,224 @@
 <html>
-<body>
-<h1>Partial Entities</h1>
+	<body>
+		<h1>Partial Entities</h1>
 
-<h1>* PARTIAL ENTITIES SHOULD BE CONSIDERED EXPERIMENTAL *</h1>
+		<h2>Latest</h2>
+		<p>
+		A review of the features of the <code>ERXPartial</code>
+		implementation has been partly funded by <a
+		href="http://logicsquad.net/">Logic Squad</a>.  The review documents
+		and an example/test application are available in
+		<code>Examples/ERXPartials</code> directory.  While not everything
+		discussed in the review document has been completed, the example
+		application is designed to provide a starting point for validating
+		the features and functions of this package.
+		</p>
+		<p>
+		-- David Aspinall, Global Village Consulting<br>
+		Sept 19, 2012
+		</p>
 
-<h2>Update Sept 19, 2012</h2>
-<p>
-A review of the features of the <code>ERXPartial</code> implementation has been partly funded by <a href="http://logicsquad.net/">Logic Squad</a>.  The review documents and an Example / Test application are available in <code>wonder/Examples/ERXPartials</code> directory.  While not everything discussed in the review document has been completed, the example application is designed to provide a starting point for validating the features and functions of this package.
-</p>
-<p>-- David Aspinall, Global Village Consulting </p>
+		<h2>Overview</h2>
+		<p>
+		Partial Entities provide a mechanism for defining a single entity
+		whose definition spans across multiple EOModels along with tools to
+		interact with these partial definitions in a type-safe way.
+		</p>
+		<p>
+		Partial entities are specifically designed to allow reuse and
+		extension of existing models.  A very common case where this becomes
+		useful is that of a <code>Person</code> entity.  <code>Person</code>
+		is an entity that is used in many different scenarios, each of which
+		requires additional attributes and relationships.  For instance, you
+		may have a task management application and you want to embed your
+		calendaring framework into it.  The common <code>Person</code> base
+		entity may have <code>username</code> and </code>password</code>
+		attributes, the tasking application may add an
+		<code>activeTasks</code> relationship, and the calendaring framework
+		may add a <code>scheduledEvents</code> relationship as well as
+		<code>dayStartTime</code> and <code>dayEndTime</code> attributes. 
+		Note that partials are not designed to address the issue of "roles,"
+		where different people in the system may have different roles at
+		different times.  Partial entities are designed to address the issue
+		of combining high level modules together to form more complex static
+		entity declarations.
+		</p>
+		<p>
+		Traditionally, this presents some complicated problems.  How do you
+		add these relationships onto your <code>Person</code> entity? 
+		Additionally, these different views of a <code>Person</code>
+		technically represent the same underlying object, and ideally we
+		want to be able to fetch these views without having to always
+		traverse additional relationships for every view type.  For
+		instance, if <code>CalendarPerson</code> is a "role" of
+		<code>Person</code> and stored as a separate entity (table) in the
+		database, it would require traversing a relationship every time you
+		need to reference calendar-specific attributes of a
+		<code>Person</code>, which can be a serious performance issue if you
+		need to show <code>CalendarPerson</code> attributes of multiple
+		<code>Person</code> objects at time.  Prefetching can alleviate some
+		of this overhead, but semantically speaking, <code>Person</code>,
+		<code>CalendarPerson</code>, and <code>TaskPerson</code>
+		<em>are</em> the same entity, just as seen from different parts of
+		your system. <code>EOGenericRecord</code> allows a certain amount of
+		flexibility, but in exchange for a loss of type-safety.  Java's type
+		system does not allow mixins like Ruby, which means that you cannot
+		just "inject" the get/set methods into the <code>Person</code> class
+		and actually be able to get compile-type checking on these methods.
+		</p>
 
-<h2>Overview</h2>
-<p>
-Partial Entities provide a mechanism for defining a single entity whose definition spans across multiple EOModels 
-along with tools to interact with these partial definitions in a type-safe way.
-</p>
-<p>
-Partial entities are specifically designed to allow reuse and extension of existing models.  A very common case 
-where this becomes useful is that of a Person entity.  Person is an entity that is used in many different 
-scenarios, each of which requires additional attributes and relationships.  For instance, you may have a 
-task management application and you want to embed your calendaring framework into it.  The common 
-Person base entity may have "username" and "password" attributes, the tasking application may add an 
-"activeTasks" relationship, and the calendaring framework may add a "scheduledEvents" relationship as well
-as "dayStartTime" and "dayEndTime" attributes.  Note that partials are not designed to address the issue of
-"roles," where different people in the system may have different roles at different times.  Partial entities
-are designed to address the issue of combining high level modules together to form more complex static 
-entity declarations.
-</p>
-<p>
-Traditionally, this presents some complicated problems.  How do you add these relationships onto your
-Person entity?  Additionally, these different views of a Person technically represent the same underlying
-object, and ideally we want to be able to fetch these views without having to always traverse additional
-relationships for every view type.  For instance, if CalendarPerson is a "role" of Person and stored
-as a separate entity (table) in the database, it would require traversing a relationship every time you
-need to reference calendar-specific attributes of a Person, which can be a serious performance issue if 
-you need to show CalendarPerson attributes of multiple Person objects at time.  Prefetching can alleviate
-some of this overhead, but semantically speaking, Person, CalendarPerson, and TaskPerson ARE the same
-entity, just as seen from different parts of your system. EOGenericRecord allows a certain amount of 
-flexibility, but in exchange for a loss of type-safety.  Java's type system does not allow mixins like Ruby, 
-which means that you cannot just "inject" the get/set methods into the Person class and actually be able to 
-get compile-type checking on these methods.
-</p>
+		<h2>Design</h2>
+		<p>
+		Enter Partial Entities.  With partial entities, you can declare a
+		base <code>Person</code> entity, a <code>TaskPerson</code> partial
+		entity that adds the <code>activeTasks</code> relationship, and a
+		<code>CalendarPerson</code> partial entity that adds the
+		<code>scheduledEvents</code> relationship and the
+		<code>dayStartTime</code> and <code>dayEndTime</code> attributes. 
+		At runtime, the base and partial entities are merged together such
+		that the entity named <code>Person</code> is the union of all of the
+		attributes and relationships of all of its partials. In fact, the
+		"partial entities" are not entities at all, but rather exist only as
+		special cover classes that are generated by VelocityEOGenerator to
+		allow compile-time type checking and get/set method access.  The
+		ability of partials to merge into a single entity means that the
+		underlying representation in the database is such that a single row
+		represents the union of all of the attributes of <code>Person</code>
+		+ <code>CalendarPerson</code> + <code>TaskPerson</code>.  The makes
+		for fairly optimal fetching behavior.
+		</p>
+		<p>
+		The design of the Java side of partial entities is inspired by the
+		concept of an <code>IAdaptable</code> in Eclipse.  Eclipse has
+		similar problem design constraints in that it provides extension
+		mechanisms for many types of classes in the system.  Because Java
+		lacks the concept of categories or mixins, there is no formal
+		mechanism to extend an existing class with a compile-type-checked
+		interface.  <code>IAdaptable</code> in Eclipse provides a very
+		simple interface to ask a class to adapt itself into another
+		interface, which can consult a factory to perform that lookup. A
+		common example of this is that you may ask a <code>Project</code>
+		for its <code>JavaProject</code> interface, which provides
+		additional capabilities that are specific to a
+		<code>JavaProject</code>.  In Partial Entities, we use the
+		capabilities of EOF to provide the underlying flexible datastore for
+		the entity state (that is, EOF doesn't care if we tell it that
+		<code>Person</code> now has 3 new relationships and 4 new attributes
+		as long as the underlying database definition agrees when it comes
+		time to fetch or save).  We use the <code>IAdaptable</code> concept
+		to address type-safe Java interfaces to this state.  Velocity
+		EOGenerator has been extended to support the generation of special
+		"partial entity" templates.  These templates are very similar to
+		normal EO templates except that where normal EO's extend
+		<code>EOGenericRecord</code> (or
+		<code>ERXPartialGenericRecord</code> in the case of partial base
+		entities), the partials themselves extend <code>ERXPartial</code>,
+		which is <em>not</em> a subclass of <code>EOEnterpriseObject</code>.
+		 It is an important concept that the partials are <em>only</em> a
+		type-safe wrapper around a single EO. <code>Person</code> is the
+		only EO in the above example.  <code>CalendarPerson</code> and
+		<code>TaskPerson</code> are simply type-safe "views" of
+		<code>Person</code>.
+		</p>
 
-<h2>Design</h2>
-<p>
-Enter Partial Entities.  With partial entities, you can declare a base Person entity, a TaskPerson partial
-entity that adds the "activeTasks" relationship, and a CalendarPerson partial entity that adds the 
-"scheduledEvents" relationship and the "dayStartTime" and "dayEndTime" attributes.  At runtime, the base
-and partial entities are merged together such that the entity named "Person" is the union of all of the 
-attributes and relationships of all of its partials.  In fact, the "partial entities" are not entities at
-all, but rather exist only as special cover classes that are generated by VelocityEOGenerator to allow
-compile-time type checking and get/set method access.  The ability of partials to merge into a single entity
-means that the underlying representation in the database is such that a single row represents the union
-of all of the attributes of Person+CalendarPerson+TaskPerson.  The makes for fairly optimal fetching behavior.
-</p>
-<p>
-The design of the Java side of partial entities is inspired by the concept of an IAdaptable in Eclipse.  Eclipse
-has similar problem design constraints in that it provides extension mechanisms for many types of classes
-in the system.  Because Java lacks the concept of categories or mixins, there is no formal mechanism to extend
-an existing class with a compile-type-checked interface.  IAdaptable in Eclipse provides a very simple interface
-to ask a class to adapt itself into another interface, which can consult a factory to perform that lookup. A 
-common example of this is that you may ask a Project for its JavaProject interface, which provides additional
-capabilities that are specific to a JavaProject.  In Partial Entities, we use the capabilities of 
-EOF to provide the underlying flexible datastore for the entity state (that is, EOF doesn't care if we tell it
-that Person now has 3 new relationships and 4 new attributes as long as the underlying database definition
-agrees when it comes time to fetch or save).  We use the IAdaptable concept to address type-safe Java 
-interfaces to this state.  Velocity EOGenerator has been extended to support the generation of special 
-"partial entity" templates.  These templates are very similar to normal EO templates except that where
-normal EO's extend EOGenericRecord (or ERXPartialGenericRecord in the case of partial base entities), the
-partials themselves extend ERXPartial, which is NOT a subclass of EOEnterpriseObject.  It is an important 
-concept that the partials are ONLY a type-safe wrapper around a single EO.  Person is the only EO in the
-above example.  CalendarPerson and TaskPerson are simply type-safe "views" of Person.
-</p>
+		<h2>Example</h2>
+		<p>
+		In code there are two ways to access the partial covers for an EO. 
+		In Java, you will want to use the programmatic interface, and in
+		components you will want to use the binding method.  The two styles
+		look like:
 
-<h2>Example</h2>
-<p>
-In code there are two ways to access the partial covers for an EO.  In Java, you will want to use the 
-programmatic interface, and in components you will want to use the binding method.  The two styles 
-look like:
-</p>
-<pre>
-Person person = ...; // fetch a Person EO from the database
+    <pre><code>Person person = ...; // fetch a Person EO from the database
 CalendarPerson calendarPerson = person.partialForClass(CalendarPerson.class);
 calendarPerson.setDayStartTime(new NSTimestamp());
 System.out.println(calendarPerson.dayStartTime());
 
 TaskPerson taskPerson = person.partialForClass(TaskPerson.class);
-System.out.println(taskPerson.activeTasks());
-</pre>
-or
-<pre>
-DayStartTime : WOString {
+System.out.println(taskPerson.activeTasks());</code></pre>
+
+		or
+
+    <pre><code>DayStartTime : WOString {
 	value = person.@CalendarPerson.dayStartTime;
 	dateformat = "%m/%d/%y";
-}
-</pre>
+}</code></pre>
 
-<h2>Usage</h2>
-<p>
-So how do you take advantage of partials?  There are several pieces.  Entities in your models need to be
-annotated as partials, the runtime needs to be notified of them, and Java code needs to be generated to 
-take care of the tedium of repetitive implementation. Partial entities require the use of Project Wonder, 
-the latest WOLips/Entity Modeler, and the latest Velocity EOGenerator (which is built into WOLips).
-</p>
-<h3>Model</h3>
-<p>
-In Entity Modeler, there is a new option under the Advanced tab of an Entity that allows the selection of
-a "Partial Entity".  The Partial Entity is the base entity that a particular entity will augment.  For instance
-"CalendarPerson"'s Partial Entity is "Person".  Currently, a partial cannot augment another partial.  For instance,
-"TaskPerson" cannot be a partial entity for "CalendarPerson," rather they can only be a partial of the base 
-"Person" entity.
-</p>
-<p>
-Any attribute of the base entity can be duplicated in the partials if it makes creating
-relationships easier -- these will just be skipped when the entities are merged at runtime.  For instance, it
-may be easier to setup your partial's relationships if you duplicate the PK's into the partial entities.
-</p>
-<p>
-Lastly, in your model, you should specify the class name of each partial entity.  For instance, CalendarPerson
-may be com.mdimension.calendar.model.CalendarPerson, whereas TaskPerson might be 
-com.mdimension.tasking.model.TaskPerson.  "External name" on partial entities is currently ignored, but should
-be set to be the same as the base entity (for instance, CalendarPerson's external name should be "Person", to
-imply that the CalendarPerson entity will be in the Person table).
-</p>
-<h3>Code Generation</h3>
-<p>
-Currently, only the Velocity EOGenerator in WOLips is able to generate code for partial entities.  In the 
-Defines section of your model's EOGenerator configuration, you should specify that your EOGenericRecord class
-should be er.extensions.partials.ERXPartialGenericRecord (rather than er.extensions.eof.ERXGenericRecord like you
-normally would).  The Velocity templates will automatically make the superclass of partial classes 
-er.extensions.partials.ERXPartial, but the "ERXPartial partialForClass(Class)" method is only on 
-ERXPartialGenericRecord.
-</p>
-<h3>SQL Generation</h3>
-<p>
-SQL Generation with partials is a complicated subject, but ideally you should use the ERMigrations API's to
-create your tables.  With migrations, you can have your base framework create the generic Person table, 
-the Calendar framework can add the appropriate columns for CalendarPerson, and the Tasking application can
-add the appropriate columns for tasking.  If you generate SQL directly out of Entity Modeler, you will likely
-get multiple definitions for the same table names, which would need to be manually merged.
-</p>
-<h3>Runtime</h3>
-<p>
-To enable the use of partials at runtime, you should set the property:
-</p>
-<pre>
-er.extensions.partials.enabled=true
-</pre>
-<p>
-This will trigger the runtime system to do entity merging for you.  To use the partials at runtime, refer back
-to the Examples section above.
-</p>
-</body>
+		<h2>Usage</h2>
+		<p>
+		So how do you take advantage of partials?  There are several pieces.
+		Entities in your models need to be annotated as partials, the
+		runtime needs to be notified of them, and Java code needs to be
+		generated to take care of the tedium of repetitive implementation.
+		Partial entities require the use of Project Wonder, the latest
+		WOLips/Entity Modeler, and the latest Velocity EOGenerator (which is
+		built into WOLips).
+		</p>
+		<h3>Model</h3>
+		<p>
+		In Entity Modeler, there is a new option under the Advanced tab of
+		an Entity that allows the selection of a "Partial Entity".  The
+		Partial Entity is the base entity that a particular entity will
+		augment.  For instance <code>CalendarPerson</code>'s Partial Entity
+		is <code>Person</code>.  Currently, a partial cannot augment another
+		partial.  For instance, <code>TaskPerson</code> cannot be a partial
+		entity for <code>CalendarPerson</code>, rather they can only be a
+		partial of the base <code>Person</code> entity.
+		</p>
+		<p>
+		Any attribute of the base entity can be duplicated in the partials
+		if it makes creating relationships easier&mdash;these will just be
+		skipped when the entities are merged at runtime.  For instance, it
+		may be easier to setup your partial's relationships if you duplicate
+		the PK's into the partial entities.
+		</p>
+		<p>
+		Lastly, in your model, you should specify the class name of each
+		partial entity.  For instance, <code>CalendarPerson</code> may be
+		<code>com.mdimension.calendar.model.CalendarPerson</code>, whereas
+		<code>TaskPerson</code> might be
+		<code>com.mdimension.tasking.model.TaskPerson</code>.  "External
+		name" on partial entities is currently ignored, but should be set to
+		be the same as the base entity (for instance,
+		<code>CalendarPerson</code>'s external name should be
+		<code>Person</code>, to imply that the <code>CalendarPerson</code>
+		entity will be in the <code>Person</code> table).
+		</p>
+		<h3>Code Generation</h3>
+		<p>
+		Currently, only the Velocity EOGenerator in WOLips is able to
+		generate code for partial entities.  In the Defines section of your
+		model's EOGenerator configuration, you should specify that your
+		<code>EOGenericRecord</code> class should be
+		<code>er.extensions.partials.ERXPartialGenericRecord</code> (rather
+		than <code>er.extensions.eof.ERXGenericRecord</code> like you
+		normally would).  The Velocity templates will automatically make the
+		superclass of partial classes
+		<code>er.extensions.partials.ERXPartial</code>, but the
+		<code>ERXPartial partialForClass(Class)</code> method is only on
+		<code>ERXPartialGenericRecord</code>.
+		</p>
+		<h3>SQL Generation</h3>
+		<p>
+		SQL Generation with partials is a complicated subject, but ideally
+		you should use the ERMigrations APIs to create your tables.  With
+		migrations, you can have your base framework create the generic
+		<code>Person</code> table, the Calendar framework can add the
+		appropriate columns for <code>CalendarPerson</code>, and the Tasking
+		application can add the appropriate columns for tasking.  If you
+		generate SQL directly out of Entity Modeler, you will likely get
+		multiple definitions for the same table names, which would need to
+		be manually merged.
+		</p>
+		<h3>Runtime</h3>
+		<p>
+		To enable the use of partials at runtime, you should set the
+		property:
+		</p>
+		<pre><code>er.extensions.partials.enabled=true</code></pre>
+		<p>
+		This will trigger the runtime system to do entity merging for you. 
+		To use the partials at runtime, refer back to the Examples section
+		above.
+		</p>
+	</body>
 </html>


### PR DESCRIPTION
This commit represents only changes to Javadoc comments (mostly
additional markup in the package-level docs, and a brief tidy-up in
the classes). There are some whitespace changes. There are no code
changes in this commit.
