### PR TITLE
Pull request for ERAttachment

### DIFF
--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/ERS3Attachment.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/ERS3Attachment.java
@@ -183,11 +183,24 @@ public class ERS3Attachment extends _ERS3Attachment {
 	}
 
 	public QueryStringAuthGenerator queryStringAuthGenerator() {
-		return new QueryStringAuthGenerator(accessKeyID(), secretAccessKey(), false);
+		String host = ERXProperties.stringForKey("er.attachment." + configurationName() + ".s3.host");
+		if (host == null) {
+			host = ERXProperties.stringForKey("er.attachment.s3.host");
+		}
+		if (host == null)
+			return new QueryStringAuthGenerator(accessKeyID(), secretAccessKey(), false);
+		else
+			return new QueryStringAuthGenerator(accessKeyID(), secretAccessKey(), false, host);
 	}
 
 	public AWSAuthConnection awsConnection() {
-		AWSAuthConnection conn = new AWSAuthConnection(accessKeyID(), secretAccessKey(), true);
-		return conn;
+		String host = ERXProperties.stringForKey("er.attachment." + configurationName() + ".s3.host");
+		if (host == null) {
+			host = ERXProperties.stringForKey("er.attachment.s3.host");
+		}
+		if (host == null)
+			return new AWSAuthConnection(accessKeyID(), secretAccessKey(), true);
+		else
+			return new AWSAuthConnection(accessKeyID(), secretAccessKey(), true, host);
 	}
 }

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/package.html
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/package.html
@@ -243,6 +243,9 @@ Note: Deleting an attachment that is in the unavailable state may result in the 
 	
 	<dt>er.attachment.s3.bucket / er.attachment.[configurationName].s3.bucket</dt>
 	<dd>(required) The name of the bucket to store and retrieve attachments into.  The bucket must already exist in your S3 account.</dd> 
+	
+	<dt>er.attachment.s3.host / er.attachment.[configurationName].s3.host</dt>
+	<dd>(optional) Defaults to s3.amazonaws.com. Use this property if your bucket is not in the default region. For example put s3-eu-west-1.amazonaws.com for EU(Ireland).</dd> 
 
 	<dt>er.attachment.s3.key / er.attachment.[configurationName].s3.key</dt>
 	<dd>(optional) The name of the file to store in the S3 bucket.  This is evaluated as a path template.  The default value is "${pk}${ext}".</dd>


### PR DESCRIPTION
Made s3 host configurable via Property er.attachment.s3.host. Useful for buckets not in the default region.
