### PR TITLE
Remove "ScriptAlias" from "httpd.conf" in LINUX RPMs

### DIFF
--- a/Utilities/Linux/RPMSpecs/woadaptor_i686.spec
+++ b/Utilities/Linux/RPMSpecs/woadaptor_i686.spec
@@ -39,6 +39,7 @@ mkdir -p %{buildroot}%{_libdir}/httpd/modules/
 mkdir -p %{buildroot}/etc/httpd/conf.d/
 %{__cp} $RPM_BUILD_DIR/wonder-master/Utilities/Adaptors/Apache2.2/mod_WebObjects.so %{buildroot}%{_libdir}/httpd/modules/
 %{__cp} $RPM_BUILD_DIR/wonder-master/Utilities/Adaptors/Apache2.2/apache.conf %{buildroot}/etc/httpd/conf.d/webobjects.conf
+sed -i 's"^ScriptAlias /cgi-bin/"## ScriptAlias /cgi-bin/"' /etc/httpd/conf/httpd.conf
 
 %clean
 rm -rf %{buildroot}

--- a/Utilities/Linux/RPMSpecs/woadaptor_x86_64.spec
+++ b/Utilities/Linux/RPMSpecs/woadaptor_x86_64.spec
@@ -39,6 +39,7 @@ mkdir -p %{buildroot}%{_libdir}/httpd/modules/
 mkdir -p %{buildroot}/etc/httpd/conf.d/
 %{__cp} $RPM_BUILD_DIR/wonder-master/Utilities/Adaptors/Apache2.2/mod_WebObjects.so %{buildroot}%{_libdir}/httpd/modules/
 %{__cp} $RPM_BUILD_DIR/wonder-master/Utilities/Adaptors/Apache2.2/apache.conf %{buildroot}/etc/httpd/conf.d/webobjects.conf
+sed -i 's"^ScriptAlias /cgi-bin/"## ScriptAlias /cgi-bin/"' /etc/httpd/conf/httpd.conf
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
Comment out the "ScriptAlias" in "httpd.conf" during LINUX RPM installations of "woadaptor"
