### PR TITLE
update maven dependency for ERJGroupsSynchronizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
             <dependency>
                 <groupId>jgroups</groupId>
                 <artifactId>jgroups-all</artifactId>
-                <version>2.4.1</version>
+                <version>2.6.8</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>


### PR DESCRIPTION
As stated by Peter Vandoros on Wonder-disc mailinglist, ERJGroupsSynchronizer
needs JGroups 2.6 to work. So set the version in pom.xml to the library version
used in ERJGroupsSynchronizer framework.
