### PR TITLE
CCDatePicker with full formatter

### DIFF
--- a/Frameworks/Ajax/ERCoolComponents/Components/Nonlocalized.lproj/CCDatePicker.wo/CCDatePicker.html
+++ b/Frameworks/Ajax/ERCoolComponents/Components/Nonlocalized.lproj/CCDatePicker.wo/CCDatePicker.html
@@ -1,2 +1,7 @@
-<webobject name = "DateField"/>
+<webobject name = "ifCustomDateFormatter">
+	<webobject name = "DateFieldWithCustomFormatter"/>
+</webobject>
+<webobject name = "ifDateFormatPatternString">
+	<webobject name = "DateField"/>
+</webobject>
 <script type="text/javascript"><webobject name = "DatePickerCreateScript"/></script>

--- a/Frameworks/Ajax/ERCoolComponents/Components/Nonlocalized.lproj/CCDatePicker.wo/CCDatePicker.wod
+++ b/Frameworks/Ajax/ERCoolComponents/Components/Nonlocalized.lproj/CCDatePicker.wo/CCDatePicker.wod
@@ -7,6 +7,24 @@ DateField : WOTextField {
   tabindex = ^tabindex;
 }
 
+DateFieldWithCustomFormatter : WOTextField {
+  value = value;
+  formatter = customDateFormatter;
+  class = dateFormatString;
+  onclick = datePickerOpenScript;
+  id = elementID;
+  tabindex = ^tabindex;
+}
+
 DatePickerCreateScript : WOString {
   value = datePickerCreateScript;
+}
+
+ifCustomDateFormatter : WOConditional {
+	condition = hasCustomDateFormatter;
+}
+
+ifDateFormatPatternString : WOConditional {
+	condition = hasCustomDateFormatter;
+	negate = true;
 }

--- a/Frameworks/Ajax/ERCoolComponents/Sources/er/coolcomponents/CCDatePicker.java
+++ b/Frameworks/Ajax/ERCoolComponents/Sources/er/coolcomponents/CCDatePicker.java
@@ -1,5 +1,6 @@
 package er.coolcomponents;
 
+import java.text.Format;
 import java.text.SimpleDateFormat;
 
 import org.apache.log4j.Logger;
@@ -10,6 +11,7 @@ import com.webobjects.appserver.WOResponse;
 import com.webobjects.foundation.NSArray;
 //import com.webobjects.foundation.NSLog;
 import com.webobjects.foundation.NSTimestamp;
+import com.webobjects.foundation.NSTimestampFormatter;
 import com.webobjects.foundation.NSValidation.ValidationException;
 
 import er.extensions.appserver.ERXApplication;
@@ -32,6 +34,7 @@ import org.apache.commons.lang.StringUtils;
  * @binding cssFile name of the css file (defaults to datepicker.css)
  * @binding cssFramework name of the framework containing the css file (defaults to ERModernDirectToWeb)
  * @binding dateformat string containing the date format for the field
+ * @binding customDateFormatter an optional custom dateFormatter to be used in addition to a dateformat String. Note: The dateformat string is always used for Javascript. Note 2: You may want a custom formatter to prevent dates of certain types such as too far in the past or future for your DB to understand.
  * @binding injectStylesheet choose whether to dynamically inject the datepicker.css at component load. 
  * 			if used in a ajax loaded component, it may be safer to load this manually.
  * 
@@ -123,6 +126,15 @@ public class CCDatePicker extends ERXStatelessComponent {
 			format = ERXTimestampFormatter.DEFAULT_PATTERN;
 		}
 		return format;
+	}
+	
+	public Format customDateFormatter() {
+		Format formatter = (Format) valueForBinding("customDateFormatter");
+		return formatter;
+	}
+	
+	public boolean hasCustomDateFormatter() {
+		return customDateFormatter() != null;
 	}
 
 	@Override


### PR DESCRIPTION
CCDatePicker - added optional full fledged formatter

The dateformat string is ok and necessary for both the WOTextField and the Javascript that work together; however, having a true formatter bound to the WOTextField adds additional validation for things such as dates that are too big or too small. 
