### PR TITLE
Prevent NSKeyValueCoding$UnknownKeyException when ERModern attempts to ...

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/embed/ERXD2WEditRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/embed/ERXD2WEditRelationship.java
@@ -50,4 +50,13 @@ public class ERXD2WEditRelationship extends D2WEmbeddedComponent {
      */
     @Override
     public void awake() {}
+    
+    /**
+     * Prevent {@link com.webobjects.foundation.NSKeyValueCoding$UnknownKeyException}
+     */
+    @SuppressWarnings("unchecked")
+    public void handleTakeValueForUnboundKey(Object value, String key) {
+        // DO NOTHING
+    }
+ 
 }


### PR DESCRIPTION
... set masterObjectAndRelationshipKey. This would occur whenever an embedded relationship is edited, closed and edited again.