### PR TITLE
Fix instantiation problem in ERRest when the destination entity of a relationship is abstract

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
@@ -1217,6 +1217,10 @@ public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdd
 					for (ERXRestRequestNode toManyNode : childNode.children()) {
 						Object id = toManyNode.id();
 
+						if (toManyNode.type() != null) {
+							destinationClassDescription = ERXRestClassDescriptionFactory.classDescriptionForEntityName(toManyNode.type());
+						}
+
 						Object childObj;
 						if (toManyNode.children().count() == 0 && ERXRestUtils.isPrimitive(toManyNode.value())) {
 							if (lockedRelationship) {
@@ -1327,6 +1331,11 @@ public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdd
 
 						ERXKeyFilter childKeyFilter = keyFilter._filterForKey(key);
 						Object childObj;
+
+						if (childNode.type() != null) {
+							destinationClassDescription = ERXRestClassDescriptionFactory.classDescriptionForEntityName(childNode.type());
+						}
+
 						if (id == null) {
 							if (lockedRelationship) {
 								childObj = null;


### PR DESCRIPTION
This commit fix a problem when the destination entity of a toOne or a toMany relationship is abstract. Instead of trying to create an instance of the abstract class (which causes an error), ERRest will try to create an instance based on the type attribute.
