### PR TITLE
Use the correct protocol for S3 attachment URLs based on the request security level

### DIFF
--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERS3AttachmentProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERS3AttachmentProcessor.java
@@ -150,9 +150,8 @@ public class ERS3AttachmentProcessor extends
 						e);
 			}
 
-		}
-
-		if(request.isSecure()) {
+		} else if(request.isSecure()) {
+			// The attachment is not proxied. So, the URL must be fixed if the request is secure.
 			attachmentUrl = StringUtils.replaceOnce(attachmentUrl, "http://", "https://");
 			attachmentUrl = StringUtils.replaceOnce(attachmentUrl, ":80/", "/");
 		}


### PR DESCRIPTION
**Problem**: the generated URL for S3 attachments always uses the HTTP protocol. In the context of secure requests (made over HTTPS), the generated URL should use the HTTPS protocol instead.

**Solution**: Chosing the URL protocol during persistence of the attachment is not ideal because the attachment may be used in secured and unsecured contexts later. The correct protocol should be determined during the URL generation. This patch replaces the HTTP protocol and removes the port (:80) from the generated URL whenever the request is secure.
