### PR TITLE
Fix a NullPointerException when calling the EOModel.createPrototypeCache method from the wrong EOModel

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXModelGroup.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXModelGroup.java
@@ -183,7 +183,7 @@ public class ERXModelGroup extends EOModelGroup {
 
 		NSMutableDictionary<String, URL> modelNameURLDictionary = new NSMutableDictionary<String, URL>();
 		NSMutableArray<String> modelNames = new NSMutableArray<String>();
-		NSMutableArray<NSBundle> bundles = new NSMutableArray<NSBundle>();
+		NSMutableSet<NSBundle> bundles = new NSMutableSet<NSBundle>();
 		bundles.addObject(NSBundle.mainBundle());
 		bundles.addObjectsFromArray(frameworkBundles);
 


### PR DESCRIPTION
The `ERXModelGroup` class may create duplicate models in some cases. They are not added to the model group, but their presence may cause problems. The root cause of this problem is related to the duplication of `NSBundle` references while loading `EOModel`s. This fix uses a `NSMutableSet` instead of a `NSMutableArray` to hold the references to all loaded bundles. It avoids the presence of duplicate bundles and therefore the presence of duplicate model references.

One can find more information about the issue at the above link.

https://github.com/hprange/wounit/issues/35
