### PR TITLE
Add an option to hide the previous and next year control for AjaxDatePicker.

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxDatePicker.api
+++ b/Frameworks/Ajax/Ajax/Components/AjaxDatePicker.api
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <wodefinitions>
    <wo class="AjaxDatePicker.java" wocomponentcontent="false">
 
@@ -34,5 +34,7 @@
     <binding defaults="Boolean" name="disabled"/>
     
     <binding name="locale"/>
+    <binding name="startDay"/>
+    <binding defaults="Boolean" name="showYearControls"/>
     </wo>
 </wodefinitions>

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDatePicker.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxDatePicker.java
@@ -59,10 +59,12 @@ import er.extensions.localization.ERXLocalizer;
  * @binding onDateSelect JavaScript to execute when a date is selected from the calendar
  * @binding fireEvent false if the onChange event for the input should NOT be fired when a date is selected in the calendar, defaults to true
  * 
+ * @binding startDay specify the first day of week to use 0(Sunday)-6(Saturday). The default use the current localizer.
  * @binding dayNames list of day names (Sunday to Saturday) for localization, English is the default
  * @binding monthNames list of month names for localization, English is the default
  * @binding imagesDir directory to take images from, takes them from Ajax.framework by default
  * @binding locale FL: locale can be set if ERXLocalizer returns the wrong one. IE the English localizer returns a US Locale. If you want the UK one then set this binding.
+ * @binding showYearControls: display the prev and next year controls. Default to true.
  * 
  * @binding calendarCSS name of CSS resource with classed for calendar, defaults to "calendar.css"
  * @binding calendarCSSFramework name of framework (null for application) containing calendarCSS resource, defaults to "Ajax"
@@ -211,7 +213,8 @@ public class AjaxDatePicker extends AjaxComponent {
 		
 		// FL Added to support start day, defaults to 0 (Sunday - choice made in calendar.js).
 		ajaxOptionsArray.addObject(new AjaxOption("start_day", "startDay", startDay(), AjaxOption.NUMBER));
-
+		ajaxOptionsArray.addObject(new AjaxOption("showYearControls", "showYearControls", showYearControls(), AjaxOption.BOOLEAN));
+		
 		ajaxOptionsArray.addObject(new AjaxOption("onDateSelect", AjaxOption.SCRIPT));
 		ajaxOptionsArray.addObject(new AjaxOption("fireEvent", AjaxOption.BOOLEAN));
 
@@ -221,7 +224,11 @@ public class AjaxDatePicker extends AjaxComponent {
     	super.appendToResponse(res, ctx);
     }
     
-    /**
+    private Boolean showYearControls() {
+		return Boolean.valueOf(booleanValueForBinding("showYearControls", true));
+	}
+
+	/**
      * @return JavaScript for onFocus binding of HTML input
      */
     public String onFocusScript() {

--- a/Frameworks/Ajax/Ajax/WebServerResources/calendar.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/calendar.js
@@ -338,8 +338,16 @@ function calendar_update() {
   get_element('calendar_header').innerHTML = calendar.month_names[m].substr(0,3).toUpperCase()+ ' ' + y;
   get_element('calendar_prev_month').onclick = calendar_prev_month;
   get_element('calendar_next_month').onclick = calendar_next_month;
-  get_element('calendar_prev_year').onclick = calendar_prev_year;
-  get_element('calendar_next_year').onclick = calendar_next_year;
+  if (calendar.showYearControls) {
+  	get_element('calendar_prev_year').style.visibility = 'visible';
+  	get_element('calendar_prev_year').onclick = calendar_prev_year;
+  	get_element('calendar_next_year').style.visibility = 'visible';
+  	get_element('calendar_next_year').onclick = calendar_next_year;
+  }
+  else {
+  	get_element('calendar_prev_year').style.visibility = 'hidden';
+  	get_element('calendar_next_year').style.visibility = 'hidden';
+  }
 
 // Iterate through the 42 calendar date boxes.
   var hide_last_row = false;
@@ -408,7 +416,11 @@ function calendar_open(input_element, options) {
   
   // FL Added to support diffrent start days. Defaults to 0 (Sunday).
   if (options.start_day) {
-  	calendar.start_day = options.start_day
+  	calendar.start_day = options.start_day;
+  }
+
+  if (options.showYearControls == false) {
+  	calendar.showYearControls = false;
   }
   // CH: Done add init of new options
   
@@ -539,6 +551,7 @@ calendar = {                        // Calendar properties.
   onDateSelect: undefined,          // CH: add function called when user selects a date
   fireEvent: true,					// CH: add should event listener for text field be fired upon date select?
   start_day: 0,						// FL: Start day, defaults to 0 Sunday.
+  showYearControls: true,			// SP: Display the year prev and next arrows.
   input_date: undefined,            // Date value of input element, set by calendar_show().
   month_date: undefined,            // First day of calendar month.
   format: undefined,                // The date display format, set by calendar_show().


### PR DESCRIPTION
Also added the documentation for the startDay binding already implemented but not documented.
