### PR TITLE
Add name to node with primitive object.

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
@@ -1025,6 +1025,9 @@ public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdd
 				setAssociatedObject(null);
 			}
 			else {
+				if (_name == null) {
+					_name = classDescription.entityName();
+				}
 				setValue(obj);
 				setAssociatedObject(obj);
 			}


### PR DESCRIPTION
This pull request adds name to node with primitive object. 

Before that we have such response:
<tabTypes2 type="String">
<null>123</null>
<null>456</null>
</tabTypes2>

And after nodes have valuable names:
<tabTypes2 type="String">
<String>123</String>
<String>456</String>
</tabTypes2>
