### PR TITLE
Enable windows WOAdaptor URLs, containing ".dll" or ".exe."

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -173,6 +173,9 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 
 	private static boolean wasERXApplicationMainInvoked = false;
 
+	/** empty array for adaptorExtensions */
+    private static String[] myAppExtensions = {};
+
 	/**
 	 * Notification to get posted when we get an OutOfMemoryError or when memory passes
 	 * the low memory threshold set in er.extensions.ERXApplication.memoryLowThreshold. 
@@ -2844,4 +2847,13 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 		NSNotificationCenter.defaultCenter().postNotification(ApplicationWillTerminateNotification, this);
 		super.terminate();
 	}
+	
+	/**
+	 * Override default implementation that returns {".dll", ".exe"} and therefor prohibits IIS
+	 * as WebServer.
+	 */
+	@Override
+    public String[] adaptorExtensions() {
+        return myAppExtensions;
+    }
 }


### PR DESCRIPTION
2nd try - now based on current integration branch

This patch enables WOAdaptor URL paths, containing ".dll" or ".exe", which is necessary for technical reasons, if you are hosting on Windows using IIS. The original Apple WO 5.4.3 implementation did disable this intentionally, for whatever reason.
I use this change on productive deployment for years.
