### PR TITLE
Fix incorrect use of URLDecoder

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
@@ -165,7 +165,7 @@ public class ERXStaticResourceRequestHandler extends WORequestHandler {
 				}
 			}
 			catch (URISyntaxException e) {
-				log.info("The URI '" + uri + "' is invalid.'");
+				log.info("Unable to get file for '"+uri+"' because the URI is invalid.'");
 			}
 		} else {
 			log.error("Can't fetch relative path: " + uri);


### PR DESCRIPTION
Use URI class to ensure that the path is correctly parsed because URLDecoder is not the correct tool for the job. URLDecoder is used for decoding form values submitted via get. It replaces all spaces (" ") with a plus ("+") character, which breaks URIs for files with spaces in their names.

See http://docs.oracle.com/javase/6/docs/api/java/net/URI.html
