### PR TITLE
Update prototype.js to version 1.7.1 (updated in june 2012).

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/prototype.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/prototype.js
@@ -1468,7 +1468,7 @@ var Hash = Class.create(Enumerable, (function() {
 
     value = value.gsub(/(\r)?\n/, '\r\n');
     value = encodeURIComponent(value);
-    value = value.gsub(/%20/, '+');
+  	value = value.gsub(/%20/, '+'); // Why reencoding spaces already encoded by encodeURIComponent? This one does not seems to harm.
     return key + '=' + value;
   }
 
@@ -5808,7 +5808,8 @@ var Form = {
       accumulator = function(result, key, value) {
         value = value.gsub(/(\r)?\n/, '\r\n');
         value = encodeURIComponent(value);
-        value = value.gsub(/%20/, '+');
+        //value = value.gsub(/%20/, '+'); // Why reencoding spaces already encoded by encodeURIComponent? 
+        // With scriptaculous, the space where double encoded to %2B and decoded as +.
         return result + (result ? '&' : '') + encodeURIComponent(key) + '=' + value;
       }
     }


### PR DESCRIPTION
Was necessary to enable the Foundation 4 javascripts incompatible with previous version of prototype.

I tested AjaxExample, AjaxExample2 and my apps without issues.
