### PR TITLE
ERD2WEditToOneRelationship advertises isMandatory key

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToOneRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToOneRelationship.java
@@ -19,7 +19,6 @@ import er.extensions.foundation.ERXUtilities;
  * @d2wKey restrictedChoiceKey keypath off the component that returns the list of objects to display
  * @d2wKey restrictingFetchSpecification name of the fetchSpec to use for the list of objects.
  * @d2wKey sortKey
- * @d2wKey isMandatory
  * @d2wKey numCols
  * @d2wKey propertyKey
  * @d2wKey size


### PR DESCRIPTION
This component hasn't honoured the `isMandatory` key since 2006, as discussed on the mailing list in [2010](http://permalink.gmane.org/gmane.comp.web.webobjects.wonder-disc/15336), 2013. This one liner pulls the corresponding `d2wKey` from the Javadocs.
