### PR TITLE
Modal Box Autowidth Fix

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/modalbox.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/modalbox.js
@@ -626,7 +626,7 @@ Modalbox.Methods = {
 	// Added by TC.
 	__computeWidth: function() {
 		var newWidth;
-		if (this._initOptions.width) { // If there's an explicit width set, respect the value.
+		if (this._initOptions.width && this._initOptions.width != -1) { // If there's an explicit width set, respect the value.
 			newWidth = this.options.width;
 		} else { // If there's no explicit width, calculate it.
 			var cWidth = this.MBcontent.getWidth();


### PR DESCRIPTION
When a fixed-width dialog was opened before an auto-width dialog, the width of the previous dialog was used. Fixed by adapting width code to height calculation.
