### PR TITLE
Wrong variable in formatValueForAttribute 

### DIFF
--- a/Frameworks/PlugIns/DB2PlugIn/Sources/com/webobjects/jdbcadaptor/DB2Expression.java
+++ b/Frameworks/PlugIns/DB2PlugIn/Sources/com/webobjects/jdbcadaptor/DB2Expression.java
@@ -414,7 +414,7 @@ public class DB2Expression extends JDBCExpression {
                 }
               }
               else if (convertedObj instanceof String) {
-                String str = (String)obj;
+                String str = (String)convertedObj;
                 String valueType = eoattribute.valueType();
                 if (valueType == null || "i".equals(valueType)) {
                   return String.valueOf(Integer.parseInt(str));

--- a/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlExpression.java
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlExpression.java
@@ -493,7 +493,7 @@ public class PostgresqlExpression extends JDBCExpression {
                 }
               }
               else if (convertedObj instanceof String) {
-                String str = (String)obj;
+                String str = (String)convertedObj;
                 String valueType = eoattribute.valueType();
                 if (valueType == null || "i".equals(valueType)) {
                   return String.valueOf(Integer.parseInt(str));


### PR DESCRIPTION
There seems to be a bug in the DB2 and PostgreSQL plugin where the wrong variable is casted. At that point _obj_ has been checked for type of _Number_ and thus cannot be a _String_ whereas _convertedObj_ is successfully identified as one.
