### PR TITLE
use long instead of int in AjaxFileUpload classes

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFileUploadRequestHandler.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFileUploadRequestHandler.java
@@ -60,7 +60,7 @@ public class AjaxFileUploadRequestHandler extends WORequestHandler {
 			String uploadIdentifier = null;
 			String uploadFileName = null;
 			InputStream uploadInputStream = null;
-			int streamLength = -1;
+			long streamLength = -1L;
 
 			try {
 				String sessionIdKey = WOApplication.application().sessionIdKey();
@@ -114,7 +114,7 @@ public class AjaxFileUploadRequestHandler extends WORequestHandler {
 					}
 					
 					try {
-						if (_maxUploadSize >= 0 && streamLength > _maxUploadSize) {
+						if (_maxUploadSize >= 0L && streamLength > _maxUploadSize) {
 							IOException e = new IOException("You attempted to upload a file larger than the maximum allowed size of " + new ERXUnitAwareDecimalFormat(ERXUnitAwareDecimalFormat.BYTE).format(_maxUploadSize) + ".");
 							progress.setFailure(e);
 							progress.dispose();

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxProgress.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxProgress.java
@@ -33,8 +33,13 @@ public class AjaxProgress {
 	 * 
 	 * @param maximum the maximum value of this progress
 	 */
-	public AjaxProgress(int maximum) {
+	public AjaxProgress(long maximum) {
 		this("AjaxProgress" + System.currentTimeMillis(), maximum);
+	}
+
+	@Deprecated
+	public AjaxProgress(int maximum) {
+		this((long) maximum);
 	}
 
 	/**
@@ -43,9 +48,14 @@ public class AjaxProgress {
 	 * @param id the id of this AjaxProgress (only useful if you're registering it with AjaxProgressBar's registry)
 	 * @param maximum the maximum value of this progress
 	 */
-	public AjaxProgress(String id, int maximum) {
+	public AjaxProgress(String id, long maximum) {
 		_id = id;
 		_maximum = maximum;
+	}
+
+	@Deprecated
+	public AjaxProgress(String id, int maximum) {
+		this(id, (long) maximum);
 	}
 
 	/**

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxUploadProgress.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxUploadProgress.java
@@ -24,12 +24,17 @@ public class AjaxUploadProgress extends AjaxProgress {
 	 * @param fileName the name of the file uploaded from the client
 	 * @param streamLength the total length of the stream
 	 */
-	public AjaxUploadProgress(String id, File tempFile, String fileName, int streamLength) {
+	public AjaxUploadProgress(String id, File tempFile, String fileName, long streamLength) {
 		super(id, streamLength);
 		_tempFile = tempFile;
 		_fileName = fileName;
 	}
-	
+
+	@Deprecated
+	public AjaxUploadProgress(String id, File tempFile, String fileName, int streamLength) {
+		this(id, tempFile, fileName, (long) streamLength);
+	}
+
 	/**
 	 * Returns the name of the file the client uploaded.
 	 * 


### PR DESCRIPTION
To support file uploads larger than 2.1GB a couple of variables have to be declared as long instead of int. This is needed if a patched WOHttpIO is used that parses the request's content length as long.
