### PR TITLE
Fix FrontBase prototypes for correct time zone handling of Joda Time

### DIFF
--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFrontBasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFrontBasePrototypes.plist
@@ -172,7 +172,7 @@
             adaptorValueConversionClassName = "er.prototypes.ValueConversion"; 
             adaptorValueConversionMethodName = jodaLocalDateTime; 
             columnName = ""; 
-            externalType = TIMESTAMP; 
+            externalType = "TIMESTAMP WITH TIME ZONE"; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsDate; 
             name = jodaLocalDateTime; 
             valueClassName = "org.joda.time.LocalDateTime"; 
@@ -184,7 +184,7 @@
             adaptorValueConversionClassName = "er.prototypes.ValueConversion"; 
             adaptorValueConversionMethodName = jodaLocalTime; 
             columnName = ""; 
-            externalType = TIME; 
+            externalType = "TIME WITH TIME ZONE"; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsDate; 
             name = jodaLocalTime; 
             valueClassName = "org.joda.time.LocalTime"; 


### PR DESCRIPTION
To make FrontBase behave like mySql and PostgreSql, we need to use TIME WITH TIME ZONE and TIMESTAMP WITH TIME ZONE columns. With regular types, values are time zone dependant.
