### PR TITLE
The method "copyFilesFromDirectory" fail to copy files into a target dir...

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
@@ -1023,7 +1023,7 @@ public class ERXFileUtilities {
                         if (deleteOriginals) {
                             renameTo(srcFile, dstFile);
                         } else {
-                            if (dstFile.mkdirs())
+                        	if (dstFile.exists() || dstFile.mkdirs())		// fix -- if directory existed no copy was done
                                 copyFilesFromDirectory(srcFile, dstFile, deleteOriginals, replaceExistingFiles, recursiveCopy, filter);
                             else
                                 log.error("Error creating directories for destination \""+dstDirectory.getPath()+"\"");


### PR DESCRIPTION
The method "copyFilesFromDirectory" fail to copy files into a target directory in recursive mode if that directory already exists because "dstFile.mkdirs()" fails.  Fix checks for existence first.
