### PR TITLE
Hardcoded timezone example => Default time zone

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERDEditDatePopup.wo/ERDEditDatePopup.html
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERDEditDatePopup.wo/ERDEditDatePopup.html
@@ -1,1 +1,1 @@
-<WEBOBJECT NAME=monthPopup></WEBOBJECT><WEBOBJECT NAME=dayPopup></WEBOBJECT><WEBOBJECT NAME=yearPopup></WEBOBJECT><WEBOBJECT NAME=Conditional1>&nbsp;&nbsp; <I>time (e.g 22:34)</I> <WEBOBJECT NAME=TextField1></WEBOBJECT> PST</WEBOBJECT>
+<WEBOBJECT NAME=monthPopup></WEBOBJECT><WEBOBJECT NAME=dayPopup></WEBOBJECT><WEBOBJECT NAME=yearPopup></WEBOBJECT><WEBOBJECT NAME=Conditional1>&nbsp;&nbsp; <I>time (e.g 22:34)</I> <WEBOBJECT NAME=TextField1></WEBOBJECT>   <webobject name="String3" /></WEBOBJECT>

--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERDEditDatePopup.wo/ERDEditDatePopup.wod
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERDEditDatePopup.wo/ERDEditDatePopup.wod
@@ -24,3 +24,7 @@ yearPopup: WOPopUpButton {
 	list = yearList;
 	selection = year;
 }
+
+String3: WOString {
+	value = timeZoneString;
+}

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/dates/ERDEditDatePopup.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/dates/ERDEditDatePopup.java
@@ -6,6 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.dates;
 
+import java.util.TimeZone;
+
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
 import com.webobjects.foundation.NSTimestamp;
@@ -36,6 +38,10 @@ public class ERDEditDatePopup extends ERDEditDatePopupCommon {
 	private static final long serialVersionUID = 1L;
 
     public ERDEditDatePopup(WOContext context) { super(context); }
+    
+    public Object timeZoneString() {
+      return TimeZone.getDefault().getDisplayName(true, TimeZone.SHORT);
+    }
     
     @Override
     public void takeValuesFromRequest (WORequest request, WOContext context) {


### PR DESCRIPTION
Change the time zone example from a hard coded string to the default timezone to match EREditDatePopupOrNull otherwise you have PST on the page with the local timezone if you happen to need both components in the same page. Confusing.
![Desired behaviour](https://f.cloud.github.com/assets/690901/207881/13de4218-8202-11e2-9e25-66f90a54aa2d.png)
