### PR TITLE
Update ERPrototype Class Names

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXMappingObjectStream.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXMappingObjectStream.java
@@ -22,7 +22,7 @@ public class ERXMappingObjectStream extends ObjectInputStream {
 	@Override
 	protected Class<?> resolveClass(ObjectStreamClass objectstreamclass) throws IOException, ClassNotFoundException {
 		Class<?> result = null;
-		if(objectstreamclass.getName().equals("er.extensions.ERXMutableArray")) {
+		if(objectstreamclass.getName().equals("er.extensions.foundation.ERXMutableArray")) {
 			return ERXMutableArray.class;
 		}
 		if(objectstreamclass.getName().equals("er.extensions.ERXMutableDictionary")) {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCAccessPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCAccessPrototypes.plist
@@ -226,7 +226,7 @@
             columnName = mutableDictionary; 
             externalType = "OLE Object"; 
             name = mutableDictionary; 
-            valueClassName = "er.extensions.ERXMutableDictionary"; 
+            valueClassName = "er.extensions.foundation.ERXMutableDictionary"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDB2Prototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDB2Prototypes.plist
@@ -230,7 +230,7 @@
             columnName = mutableDictionary; 
             externalType = BLOB; 
             name = mutableDictionary; 
-            valueClassName = "er.extensions.ERXMutableDictionary"; 
+            valueClassName = "er.extensions.foundation.ERXMutableDictionary"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDBasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCDBasePrototypes.plist
@@ -231,7 +231,7 @@
             columnName = mutableDictionary; 
             externalType = MEMO; 
             name = mutableDictionary; 
-            valueClassName = "er.extensions.ERXMutableDictionary"; 
+            valueClassName = "er.extensions.foundation.ERXMutableDictionary"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFirebirdPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFirebirdPrototypes.plist
@@ -102,7 +102,7 @@
             externalType = VARCHAR; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             valueType = c; 
             width = 255; 
@@ -217,7 +217,7 @@
             columnName = mutableArray; 
             externalType = "BLOB SUB_TYPE 0"; 
             name = mutableArray; 
-            valueClassName = "er.extensions.ERXMutableArray"; 
+            valueClassName = "er.extensions.foundation.ERXMutableArray"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {
@@ -225,7 +225,7 @@
             columnName = mutableDictionary; 
             externalType = "BLOB SUB_TYPE 0"; 
             name = mutableDictionary; 
-            valueClassName = "er.extensions.ERXMutableDictionary"; 
+            valueClassName = "er.extensions.foundation.ERXMutableDictionary"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCInterbasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCInterbasePrototypes.plist
@@ -231,7 +231,7 @@
             columnName = mutableDictionary; 
             externalType = BLOB; 
             name = mutableDictionary; 
-            valueClassName = "er.extensions.ERXMutableDictionary"; 
+            valueClassName = "er.extensions.foundation.ERXMutableDictionary"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCSQLServerPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCSQLServerPrototypes.plist
@@ -231,7 +231,7 @@
             columnName = mutableDictionary; 
             externalType = binary; 
             name = mutableDictionary; 
-            valueClassName = "er.extensions.ERXMutableDictionary"; 
+            valueClassName = "er.extensions.foundation.ERXMutableDictionary"; 
             valueFactoryMethodName = fromBlob; 
         }, 
         {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EORESTPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EORESTPrototypes.plist
@@ -93,7 +93,7 @@
             externalType = VARCHAR; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = globalID; 
-            valueClassName = "er.extensions.foundation.ERXKeyGlobalID"; 
+            valueClassName = "er.extensions.eof.ERXKeyGlobalID"; 
             valueFactoryMethodName = fromString; 
             width = 255; 
         }, 


### PR DESCRIPTION
Fix prototype class names to match the naming convention that we changed to, oh, say 5 or 6 years ago. Always good to catch these things early!
