### PR TITLE
ERXStyleSheet fix

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXStyleSheet.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXStyleSheet.java
@@ -117,13 +117,18 @@ public class ERXStyleSheet extends ERXStatelessComponent {
 					log.warn("ERXStyleSheet.performActionNamed() \"session\" -> " + session());
 					log.warn("ERXStyleSheet.performActionNamed() \"cache key\" -> " + name);
 					log.warn("ERXStyleSheet.performActionNamed() \"cache\" -> " + cache);
-					log.warn("ERXStyleSheet.performActionNamed() \"isStale\" -> " + cache.isStale(name));
+					if (cache != null) {
+						log.warn("ERXStyleSheet.performActionNamed() \"isStale\" -> " + cache.isStale(name));
+					}
+					
 				} else {
 					log.error("ERXStyleSheet.performActionNamed() \"response\" was unexpectedly null");
 					log.error("ERXStyleSheet.performActionNamed() \"session\" -> " + session());
 					log.error("ERXStyleSheet.performActionNamed() \"cache key\" -> " + name);
 					log.error("ERXStyleSheet.performActionNamed() \"cache\" -> " + cache);
-					log.error("ERXStyleSheet.performActionNamed() \"isStale\" -> " + cache.isStale(name));
+					if (cache != null) {
+						log.error("ERXStyleSheet.performActionNamed() \"isStale\" -> " + cache.isStale(name));
+					}
 				}
 			}							
 			


### PR DESCRIPTION
There is a brittle relationship between "appendToResponse()" and "performActionNamed()." The RR-loop puts a fresh stylesheet response in the "cache" but only if it is stale. There are times when it's on the edge and not stale at that moment in the RR loop but when the direct action fires (while Safari interprets the head tags) when the DA will not have the canned response in the cache. It is for these times that something must be done. Hence the failSafeCache. 
