### PR TITLE
Added CELL_TYPE_BOOLEAN support to ExcelGenerator

### DIFF
--- a/Frameworks/Excel/ExcelGenerator/Sources/er/excel/EGSimpleTableCreator.java
+++ b/Frameworks/Excel/ExcelGenerator/Sources/er/excel/EGSimpleTableCreator.java
@@ -229,7 +229,11 @@ public class EGSimpleTableCreator {
 			case HSSFCell.CELL_TYPE_FORMULA:
 			value = cell.getCellFormula();
 			break;
-
+			
+			case HSSFCell.CELL_TYPE_BOOLEAN:
+			value = cell.getBooleanCellValue();
+			break;
+			
 			default:
 			value = cell.getStringCellValue();
 			break;

--- a/Frameworks/Excel/ExcelGenerator/Sources/er/excel/EGSimpleTableParser.java
+++ b/Frameworks/Excel/ExcelGenerator/Sources/er/excel/EGSimpleTableParser.java
@@ -407,6 +407,21 @@ public class EGSimpleTableParser {
     								log.info(e1);
     							}
     							
+    						case HSSFCell.CELL_TYPE_BOOLEAN:
+    							cell.setCellType(cellType.intValue());
+    							if (value != null) {
+    								try {
+    									Integer integer = Integer.parseInt(value.toString());
+    									cell.setCellValue(integer > 0);
+    								} catch (NumberFormatException ex) {
+    									if (log.isDebugEnabled()) {
+    										log.debug(ex.getMessage(), ex);
+    									}
+    	    							cell.setCellValue(new Boolean(value.toString()));
+    								}
+    							}
+    							break;
+    							
     						case HSSFCell.CELL_TYPE_STRING:
 							default:
 								cell.setCellType(cellType.intValue());


### PR DESCRIPTION
Implemented CELL_TYPE_BOOLEAN in EGSimpleTableCreator and EGSimpleTableParser
Catch SAXParseException and display Excel generated content with line numbers for easier debugging
