### PR TITLE
Add support for ERXCryptoString to ERRest when the content type is JSON

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestUtils.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestUtils.java
@@ -22,6 +22,7 @@ import com.webobjects.foundation.NSTimestamp;
 import com.webobjects.foundation.NSTimestampFormatter;
 import com.webobjects.foundation._NSUtilities;
 
+import er.extensions.crypting.ERXCryptoString;
 import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXValueUtilities;
 
@@ -99,6 +100,9 @@ public class ERXRestUtils {
 			primitive = true;
 		}
 		else if (NSKeyValueCoding.Null.class.isAssignableFrom(valueType)) {
+			primitive = true;
+		}
+		else if (ERXCryptoString.class.isAssignableFrom(valueType)) {
 			primitive = true;
 		}
 		return primitive;
@@ -406,6 +410,9 @@ public class ERXRestUtils {
 		}
 		else if (valueType != null && Enum.class.isAssignableFrom(valueType)) {
 			parsedValue = ERXValueUtilities.enumValueWithDefault(value, (Class<? extends Enum>) valueType, null);
+		}
+		else if (valueType != null && ERXCryptoString.class.isAssignableFrom(valueType)) {
+			parsedValue = new ERXCryptoString(value.toString());
 		}
 		else if (resolveEntities) {
 			EOClassDescription entity = ERXRestClassDescriptionFactory.classDescriptionForEntityName(valueTypeName);

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/_ERXJSONConfig.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/_ERXJSONConfig.java
@@ -13,6 +13,7 @@ import org.joda.time.LocalDateTime;
 import com.webobjects.foundation.NSData;
 import com.webobjects.foundation.NSTimestamp;
 
+import er.extensions.crypting.ERXCryptoString;
 import er.rest.ERXRestContext;
 import er.rest.ERXRestUtils;
 
@@ -29,13 +30,13 @@ public class _ERXJSONConfig {
 		}
 	}
 
-	public static class NSTimestampProcessor implements JsonValueProcessor {
+	public static class GeneralObjectToStringProcessor implements JsonValueProcessor {
 		private ERXRestContext _context;
-		
-		public NSTimestampProcessor(ERXRestContext context) {
+
+		public GeneralObjectToStringProcessor(ERXRestContext context) {
 			_context = context;
 		}
-		
+
 		public Object processArrayValue(Object obj, JsonConfig jsonconfig) {
 			return ERXRestUtils.coerceValueToString(obj, _context);
 		}
@@ -45,63 +46,16 @@ public class _ERXJSONConfig {
 		}
 	}
 
-	public static class NSDataProcessor implements JsonValueProcessor {
-		private ERXRestContext _context;
-		
-		public NSDataProcessor(ERXRestContext context) {
-			_context = context;
-		}
-		
-		public Object processArrayValue(Object obj, JsonConfig jsonconfig) {
-			return ERXRestUtils.coerceValueToString(obj, _context);
-		}
-
-		public Object processObjectValue(String s, Object obj, JsonConfig jsonconfig) {
-			return ERXRestUtils.coerceValueToString(obj, _context);
-		}
-	}
-
-	public static class JodaTimeProcessor implements JsonValueProcessor {
-		private ERXRestContext _context;
-		
-		public JodaTimeProcessor(ERXRestContext context) {
-			_context = context;
-		}
-		
-		public Object processArrayValue(Object obj, JsonConfig jsonconfig) {
-			return ERXRestUtils.coerceValueToString(obj, _context);
-		}
-
-		public Object processObjectValue(String s, Object obj, JsonConfig jsonconfig) {
-			return ERXRestUtils.coerceValueToString(obj, _context);
-		}
-	}
-	
-	public static class JodaDateTimeProcessor implements JsonValueProcessor {
-		private ERXRestContext _context;
-		
-		public JodaDateTimeProcessor(ERXRestContext context) {
-			_context = context;
-		}
-		
-		public Object processArrayValue(Object obj, JsonConfig jsonconfig) {
-			return ERXRestUtils.coerceValueToString(obj, _context);
-		}
-
-		public Object processObjectValue(String s, Object obj, JsonConfig jsonconfig) {
-			return ERXRestUtils.coerceValueToString(obj, _context);
-		}
-	}
-	
 	public static JsonConfig createDefaultConfig(ERXRestContext context) {
 		JsonConfig config = new JsonConfig();
-		config.registerJsonValueProcessor(NSTimestamp.class, new NSTimestampProcessor(context));
-		config.registerJsonValueProcessor(LocalDate.class, new JodaTimeProcessor(context));
-		config.registerJsonValueProcessor(LocalDateTime.class, new JodaDateTimeProcessor(context));
-		config.registerJsonValueProcessor(Date.class, new NSTimestampProcessor(context));
-		config.registerJsonValueProcessor(NSData.class, new NSDataProcessor(context));		
+		config.registerJsonValueProcessor(NSTimestamp.class, new GeneralObjectToStringProcessor(context));
+		config.registerJsonValueProcessor(LocalDate.class, new GeneralObjectToStringProcessor(context));
+		config.registerJsonValueProcessor(LocalDateTime.class, new GeneralObjectToStringProcessor(context));
+		config.registerJsonValueProcessor(Date.class, new GeneralObjectToStringProcessor(context));
+		config.registerJsonValueProcessor(NSData.class, new GeneralObjectToStringProcessor(context));
+		config.registerJsonValueProcessor(ERXCryptoString.class, new GeneralObjectToStringProcessor(context));
 		config.setJsonValueProcessorMatcher(new ERXRestValueProcessorMatcher());
 		return config;
 	}
-	
+
 }


### PR DESCRIPTION
This change adds the required code to transform ERXCryptoString fields into JSON format and to transform the corresponding text from JSON format into an ERXCryptoString object.
