### PR TITLE
Enabling checkHashCodes on object repetitions in ERModern

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDListPageRepetition.wo/ERMDListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDListPageRepetition.wo/ERMDListPageRepetition.wod
@@ -87,6 +87,8 @@ ObjectsRepetition: WORepetition {
 	item = d2wContext.object;
 	list = ^displayGroup.displayedObjects;
 	index = rowIndex;
+	checkHashCodes = true;
+	eoSupport = true;	
 }
 
 LeftAction: WOSwitchComponent { 

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDReducedListPageRepetition.wo/ERMDReducedListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDReducedListPageRepetition.wo/ERMDReducedListPageRepetition.wod
@@ -16,6 +16,8 @@ ObjectsRepetition: WORepetition {
 	item = d2wContext.object;
 	list = ^displayGroup.displayedObjects;
 	index = rowIndex;
+	checkHashCodes = true;
+	eoSupport = true;	
 }
 
 LeftAction: WOSwitchComponent { 

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.wod
@@ -22,6 +22,8 @@ ObjectsRepetition: WORepetition {
 	item = d2wContext.object;
 	list = ^displayGroup.displayedObjects;
 	index = rowIndex;
+	checkHashCodes = true;
+	eoSupport = true;	
 }
 
 LeftAction: WOSwitchComponent { 


### PR DESCRIPTION
to ensure deletes are handled correctly. Without this, if an object is deleted and the object on the row below cannot be deleted, the latter may erroneously be marked as deleteable in the UI, once the deleted object has been removed from the repetition.

Enabling checkHashCodes globally causes attribute repetitions to break.
