### PR TITLE
Make sure correct value returned from in-memory evaluation of selector over a toMany relationship

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXKeyValueQualifier.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXKeyValueQualifier.java
@@ -3,7 +3,6 @@ package er.extensions.qualifiers;
 import com.webobjects.eocontrol.EOKeyValueQualifier;
 import com.webobjects.eocontrol.EOQualifier;
 import com.webobjects.eocontrol.EOQualifierVariable;
-import com.webobjects.eocontrol.EOQualifier.ComparisonSupport;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSKeyValueCoding;
 import com.webobjects.foundation.NSKeyValueCodingAdditions;
@@ -14,7 +13,6 @@ import com.webobjects.foundation._NSStringUtilities;
 import er.extensions.eof.ERXQ;
 import er.extensions.foundation.ERXArrayUtilities;
 import er.extensions.foundation.ERXProperties;
-import er.extensions.qualifiers.ERXKeyValueQualifier.PROPERTIES;
 
 /**
  * ERXKeyValueQualifier is a chainable extension of EOKeyValueQualifier.


### PR DESCRIPTION
Current behaviour of in-memory evaluation of selector over a toMany relationship is still not correct.

i.e. an entity Person has a toMany relationship to entity PersonName
When we evaluate either of the following qualifiers over a person or a person array:
Person.PERSON_NAMES.dot(PersonName.FIRST_NAME).startsWithInsensitive("Jennie");
or
Person.PERSON_NAMES.dot(PersonName.FIRST_NAME).contains("Jenni").and(Person.PERSON_NAMES.dot(PersonName.ACTIVE_FLAG).eq(1));

The result from invoking method EOKeyValueQualifier.evaluateWithObject(Object obj) was always false due to a bug in WebObjects core.

We could get the misbehaviour from invoking the following methods:
1) ERXArrayUtilities.filteredArrayWithQualifierEvaluation(arrayOfPersonToEvaluate, qualifierAsExample)
2) ERXQ.filtered(arrayOfPersonToEvaluate, qualifierAsExample)
3) ERXKeyValueQualifier.evaluateWithObject(aPersonEO)
there are more...
