### PR TITLE
Removed hard coded width limit

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/ajaxHoverable.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/ajaxHoverable.js
@@ -53,7 +53,6 @@ var erxToolTip=function(){
 			t.style.display = 'block';
 			b.style.display = 'block';
 		}
-		if(tt.offsetWidth > maxw){tt.style.width = maxw + 'px'}
 		
 		// (Aaron) Use Prototype and the erxHoverArea action element
 		hoverActionElem = hoverActionElement;


### PR DESCRIPTION
There was a hard coded limit on the width of the hoverable. Did not seem necessary and was stopping us from using a wider width. Removing this hard coded limit. 
