### PR TITLE
AjaxObserveField compatible

### DIFF
--- a/Frameworks/Ajax/ERCoolComponents/Sources/er/coolcomponents/CCDatePicker.java
+++ b/Frameworks/Ajax/ERCoolComponents/Sources/er/coolcomponents/CCDatePicker.java
@@ -105,7 +105,10 @@ public class CCDatePicker extends ERXStatelessComponent {
     		String cssFilename = stringValueForBinding("cssFile", CSS_FILENAME);
     		ERXResponseRewriter.addStylesheetResourceInHead(response, context, framework, cssFilename);
     	}
-    	String datepickerjsName = ERXApplication.isDevelopmentModeSafe() ? "datepicker_lg.js" : "datepicker.js";
+    	//(AR) do not know how to generate minified js file. Added event notifications to the "lg.js"
+    	// file that makes this date picker compatible with AjaxObserveField.
+    	//String datepickerjsName = ERXApplication.isDevelopmentModeSafe() ? "datepicker_lg.js" : "datepicker.js";
+    	String datepickerjsName = "datepicker_lg.js";
         ERXResponseRewriter.addScriptResourceInHead(response, context, FRAMEWORK_NAME, datepickerjsName);
         String langScript = ERXLocalizer.currentLocalizer().languageCode() + ".js";
         ERXResponseRewriter.addScriptResourceInHead(response, context, FRAMEWORK_NAME, "lang/" + langScript);

--- a/Frameworks/Ajax/ERCoolComponents/WebServerResources/datepicker_lg.js
+++ b/Frameworks/Ajax/ERCoolComponents/WebServerResources/datepicker_lg.js
@@ -97,6 +97,31 @@ var datePickerController = (function datePickerController() {
                 };                              
         })();
         
+		// AR (stolen from CH in calendar.js): new method start
+		/* Fire the onChange event of the text input that we are setting so that it plays nice with
+		   AjaxObserveField etc. that use this notification.  */
+		function fireOnChangeEvent (input_element) {
+			var evt;
+			var el = input_element;
+			if (document.createEvent) {
+				evt = document.createEvent("HTMLEvents");
+				if (evt.initEvent) {
+					evt.initEvent("change", false, false);
+				}
+				else {
+					evt = false;
+				}
+				el.dispatchEvent(evt);
+			}
+			else {
+				if(document.createEventObject) {
+					var evt=document.createEventObject();
+					el.fireEvent("onChange", evt);
+				}
+			}
+		};
+		// AR (stolen from CH in calendar.js): new method done
+
         function parseUILanguage() {                                 
                 var languageTag = document.getElementsByTagName('html')[0].getAttribute('lang') || document.getElementsByTagName('html')[0].getAttribute('xml:lang');
                 
@@ -2084,7 +2109,16 @@ var datePickerController = (function datePickerController() {
                         
                         fmtDate = printFormattedDate(this.dateSet, elemFmt, returnLocaleDate);                   
                         if(elem.tagName.toLowerCase() == "input") {
-                                elem.value = fmtDate; 
+                        		var valueDiffers = false;
+                                if (elem.value != fmtDate) {
+                                	valueDiffers = true;
+                                }
+                                
+                                elem.value = fmtDate;
+                                 
+                                if (valueDiffers) {
+                                	fireOnChangeEvent(elem);
+                                }
                         } else {  
                                 this.setSelectIndex(elem, fmtDate);                              
                         };


### PR DESCRIPTION
Now when the CCDatePicker changes the value of the text field it makes a "change event" just as if a user typed in a new date. This allows observers to react such as AjaxObserveField. It mimics the default behavior of AjaxDatePicker and borrows code from that picker.

Signed-off-by: Aaron Rosenzweig aaron@chatnbike.com
