### PR TITLE
wotaskd fixes : empty rest response causes client hanging

### DIFF
--- a/Applications/wotaskd/Sources/com/webobjects/monitor/wotaskd/DirectAction.java
+++ b/Applications/wotaskd/Sources/com/webobjects/monitor/wotaskd/DirectAction.java
@@ -52,7 +52,7 @@ public class DirectAction extends WODirectAction  {
     static private Object[] hostQueryKeys;
     static private Object[] appQueryKeys;
     static private Object[] instanceQueryKeys;
-    static private NSDictionary successElement;
+    static public NSDictionary successElement;
     static public Object[] errorKeys;
     static private String _accessDenied;
     static private String _invalidPassword;

--- a/Applications/wotaskd/Sources/com/webobjects/monitor/wotaskd/rest/controllers/MApplicationController.java
+++ b/Applications/wotaskd/Sources/com/webobjects/monitor/wotaskd/rest/controllers/MApplicationController.java
@@ -11,7 +11,6 @@ import com.webobjects.monitor._private.MObject;
 import com.webobjects.monitor._private.MonitorException;
 import com.webobjects.monitor.wotaskd.DirectAction;
 
-import er.extensions.appserver.ERXHttpStatusCodes;
 import er.extensions.eof.ERXKeyFilter;
 import er.extensions.eof.ERXQ;
 
@@ -182,6 +181,11 @@ public class MApplicationController extends JavaMonitorController {
     return response(status, ERXKeyFilter.filterWithAll());
   }
   
+  private WOActionResults successResponse() {
+      NSDictionary element = DirectAction.successElement;
+      return response(element, ERXKeyFilter.filterWithAttributes());    
+  }
+  
   public WOActionResults stopAction() throws MonitorException {
     checkPassword();
     for (MInstance minstance: instancesArray()) {
@@ -191,7 +195,7 @@ public class MApplicationController extends JavaMonitorController {
           throw new MonitorException("No response to STOP " + minstance.displayName());
       }
     }
-    return response(ERXHttpStatusCodes.OK);    
+    return successResponse();    
   }
   
   public WOActionResults startAction() {
@@ -210,7 +214,7 @@ public class MApplicationController extends JavaMonitorController {
         }    
       }
     }
-    return response(ERXHttpStatusCodes.OK);    
+    return successResponse();    
   }
   
   public WOActionResults forceQuitAction() throws MonitorException {
@@ -219,7 +223,7 @@ public class MApplicationController extends JavaMonitorController {
       if (application().localMonitor().terminateInstance(minstance) == null)
         throw new MonitorException("No response to STOP " + minstance.displayName());
     }
-    return response(ERXHttpStatusCodes.OK);
+    return successResponse();
   }
 
   public ERXKeyFilter instanceFilter() {

--- a/Applications/wotaskd/build.properties
+++ b/Applications/wotaskd/build.properties
@@ -1,0 +1,6 @@
+classes.dir = bin
+project.name = WOTaskd
+principalClass = com.webobjects.monitor.wotaskd.Application
+customInfoPListContent =
+webXML = false
+webXML_CustomContent = 


### PR DESCRIPTION
On wotaskd REST actions returning an empty response, various http clients were hanging (tested with jersey, postman). This fix returns a response with {"success":true}. 
