### PR TITLE
Connection validation, auto reconnect

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
@@ -197,7 +197,7 @@ public class ERXDatabaseContextDelegate {
 				throw e;
 			}
 			String exceptionsRegex = ERXProperties.stringForKeyWithDefault(ERX_ADAPTOR_EXCEPTIONS_REGEX, ERX_ADAPTOR_EXCEPTIONS_REGEX_DEFAULT);
-			if(!handled && throwable.getMessage() != null && exceptionsRegex.matches(throwable.getMessage())) {
+			if(!handled && throwable.getMessage() != null && throwable.getMessage().matches(exceptionsRegex)) {
 				NSArray models = databaseContext.database().models();
 				for(Enumeration e = models.objectEnumerator(); e.hasMoreElements(); ) {
 					EOModel model = (EOModel)e.nextElement();


### PR DESCRIPTION
Patch suggested by JR Ruggentaler taken from mailing list from 20. Dec 2012:

> The ERXDatabaseContextDelegate class method databaseContextShouldHandleDatabaseException(EODatabaseContext databaseContext, Throwable throwable) only reconnects to the database if the exception message contains the string "_obtainOpenChannel". The string looks like something from the early WOAdaptor. I changed the code to make the string a property and changed the code to do String.matches() so anyone can configure which messages the ERXDatabaseContextDelegate will reconnect on.
