### PR TITLE
Ajax hoverable css hook

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxHoverable.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxHoverable.java
@@ -76,6 +76,10 @@ public class AjaxHoverable extends WOComponent {
 		if (ERXStringUtilities.isNotBlank(userDefined)) {
 			classes += " " + userDefined;
 		}
+		
+		if (showHoverable()) {
+			classes += " showHoverable";
+		}
 		return classes;
 	}
 	


### PR DESCRIPTION
Adding an extra hook for CSS rules to latch onto. It will add the class "showHoverable" to the outermost DIV when the hoverable is active. We used this to add an "info icon" to all our hoverables just via CSS rules. 
