### PR TITLE
Fix joda time timezone handling

### DIFF
--- a/Frameworks/Core/ERPrototypes/Sources/er/prototypes/ValueConversion.java
+++ b/Frameworks/Core/ERPrototypes/Sources/er/prototypes/ValueConversion.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
@@ -45,8 +46,10 @@ public class ValueConversion {
 	}
 
 	public static Date jodaDateTime(DateTime value) {
-		Date d = new Date(value.getMillis());
-		return d;
+		long dateInMillis = value.toInstant().getMillis();
+		int offset = TimeZone.getDefault().getOffset(dateInMillis);
+		Date javaDate = new Date(dateInMillis - offset);
+		return javaDate;
 	}
 	
 	@SuppressWarnings("rawtypes")

--- a/Frameworks/Core/ERPrototypes/Sources/er/prototypes/ValueFactory.java
+++ b/Frameworks/Core/ERPrototypes/Sources/er/prototypes/ValueFactory.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.TimeZone;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -60,8 +61,10 @@ public class ValueFactory {
 	}
 
 	public static DateTime jodaDateTime(Date value) {
-		DateTime dt = new DateTime(value.getTime());
-		return dt;
+		long dateInMillis = value.getTime();
+		int offset = TimeZone.getDefault().getOffset(dateInMillis);
+		DateTime dateTime = new DateTime(dateInMillis + offset);
+		return dateTime;
 	}
 	
 	@SuppressWarnings("rawtypes")


### PR DESCRIPTION
Made the JodaTime type works for all time zone. The previous code was working only with GMT as default application time zone.
