### PR TITLE
Add support to count distinct rows based on multiple columns using MySQL

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2282,6 +2282,18 @@ public class ERXSQLHelper {
 		public int varcharLargeColumnWidth() {
 			return -1;
 		}
+
+		@Override
+		protected String sqlForCountDistinct(EOEntity entity) {
+			NSArray<String> primaryKeyAttributeNames = entity.primaryKeyAttributeNames();
+			NSMutableArray<String> pkColumnNames = new NSMutableArray<String>(primaryKeyAttributeNames.size());
+
+			for (String pkAttributeName : primaryKeyAttributeNames) {
+				pkColumnNames.add(quoteColumnName("t0." + entity.attributeNamed(pkAttributeName).columnName()));
+			}
+
+			return "count(distinct " + StringUtils.join(pkColumnNames, ", ") + ") ";
+		}
 	}
 
 	public static class PostgresqlSQLHelper extends ERXSQLHelper {


### PR DESCRIPTION
This pull request complements the pull request #474 and #475 adding support to count distinct with multiple columns using MySQL. Even though this solution wasn't verified using a real system, the produced SQL expression is valid based on the MySQL documentation. I'm not going to merge this change unless someone confirms it really works on a real system.
