### PR TITLE
use format string in ap_log_error

### DIFF
--- a/Utilities/Adaptors/Adaptor/log.c
+++ b/Utilities/Adaptors/Adaptor/log.c
@@ -237,7 +237,7 @@ void WOLog(int level, const char *format, ...)
 #if defined(Netscape)
       log_error(0,"WebObjects",NULL,NULL,str->text);
 #elif defined(APACHE)
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, _webobjects_server, str->text);
+      ap_log_error(APLOG_MARK, APLOG_ERR, 0, _webobjects_server, "%s", str->text);
 #elif defined(IIS)
       /*
        *	again, we're stymied because we don't have a ptr to the


### PR DESCRIPTION
Debian/Ubuntu's gcc uses -Werror=format-security as default option, which
makes this warning a fatal error.
http://wiki.debian.org/Hardening#DEB_BUILD_HARDENING_FORMAT_.28gcc.2Fg.2B-.2B-_-Wformat_-Wformat-security_-Werror.3Dformat-security.29
