### PR TITLE
removing OpenQA repo from ERSelenium pom because OpenQA is off the air

### DIFF
--- a/Frameworks/Misc/ERSelenium/pom.xml
+++ b/Frameworks/Misc/ERSelenium/pom.xml
@@ -35,6 +35,8 @@
 		<sourceDirectory>Sources</sourceDirectory>
 	</build>
 	<repositories>
+	<!-- OpenQA is off the air. I'm just commenting this out
+	instead of deleting it in case a replacement is necessary.
 		<repository>
 			<id>openqa-releases</id>
 			<name>OpenQA Releases</name>
@@ -46,5 +48,6 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+		-->
 	</repositories>
 </project>


### PR DESCRIPTION
archiva.openqa.org redirects to www.openqa.org announcing that OpenQA is off the air. The result of this was that the html announcemnet was finding it's way into the maven repository as the pom for this artifact. That is obviously an invalid pom and caused problems compiling. Reloading the artifact in the local repository works (as long as you get rid of the old pom.
