### PR TITLE
Allow a custom listener to be created for ERXStatisticsStore

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/ERXStatisticsStore.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/ERXStatisticsStore.java
@@ -1,19 +1,36 @@
 package er.extensions.statistics;
 
-import com.webobjects.appserver.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import org.apache.log4j.Logger;
+
+import com.webobjects.appserver.WOComponent;
+import com.webobjects.appserver.WOContext;
+import com.webobjects.appserver.WORequest;
+import com.webobjects.appserver.WOSession;
+import com.webobjects.appserver.WOStatisticsStore;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSMutableDictionary;
+
 import er.extensions.appserver.ERXApplication;
 import er.extensions.appserver.ERXSession;
 import er.extensions.eof.ERXEC;
 import er.extensions.eof.ERXObjectStoreCoordinator;
 import er.extensions.foundation.ERXProperties;
-import er.extensions.statistics.store.*;
-import org.apache.log4j.Logger;
-
-import java.util.*;
+import er.extensions.statistics.store.ERXDumbStatisticsStoreListener;
+import er.extensions.statistics.store.IERXStatisticsStoreListener;
+import er.extensions.statistics.store.ERXEmptyRequestDescription;
+import er.extensions.statistics.store.ERXNormalRequestDescription;
+import er.extensions.statistics.store.IERXRequestDescription;
 
 /**
  * Enhances the normal stats store with a bunch of useful things which get
@@ -46,10 +63,10 @@ public class ERXStatisticsStore extends WOStatisticsStore {
 		return _timer;
 	}
 
-    private final ERXStatisticsStoreListener listener;
+    private final IERXStatisticsStoreListener listener;
 
     public ERXStatisticsStore() {
-        listener = new DumbERXStatisticsStoreListener();
+        listener = new ERXDumbStatisticsStoreListener();
     }
 
     /**
@@ -58,7 +75,7 @@ public class ERXStatisticsStore extends WOStatisticsStore {
      * 
      * @param listener a customer listener to do something 'special' when requests are slow
      */
-    public ERXStatisticsStore(ERXStatisticsStoreListener listener) {
+    public ERXStatisticsStore(IERXStatisticsStoreListener listener) {
         this.listener = listener;
     }
 
@@ -118,7 +135,7 @@ public class ERXStatisticsStore extends WOStatisticsStore {
 					_lastLog = currentTime;
 				}
 			
-                RequestDescription requestDescription = descriptionObjectForContext(aContext, aString);
+                IERXRequestDescription requestDescription = descriptionObjectForContext(aContext, aString);
                 listener.log(requestTime, requestDescription);
 				if (requestTime > _maximumRequestFatalTime) {
 					log.fatal("Request did take too long : " + requestTime + "ms request was: " + requestDescription + trace);
@@ -222,7 +239,7 @@ public class ERXStatisticsStore extends WOStatisticsStore {
 			return descriptionObjectForContext(aContext, string).toString();
 		}
 
-        public RequestDescription descriptionObjectForContext(WOContext aContext, String string) {
+        public IERXRequestDescription descriptionObjectForContext(WOContext aContext, String string) {
             if (aContext != null) {
                 try {
                     WOComponent component = aContext.page();
@@ -233,13 +250,13 @@ public class ERXStatisticsStore extends WOStatisticsStore {
                     if (!requestHandler.equals("wo")) {
                         additionalInfo = additionalInfo + aContext.request().uri();
                     }
-                    return new NormalRequestDescription(componentName, requestHandler, additionalInfo);
+                    return new ERXNormalRequestDescription(componentName, requestHandler, additionalInfo);
                 }
                 catch (RuntimeException e) {
                     log.error("Cannot get context description since received exception " + e, e);
                 }
             }
-            return new EmptyRequestDescription(string);
+            return new ERXEmptyRequestDescription(string);
         }
 
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/DumbERXStatisticsStoreListener.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/DumbERXStatisticsStoreListener.java
@@ -1,8 +1,0 @@
-package er.extensions.statistics.store;
-
-public class DumbERXStatisticsStoreListener implements ERXStatisticsStoreListener {
-
-    public void log(long requestTime, RequestDescription description) {}
-
-    public void deadlock(int deadlocksCount) {}
-}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXDumbStatisticsStoreListener.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXDumbStatisticsStoreListener.java
@@ -1,0 +1,8 @@
+package er.extensions.statistics.store;
+
+public class ERXDumbStatisticsStoreListener implements IERXStatisticsStoreListener {
+
+    public void log(long requestTime, IERXRequestDescription description) {}
+
+    public void deadlock(int deadlocksCount) {}
+}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXEmptyRequestDescription.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXEmptyRequestDescription.java
@@ -1,11 +1,11 @@
 package er.extensions.statistics.store;
 
-public class EmptyRequestDescription implements RequestDescription {
+public class ERXEmptyRequestDescription implements IERXRequestDescription {
 
     public static final String ERROR_STRING = "Error-during-context-description";
     private String descriptionString = ERROR_STRING;
 
-    public EmptyRequestDescription(String descriptionString) {
+    public ERXEmptyRequestDescription(String descriptionString) {
         if (descriptionString != null) {
             this.descriptionString = descriptionString;
         }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXNormalRequestDescription.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXNormalRequestDescription.java
@@ -1,12 +1,12 @@
 package er.extensions.statistics.store;
 
-public class NormalRequestDescription implements RequestDescription {
+public class ERXNormalRequestDescription implements IERXRequestDescription {
 
     private final String componentName;
     private final String requestHandler;
     private final String additionalInfo;
 
-    public NormalRequestDescription(String componentName, String requestHandler, String additionalInfo) {
+    public ERXNormalRequestDescription(String componentName, String requestHandler, String additionalInfo) {
         this.componentName = componentName;
         this.requestHandler = requestHandler;
         this.additionalInfo = additionalInfo;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXStatisticsStoreListener.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/ERXStatisticsStoreListener.java
@@ -1,9 +1,0 @@
-package er.extensions.statistics.store;
-
-public interface ERXStatisticsStoreListener {
-
-    public void log(long requestTime, RequestDescription description);
-
-    public void deadlock(int deadlocksCount);
-
-}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/IERXRequestDescription.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/IERXRequestDescription.java
@@ -1,6 +1,6 @@
 package er.extensions.statistics.store;
 
-public interface RequestDescription {
+public interface IERXRequestDescription {
 
     public String getComponentName();
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/IERXStatisticsStoreListener.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/store/IERXStatisticsStoreListener.java
@@ -1,0 +1,9 @@
+package er.extensions.statistics.store;
+
+public interface IERXStatisticsStoreListener {
+
+    public void log(long requestTime, IERXRequestDescription description);
+
+    public void deadlock(int deadlocksCount);
+
+}


### PR DESCRIPTION
When slow requests are detected it will now log on every request but skip printing the stack traces if that has already been done within the last 10 seconds. There is a new constructor that allows a custom listener to be created for EXRXStatisticsStore so that as well as its normal behaviour it's possible to add custom behaviour.

In our case we use the custom listener to notify an external system of slow requests so that we can graph their occurrences and automatically alert the operations team if we see any of them. E.g.:

```
ERXStatisticsStoreListener customStatsListener = new ERXStatisticsStoreListener() {

    @Override
    public void log(long requestTime, RequestDescription description) {
        callForHelp(requestTime);
    }

    @Override
    public void deadlock(int deadlocksCount) { /* DO NOTHING */ }

};

ERXStatisticsStore statisticsStore = new ERXStatisticsStore(customStatsListener);
```
