### PR TITLE
display group's setSelectedObjects did not call setSelectionIndexes

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDisplayGroup.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDisplayGroup.java
@@ -17,7 +17,9 @@ import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSMutableSet;
 import com.webobjects.foundation.NSSet;
+import com.webobjects.foundation._NSArrayUtilities;
 
+import er.extensions.batching.ERXBatchingDisplayGroup;
 import er.extensions.eof.ERXEOAccessUtilities;
 import er.extensions.eof.ERXS;
 
@@ -97,7 +99,7 @@ public class ERXDisplayGroup<T> extends WODisplayGroup {
 	}
 	
 	/**
-	 * Will return the qualifer set by "setQualifierForKey()" if it exists. Null returns otherwise.
+	 * Will return the qualifier set by "setQualifierForKey()" if it exists. Null returns otherwise.
 	 * @param key
 	 * @return
 	 */
@@ -189,11 +191,20 @@ public class ERXDisplayGroup<T> extends WODisplayGroup {
 	}
 
 	@Override
-	public void setSelectedObjects(NSArray nsarray) {
+	public void setSelectedObjects(NSArray objects) {
 		if(log.isDebugEnabled()) {
-			log.debug("setSelectedObjects@" + hashCode()  + ":" + (nsarray != null ? nsarray.count() : "0"));
+			log.debug("setSelectedObjects@" + hashCode()  + ":" + (objects != null ? objects.count() : "0"));
 		}
-		super.setSelectedObjects(nsarray);
+		if (this instanceof ERXBatchingDisplayGroup) {
+			// keep previous behavior
+			// CHECKME a batching display group has its own _displayedObjects variable so setSelectionIndexes won't work
+			super.setSelectedObjects(objects);
+		} else {
+			// jw: don't call super as it does not call setSelectionIndexes as advertised in its
+			// javadocs and thus doesn't invoke events on the delegate
+			NSArray<Integer> newSelection = _NSArrayUtilities.indexesForObjectsIndenticalTo(displayedObjects(), objects);
+			setSelectionIndexes(newSelection);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
`WODisplayGroup.setSelectedObjects(NSArray)` directly sets variables holding selection information instead of calling `WODisplayGroup.setSelectionIndexes(NSArray)` as the Javadocs pretend. That means that when calling _setSelectedObjects_ a display group's delegate will **not** be notified of the selection change.

This patch correctly calls _setSelectionIndexes_ but for ERXBatchingDisplayGroups as _setSelectionIndexes_ uses the private variable __displayedObjects_ which is redefined in ERXBatchingDisplayGroup.

If there are no objections this patch will be merged soon.
