### PR TITLE
Template parser patch

### DIFF
--- a/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionHTMLParser.java
+++ b/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionHTMLParser.java
@@ -174,14 +174,18 @@ public class WOHelperFunctionHTMLParser {
 	 * @return a rewritten token if it has an inline binding or a closing tag, if it belongs to a rewritten token
 	 */
 	private String checkToken(String token) {
+		if (token == null) {
+			return token;
+		}
+		String tokenLowerCase = token.toLowerCase();
+		if (tokenLowerCase.startsWith(WEBOBJECT_START_TAG) || tokenLowerCase.startsWith(WO_COLON_START_TAG) || tokenLowerCase.startsWith(WO_START_TAG)
+				|| tokenLowerCase.startsWith(XML_CDATA_START_TAG)) {
+			// we return immediately, if it is a webobject token or CDATA tag
+			return token;
+		}
+		
 		String original = new String(token);
 		try {
-			if (token == null || token.toLowerCase().startsWith(WEBOBJECT_START_TAG) || token.toLowerCase().startsWith(WO_COLON_START_TAG) || token.toLowerCase().startsWith(WO_START_TAG)
-					|| token.toLowerCase().startsWith(XML_CDATA_START_TAG) ) {
-				// we return immediately, if it is a webobject token or CDATA tag
-				return token;
-			}
-
 			String[] tokenParts = token.split(" ");
 			String tokenPart = tokenParts[0].substring(1);
 


### PR DESCRIPTION
When using CDATA sections within a XHTML document the parser produces stack traces in the logfiles (document is completely and correctly parsed though). This patch tests for CDATA sections and prevents the stack trace.

Additionally the patch makes some memory optimizations to reduce the creation of string objects during parsing.
