### PR TITLE
Fix ERXStringUtilities.replaceStringByStringInString()

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXStringUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXStringUtilities.java
@@ -687,6 +687,13 @@ public class ERXStringUtilities {
      * @return string after having all of the replacement done.
      */
     public static String replaceStringByStringInString(String old, String newString, String buffer) {
+        if (buffer == null || buffer.length() == 0) {
+            return "";
+        } else if (old == null || old.length() == 0) {
+            return buffer;
+        } else if (newString == null) {
+            newString = "";
+        }
         int begin, end;
         int oldLength = old.length();
         int length = buffer.length();


### PR DESCRIPTION
As the mentioned method has been advertised as being a replacement for ERXExtensions.substituteStringByStringInString() it should behave the same way if you feed it with _null_ parameters.
