### PR TITLE
Fix for issue 140. Appends the relationship name to the update container ID

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/assignments/defaults/ERMDDefaultCSSAssignment.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/assignments/defaults/ERMDDefaultCSSAssignment.java
@@ -3,6 +3,7 @@ package er.modern.directtoweb.assignments.defaults;
 import org.apache.log4j.Logger;
 
 import com.webobjects.directtoweb.D2WContext;
+import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
@@ -55,13 +56,13 @@ public class ERMDDefaultCSSAssignment extends ERDAssignment {
 			new NSArray(new Object[] {"propertyKey"}), "classForAttributeColumn",
 			new NSArray(new Object[] {"task", "pageConfiguration"}), "pageType",
 			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration"}), "idForRepetitionContainer",
-			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration"}), "idForMainContainer",
+			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration", "currentRelationship"}), "idForMainContainer",
 			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration"}), "idForPageTabContainer",
 			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration"}), "idForPageConfiguration",
 			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration", "propertyKey"}), "idForPropertyContainer",
 			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration"}), "idForMainBusyIndicator",
 			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration", "parentPageConfiguration"}), "idForParentPageConfiguration",
-			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration", "parentPageConfiguration"}), "idForParentMainContainer"
+			new NSArray(new Object[] {"task", "entity.name", "pageConfiguration", "parentPageConfiguration", "parentRelationship", "masterObjectAndRelationshipKey"}), "idForParentMainContainer"
 	});
 
     /**
@@ -265,7 +266,14 @@ public class ERMDDefaultCSSAssignment extends ERDAssignment {
 	// IDs
 	
 	public String idForMainContainer(D2WContext c) {
-		return "MUC_" + idForPageConfiguration(c);
+        String idForMainContainer = "MUC_" + idForPageConfiguration(c);
+        if (c.valueForKey("currentRelationship") != null) {
+            EORelationship relationship = (EORelationship) c
+                    .valueForKey("currentRelationship");
+            // use currentRelationship key to create unique ID (wonder-140)
+            idForMainContainer = idForMainContainer.concat("_" + relationship.name());
+        }
+        return idForMainContainer;
 	}
 	
 	public String idForRepetitionContainer(D2WContext c) {
@@ -281,7 +289,16 @@ public class ERMDDefaultCSSAssignment extends ERDAssignment {
 	}
 	
 	public String idForParentMainContainer(D2WContext c) {
-		return "MUC_" + idForParentPageConfiguration(c);
+        String idForParentMainContainer = "MUC_" + idForParentPageConfiguration(c);
+        if (c.valueForKey("parentRelationship") != null) {
+            EORelationship parentRelationship = (EORelationship) c
+                    .valueForKey("parentRelationship");
+            // use parentRelationship key to create unique parent ID
+            // (wonder-140)
+            idForParentMainContainer = idForParentMainContainer.concat("_"
+                    + parentRelationship.name());
+        }
+        return idForParentMainContainer;
 	}
 	
 	public String idForParentPageConfiguration(D2WContext c) {

--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
@@ -13,6 +13,8 @@ import com.webobjects.directtoweb.D2W;
 import com.webobjects.directtoweb.EditPageInterface;
 import com.webobjects.directtoweb.NextPageDelegate;
 import com.webobjects.directtoweb.SelectPageInterface;
+import com.webobjects.eoaccess.EOEntity;
+import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.eoaccess.EOUtilities;
 import com.webobjects.eocontrol.EOClassDescription;
 import com.webobjects.eocontrol.EODataSource;
@@ -36,6 +38,7 @@ import er.extensions.eof.ERXEOAccessUtilities;
 import er.extensions.eof.ERXEOControlUtilities;
 import er.extensions.eof.ERXGenericRecord;
 import er.extensions.foundation.ERXArrayUtilities;
+import er.extensions.foundation.ERXStringUtilities;
 import er.extensions.foundation.ERXValueUtilities;
 import er.modern.directtoweb.components.buttons.ERMDActionButton;
 import er.modern.directtoweb.interfaces.ERMEditRelationshipPageInterface;
@@ -289,7 +292,18 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 	 * @param a an NSArray containing the master object (index 0) and relationship key (index 1).
 	 */
 	public void setMasterObjectAndRelationshipKey(NSArray<?> a) {
-		setMasterObjectAndRelationshipKey((EOEnterpriseObject)a.objectAtIndex(0), (String)a.objectAtIndex(1));
+        EOEnterpriseObject masterObject = (EOEnterpriseObject) a.objectAtIndex(0);
+        String relationshipKey = (String) a.objectAtIndex(1);
+        if (masterObject != null
+                && !ERXStringUtilities.stringIsNullOrEmpty(relationshipKey)) {
+            EOEntity masterEntity = EOUtilities.entityForObject(
+                    masterObject.editingContext(), masterObject);
+            EORelationship rel = masterEntity.relationshipNamed(relationshipKey);
+            // set currentRelationship key to allow unique ID creation
+            // (wonder-140)
+            d2wContext().takeValueForKey(rel, "currentRelationship");
+        }
+        setMasterObjectAndRelationshipKey(masterObject, relationshipKey);
 	}
 	
 	/**
@@ -329,6 +343,28 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 		}
 	}
 	
+    /*
+     * Overridden to set the parentRelationship key.
+     * 
+     * @see er.directtoweb.pages.ERD2WPage#settings()
+     */
+    @Override
+    public NSDictionary settings() {
+        String pc = d2wContext().dynamicPage();
+        if (pc != null) {
+            if (d2wContext().valueForKey("currentRelationship") != null) {
+                // set parentRelationship key to allow subcomponents to
+                // reference the correct ID (wonder-140)
+                return new NSDictionary(new Object[] { pc,
+                        d2wContext().valueForKey("currentRelationship") }, new Object[] {
+                        "parentPageConfiguration", "parentRelationship" });
+            } else {
+                return new NSDictionary(pc, "parentPageConfiguration");
+            }
+        }
+        return null;
+    }
+
 	// SORT ORDERING
 	
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
E.g. having two relationships from movie to "studio", one named studio and one named "coStudio", the resulting IDs will be "MUC_EditRelationshipEmbeddedStudio_studio" and "MUC_EditRelationshipEmbeddedStudio_coStudio".
