### PR TITLE
Fixed bug in ERXStatisticsStore - it was never logging

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/ERXStatisticsStore.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/ERXStatisticsStore.java
@@ -118,7 +118,7 @@ public class ERXStatisticsStore extends WOStatisticsStore {
 					_requestThreads.remove(Thread.currentThread());
 				}
 				long currentTime = System.currentTimeMillis();
-				if(currentTime - _lastLog > 10000) {
+				if(currentTime - _lastLog < 10000) {
 					return;
 				}
 				_lastLog = currentTime;


### PR DESCRIPTION
The last commit copied from SourceForge broke ERXStatisticsStore. I spotted it because I am about to submit another pull request to allow a customer listener for the ERXStatisticsStore request timer.
