### PR TITLE
Fixes for multiple to-many relationships on a modEditPage

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/ERMDBatchSizeControl.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/ERMDBatchSizeControl.java
@@ -13,7 +13,7 @@ import er.extensions.foundation.ERXStringUtilities;
 import er.extensions.localization.ERXLocalizer;
 
 /**
- * A modern batch size controll that uses an AjaxInplaceEditor to edit
+ * A modern batch size control that uses an AjaxInplaceEditor to edit
  * the batch size.
  * 
  * @d2wKey itemString
@@ -132,7 +132,14 @@ public class ERMDBatchSizeControl extends ERDCustomComponent {
 	 */
 	public String batchSizeFieldID() {
 		if (_batchSizeFieldID == null) {
-			_batchSizeFieldID = "BSIF" + ERXStringUtilities.safeIdentifierName(context().contextID());;
+		  /*
+		   * the original contextID fails to provide a unique ID when there are multiple 
+		   * to-many relationships on the same edit page
+		   * 
+		   * Ted
+		   */
+//      _batchSizeFieldID = "BSIF" + ERXStringUtilities.safeIdentifierName(context().contextID());;
+			_batchSizeFieldID = "BSIF" + ERXStringUtilities.safeIdentifierName(context().elementID());;
 		}
 		return _batchSizeFieldID;
 	}

--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
@@ -90,6 +90,7 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 	public boolean isRelationshipToMany;
 	public WOComponent nextPage;
 	public NextPageDelegate nextPageDelegate;
+	private Integer _batchSize;
 	
 	public ERMODEditRelationshipPage(WOContext context) {
         super(context);
@@ -461,13 +462,33 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 			String count = (String)d2wContext().valueForKey("defaultBatchSize");
 			if (count != null) {
 				int intCount = Integer.parseInt(count);
-				_relationshipDisplayGroup.setNumberOfObjectsPerBatch(intCount);
+				_relationshipDisplayGroup.setNumberOfObjectsPerBatch(numberOfObjectsPerBatch());
 			}
 			
 		}
 		return _relationshipDisplayGroup;
 	}
 
+	 public int numberOfObjectsPerBatch() {
+	    if (_batchSize == null) {
+	      if (shouldShowBatchNavigation()) {
+	      int batchSize = ERXValueUtilities.intValueWithDefault(d2wContext().valueForKey("defaultBatchSize"), 0);
+	      Object batchSizePref = userPreferencesValueForPageConfigurationKey("batchSize");
+	      if (batchSizePref != null) {
+	        if (log.isDebugEnabled()) {
+	            log.debug("batchSize User Preference: " + batchSizePref);
+	        }
+	        batchSize = ERXValueUtilities.intValueWithDefault(batchSizePref, batchSize);
+	      }
+	      _batchSize = ERXConstant.integerForInt(batchSize);
+	      } else {
+	        // We are not showing the batch nav, so we need to display all results.
+	        _batchSize = ERXConstant.ZeroInteger;
+	      }
+	    }
+	    return _batchSize.intValue();
+	  }
+	 
 	public void setRelationshipDisplayGroup(WODisplayGroup relationshipDisplayGroup) {
 		_relationshipDisplayGroup = relationshipDisplayGroup;
 	}
@@ -532,5 +553,15 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 			d2wContext().takeValueForKey(inlineTask, "inlineTask");
 		}
 	}
+	
+	/**
+	 * Determines if the batch navigation should be shown.  It can be explicitly disabled by setting the D2W key 
+	 * <code>showBatchNavigation</code> to false.
+	 * @return true if the batch navigation should be shown
+	 */
+	public boolean  shouldShowBatchNavigation() {
+	  return ERXValueUtilities.booleanValueWithDefault(d2wContext().valueForKey("showBatchNavigation"), true);
+	}
+
 
 }


### PR DESCRIPTION
batchSizeFieldID was not unique

and EditRelationshipPage did not respect the saved batchsizes.
