### PR TITLE
change resopurces.include.patternset to current correct implementation

### DIFF
--- a/Frameworks/Ajax/Ajax/woproject/resources.include.patternset
+++ b/Frameworks/Ajax/Ajax/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
 Components/**/*.api
-Components/**/*.wo/
+Components/**/*.wo/**/*
 Resources/**/*

--- a/Frameworks/BusinessLogic/ERAttachment/woproject/resources.include.patternset
+++ b/Frameworks/BusinessLogic/ERAttachment/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/BusinessLogic/ERCoreBusinessLogic/woproject/resources.include.patternset
+++ b/Frameworks/BusinessLogic/ERCoreBusinessLogic/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
 Components/**/*.api
-Components/**/*.wo
+Components/**/*.wo/**/*
 Resources/**/*

--- a/Frameworks/Core/ERNeutralLook/woproject/resources.include.patternset
+++ b/Frameworks/Core/ERNeutralLook/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/Core/WOOgnl/woproject/resources.include.patternset
+++ b/Frameworks/Core/WOOgnl/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
 Components/**/*.api
-Components/**/*.wo
+Components/**/*.wo/**/*
 Resources/**/*

--- a/Frameworks/Excel/ERExcelLook/woproject/resources.include.patternset
+++ b/Frameworks/Excel/ERExcelLook/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
 Resources/**/*
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api

--- a/Frameworks/Misc/ERCalendar/woproject/resources.include.patternset
+++ b/Frameworks/Misc/ERCalendar/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/Misc/ERCaptcha/woproject/resources.include.patternset
+++ b/Frameworks/Misc/ERCaptcha/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/Misc/ERChronic/woproject/resources.include.patternset
+++ b/Frameworks/Misc/ERChronic/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/Misc/ERSelenium/woproject/resources.include.patternset
+++ b/Frameworks/Misc/ERSelenium/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/Misc/WOLips/woproject/resources.include.patternset
+++ b/Frameworks/Misc/WOLips/woproject/resources.include.patternset
@@ -1,3 +1,3 @@
-Components/**/*.wo
+Components/**/*.wo/**/*
 Components/**/*.api
 Resources/**/*

--- a/Frameworks/PlugIns/PostgresqlPlugIn/woproject/resources.include.patternset
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/woproject/resources.include.patternset
@@ -1,7 +1,3 @@
-Properties
-**/*.eomodeld/
-**/*.d2wmodel
-**/*.wo/
-**/*.api
-**/*.strings
-**/*.plist
+Components/**/*.wo/**/*
+Components/**/*.api
+Resources/**/*

--- a/Frameworks/Reporting/WRReporting/woproject/resources.include.patternset
+++ b/Frameworks/Reporting/WRReporting/woproject/resources.include.patternset
@@ -1,6 +1,3 @@
-Properties
-**/*.eomodeld/
-**/*.d2wmodel
-**/*.wo/
-**/*.api
-**/*.strings
+Components/**/*.wo/**/*
+Components/**/*.api
+Resources/**/*

--- a/Frameworks/WOAdaptors/ERIMAdaptor/woproject/resources.include.patternset
+++ b/Frameworks/WOAdaptors/ERIMAdaptor/woproject/resources.include.patternset
@@ -1,6 +1,3 @@
-Properties
-**/*.eomodeld/
-**/*.d2wmodel
-**/*.wo/
-**/*.api
-**/*.strings
+Resources/**/*
+Components/**/*.api
+Components/**/*.wo/**/*


### PR DESCRIPTION
some Framworks after building with Ant has not all Data in the deployment Package and the deployment was broken. like the .wo Components are created but no HTML or WOD was inside.

I had this problem in deployment and 2 days to find out what was going on.
