### PR TITLE
ERXKey.Type and NSArray#valueForKey(ERXKey) additions

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Vector;
 
+import er.extensions.eof.ERXKey;
+import er.extensions.foundation.ERXArrayUtilities;
+
 /**
  * <span class="en">
  * NSArray re-implementation to support JDK 1.5 templates. Use with
@@ -1074,5 +1077,96 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 			}
 			throw NSForwardException._runtimeExceptionForThrowable(e);
 		}
+	}
+	
+	/**
+	 * A type-safe wrapper for {@link #valueForKeyPath(String)} that simply
+	 * calls {@code valueForKeyPath(erxKey.key())} and attempts to cast the
+	 * result to {@code NSArray<T>}. If the value returned cannot be cast it
+	 * will throw a {@link ClassCastException}.
+	 * 
+	 * @param <T>
+	 *            the Type of elements in the returned {@code NSArray}
+	 * @param erxKey
+	 * @return an {@code NSArray} of {@code T} objects.
+	 * @author David Avendasora
+	 */
+	public <T> NSArray<T> valueForKeyPath(ERXKey<T> erxKey) {
+		return (NSArray<T>) valueForKeyPath(erxKey.key());
+	}
+
+	/**
+	 * A type-safe wrapper for {@link #valueForKey(String)} that calls
+	 * {@code valueForKey(erxKey, true, true, true)}
+	 * 
+	 * <p>
+	 * This method will automatically
+	 * {@link ERXArrayUtilities#removeNullValues(NSArray) remove}
+	 * {@code NSKeyValueCoding.Null} elements,
+	 * {@link ERXArrayUtilities#flatten(NSArray) flatten} all elements that are
+	 * arrays and {@link ERXArrayUtilities#distinct(NSArray) remove} all
+	 * duplicate objects.
+	 * </p>
+	 * 
+	 * @param <T>
+	 *            the Type of elements in the returned {@code NSArray}
+	 * @param erxKey
+	 * @return an {@code NSArray} of {@code T} objects.
+	 * @author David Avendasora
+	 */
+	public <T> NSArray<T> valueForKey(ERXKey<T> erxKey) {
+		return valueForKey(erxKey, true, true, true);
+	}
+
+	/**
+	 * <p>
+	 * A type-safe wrapper for {@link #valueForKeyPath(String)} that calls
+	 * {@code valueForKeyPath(erxKey.key())} and attempts to cast the result to
+	 * {@code NSArray<T>}.
+	 * </p>
+	 * <p>
+	 * Then, depending upon the parameters, removes
+	 * {@link NSKeyValueCoding.Null} elements, flattens any {@link NSArray}
+	 * elements and then filters out duplicate values.
+	 * </p>
+	 * <p>
+	 * <b>If the value cannot be cast it will throw a {@link ClassCastException}
+	 * .</b>
+	 * </p>
+	 * 
+	 * @param <T>
+	 *            the Type of elements in the returned {@code NSArray}
+	 * @param erxKey
+	 * @param removeNulls
+	 *            if {@code true} all {@link NSKeyValueCoding.Null} elements
+	 *            will be {@link ERXArrayUtilities#removeNullValues(NSArray)
+	 *            removed}
+	 * @param distinct
+	 *            if {@code true} all duplicate elements will be
+	 *            {@link ERXArrayUtilities#distinct(NSArray) removed}
+	 * @param flatten
+	 *            if {@code true} all {@link NSArray} elements will be
+	 *            {@link ERXArrayUtilities#flatten(NSArray) flattened}
+	 * @return an {@code NSArray} of {@code T} objects.
+	 * @author David Avendasora
+	 */
+	public <T> NSArray<T> valueForKey(ERXKey<T> erxKey, boolean removeNulls, boolean distinct, boolean flatten) {
+		if (erxKey.type() == ERXKey.Type.Operator) {
+			final String message = "You cannot use an Opperator (@sum, @max, etc.) ERXKey with valueForKey(ERXKey) " 
+								 + "because the value returned by valueForKey(opperator) cannot be cast to NSArray. " 
+								 + "Call valueForKey(myERXKey.key()) instead.";
+			throw new IllegalArgumentException(message);
+		}
+		NSArray<T> values = (NSArray<T>) valueForKeyPath(erxKey.key());
+		if (removeNulls) {
+			values = ERXArrayUtilities.removeNullValues(values);
+		}
+		if (flatten && erxKey.isToManyRelationship()) {
+			values = ERXArrayUtilities.flatten(values);
+		}
+		if (distinct) {
+			values = ERXArrayUtilities.distinct(values);
+		}
+		return values;
 	}
 }

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
@@ -1096,22 +1096,28 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 	}
 
 	/**
-	 * A type-safe wrapper for {@link #valueForKey(String)} that calls
-	 * {@code valueForKey(erxKey, true, true, true)}
-	 * 
 	 * <p>
-	 * This method will automatically
-	 * {@link ERXArrayUtilities#removeNullValues(NSArray) remove}
-	 * {@code NSKeyValueCoding.Null} elements,
-	 * {@link ERXArrayUtilities#flatten(NSArray) flatten} all elements that are
-	 * arrays and {@link ERXArrayUtilities#distinct(NSArray) remove} all
-	 * duplicate objects.
+	 * A type-safe wrapper for {@link #valueForKey(String)} that automatically
+	 * does the following (in order) to the resulting array prior to returning
+	 * it:
+	 * <ol>
+	 * <li>{@link ERXArrayUtilities#removeNullValues(NSArray) remove}
+	 * {@code NSKeyValueCoding.Null} elements</li>
+	 * <li>{@link ERXArrayUtilities#flatten(NSArray) flatten} all elements that
+	 * are arrays (<em>Only</em> if {@link ERXKey#isToManyRelationship()}
+	 * returns <code>true</code>, which can only possibly happen if
+	 * {@link ERXKey#type()} has been set.)</li>
+	 * <li>{@link ERXArrayUtilities#distinct(NSArray) remove} all duplicate
+	 * objects</li>
+	 * </ol>
 	 * </p>
 	 * 
 	 * @param <T>
 	 *            the Type of elements in the returned {@code NSArray}
 	 * @param erxKey
+	 * 
 	 * @return an {@code NSArray} of {@code T} objects.
+	 * 
 	 * @author David Avendasora
 	 */
 	public <T> NSArray<T> valueForKey(ERXKey<T> erxKey) {
@@ -1125,9 +1131,17 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 	 * {@code NSArray<T>}.
 	 * </p>
 	 * <p>
-	 * Then, depending upon the parameters, removes
-	 * {@link NSKeyValueCoding.Null} elements, flattens any {@link NSArray}
-	 * elements and then filters out duplicate values.
+	 * Then, depending upon the parameters,
+	 * <ol>
+	 * <li>{@link ERXArrayUtilities#removeNullValues(NSArray) remove}
+	 * {@code NSKeyValueCoding.Null} elements</li>
+	 * <li>{@link ERXArrayUtilities#flatten(NSArray) flatten} all elements that
+	 * are arrays (<em>Only</em> if {@link ERXKey#isToManyRelationship()}
+	 * returns <code>true</code>, which can only possibly happen if
+	 * {@link ERXKey#type()} has been set.)</li>
+	 * <li>{@link ERXArrayUtilities#distinct(NSArray) remove} all duplicate
+	 * objects</li>
+	 * </ol>
 	 * </p>
 	 * <p>
 	 * <b>If the value cannot be cast it will throw a {@link ClassCastException}
@@ -1147,14 +1161,16 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 	 * @param flatten
 	 *            if {@code true} all {@link NSArray} elements will be
 	 *            {@link ERXArrayUtilities#flatten(NSArray) flattened}
+	 * 
 	 * @return an {@code NSArray} of {@code T} objects.
+	 * 
 	 * @author David Avendasora
 	 */
 	public <T> NSArray<T> valueForKey(ERXKey<T> erxKey, boolean removeNulls, boolean distinct, boolean flatten) {
 		if (erxKey.type() == ERXKey.Type.Operator) {
-			final String message = "You cannot use an Opperator (@sum, @max, etc.) ERXKey with valueForKey(ERXKey) " 
+			final String message = "You cannot use an Operator (@sum, @max, etc.) ERXKey with valueForKey(ERXKey) " 
 								 + "because the value returned by valueForKey(opperator) cannot be cast to NSArray. " 
-								 + "Call valueForKey(myERXKey.key()) instead.";
+								 + "Call valueForKey(MY_OPPERATOR_ERXKEY.key()) instead.";
 			throw new IllegalArgumentException(message);
 		}
 		NSArray<T> values = (NSArray<T>) valueForKeyPath(erxKey.key());

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXKey.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXKey.java
@@ -1505,7 +1505,7 @@ public class ERXKey<T> {
 	 * @author mschrag
 	 */
 	public static enum Type {
-		Attribute, ToOneRelationship, ToManyRelationship
+		Attribute, ToOneRelationship, ToManyRelationship, Operator, NonModelAttribute, NonModelToOneRelationshiop, NonModelToManyRelationship
 	}
 	
 	public interface ValueCoding {
@@ -1515,6 +1515,7 @@ public class ERXKey<T> {
 	}
 
 	private String _key;
+	private Type _type;
 
 	/**
 	 * Constructs an ERXKey.
@@ -1524,6 +1525,18 @@ public class ERXKey<T> {
 	 */
 	public ERXKey(String key) {
 		_key = key;
+	}
+
+	/**
+	 * Constructs an ERXKey.
+	 * 
+	 * @param key
+	 *            the underlying keypath
+	 * @param type
+	 */
+	public ERXKey(String key, Type type) {
+		_key = key;
+		setType(type);
 	}
 
 	/**
@@ -2642,5 +2655,25 @@ public class ERXKey<T> {
 	 */
 	public ERXSortOrderings dot(NSArray<EOSortOrdering> sortOrderings) {
 		return prefix(sortOrderings);
+	}
+
+	public Type type() {
+		return _type;
+	}
+
+	public void setType(Type type) {
+		_type = type;
+	}
+	
+	public boolean isAttribute() {
+		return type() == ERXKey.Type.Attribute || type() == ERXKey.Type.NonModelAttribute;
+	}
+	
+	public boolean isToOneRelationship() {
+		return type() == ERXKey.Type.ToOneRelationship || type() == ERXKey.Type.NonModelToOneRelationshiop;
+	}
+	
+	public boolean isToManyRelationship() {
+		return type() == ERXKey.Type.ToManyRelationship || type() == ERXKey.Type.NonModelToManyRelationship;
 	}
 }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXKey.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXKey.java
@@ -1505,7 +1505,7 @@ public class ERXKey<T> {
 	 * @author mschrag
 	 */
 	public static enum Type {
-		Attribute, ToOneRelationship, ToManyRelationship, Operator, NonModelAttribute, NonModelToOneRelationshiop, NonModelToManyRelationship
+		Attribute, ToOneRelationship, ToManyRelationship, Operator, NonModelAttribute, NonModelToOneRelationship, NonModelToManyRelationship
 	}
 	
 	public interface ValueCoding {
@@ -2670,7 +2670,7 @@ public class ERXKey<T> {
 	}
 	
 	public boolean isToOneRelationship() {
-		return type() == ERXKey.Type.ToOneRelationship || type() == ERXKey.Type.NonModelToOneRelationshiop;
+		return type() == ERXKey.Type.ToOneRelationship || type() == ERXKey.Type.NonModelToOneRelationship;
 	}
 	
 	public boolean isToManyRelationship() {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXKey.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXKey.java
@@ -3,6 +3,10 @@ package er.extensions.eof;
 import java.math.BigDecimal;
 import java.util.Locale;
 
+import com.webobjects.eoaccess.EOAttribute;
+import com.webobjects.eoaccess.EOModel;
+import com.webobjects.eoaccess.EORelationship;
+import com.webobjects.eocontrol.EOEnterpriseObject;
 import com.webobjects.eocontrol.EOQualifier;
 import com.webobjects.eocontrol.EOSortOrdering;
 import com.webobjects.foundation.NSArray;
@@ -13,6 +17,7 @@ import com.webobjects.foundation.NSTimestamp;
 
 import er.extensions.eof.ERXSortOrdering.ERXSortOrderings;
 import er.extensions.eof.qualifiers.ERXExistsQualifier;
+import er.extensions.foundation.ERXArrayUtilities;
 import er.extensions.qualifiers.ERXAndQualifier;
 import er.extensions.qualifiers.ERXKeyComparisonQualifier;
 import er.extensions.qualifiers.ERXKeyValueQualifier;
@@ -1500,12 +1505,123 @@ public class ERXKey<T> {
 	}
 	
 	/**
-	 * Enums to desribe the type of key this represents.
+	 * Enums to describe the type of key this represents.
 	 * 
 	 * @author mschrag
 	 */
 	public static enum Type {
-		Attribute, ToOneRelationship, ToManyRelationship, Operator, NonModelAttribute, NonModelToOneRelationship, NonModelToManyRelationship
+		/**
+		 * <p>
+		 * Indicates that this key represents an {@link EOAttribute} defined in
+		 * the {@link EOModel}. Since it is defined in the model it can be used
+		 * when instantiating Objects that impact SQL generation, e.g.,
+		 * {@link EOQualifier} and {@link EOSortOrdering}.
+		 * </p>
+		 */
+		Attribute, 
+		/**
+		 * <p>
+		 * Indicates that this key represents an {@link EORelationship} defined
+		 * in the {@link EOModel} that will return <code>false</code> for
+		 * {@link EORelationship#isToMany()}. Since it is defined in the model
+		 * it can be used when instantiating Objects that impact SQL generation,
+		 * e.g., {@link EOQualifier} and {@link EOSortOrdering}.
+		 * </p>
+		 */
+		ToOneRelationship, 
+		/**
+		 * <p>
+		 * Indicates that this key represents an {@link EORelationship} defined
+		 * in the {@link EOModel} that will return <code>true</code> for
+		 * {@link EORelationship#isToMany()}. Since it is defined in the model
+		 * it can be used when instantiating Objects that impact SQL generation,
+		 * e.g., {@link EOQualifier} and {@link EOSortOrdering}.
+		 * </p>
+		 */
+		ToManyRelationship, 
+		/**
+		 * <p>
+		 * Indicates that this key represents an {@link NSArray.Operator}, e.g.,
+		 * {@link NSArray._SumNumberOperator @sum},
+		 * {@link ERXArrayUtilities.FlattenOperator @flatten},
+		 * {@link ERXArrayUtilities.FlattenOperator @fetchSpec},
+		 * {@link NSArray._MinOperator @min}
+		 * </p>
+		 * <p>
+		 * <em>Note:</em> this Type is not recognized by the
+		 * {@link ERXKeyFilter#matches(ERXKey, Type)} and will not be included
+		 * in {@link ERXKeyFilter#includeAll()},
+		 * {@link ERXKeyFilter#includeAttributes()} nor
+		 * {@link ERXKeyFilter#includeAttributesAndToOneRelationships()} because
+		 * {@link ERXKeyFilter} can only be used with {@link ERXKey}s that
+		 * represent a single key {@link NSArray.Operator}s represent a keypath.
+		 * </p>
+		 */
+		Operator,
+		/**
+		 * <p>
+		 * Indicates that this key represents a visible method or ivar that
+		 * returns an object of type T, but does not have a corresponding
+		 * relationship entry in the {@link EOModel} and therefore cannot be
+		 * used to instantiate objects that will impact SQL generation. e.g.,
+		 * {@link EOQualifier} and {@link EOSortOrdering}.
+		 * </p>
+		 * <p>
+		 * <em>Note:</em> this ERXKey.Type is not recognized by the
+		 * {@link ERXKeyFilter#matches(ERXKey, Type)} and will not be included
+		 * in {@link ERXKeyFilter#includeAll()},
+		 * {@link ERXKeyFilter#includeAttributes()} nor
+		 * {@link ERXKeyFilter#includeAttributesAndToOneRelationships()}.
+		 * </p>
+		 * <p>
+		 * TODO: Additional work needs to be done to validate that ERRest's use
+		 * of ERXKeyFilter is compatible with this ERXKey.Type.
+		 * </p>
+		 */
+		NonModelAttribute,
+		/**
+		 * <p>
+		 * Indicates that this key represents a visible instance member that
+		 * returns an instance of {@link EOEnterpriseObject} of type T, but does
+		 * not have a corresponding relationship entry in the {@link EOModel}
+		 * and therefore cannot be used to instantiate objects that will impact
+		 * SQL generation. e.g., {@link EOQualifier} and {@link EOSortOrdering}.
+		 * </p>
+		 * <p>
+		 * <em>Note:</em> this ERXKey.Type is not recognized by the
+		 * {@link ERXKeyFilter#matches(ERXKey, Type)} and will not be included
+		 * in {@link ERXKeyFilter#includeAll()},
+		 * {@link ERXKeyFilter#includeAttributes()} nor
+		 * {@link ERXKeyFilter#includeAttributesAndToOneRelationships()}.
+		 * </p>
+		 * <p>
+		 * TODO: Additional work needs to be done to validate that ERRest's use
+		 * of ERXKeyFilter is compatible with this ERXKey.Type.
+		 * </p>
+		 */
+		NonModelToOneRelationship, 
+		/**
+		 * <p>
+		 * Indicates that this key represents a visible instance member that
+		 * returns an array of {@link EOEnterpriseObject} instances of type T,
+		 * but does not have a corresponding relationship entry in the
+		 * {@link EOModel} and therefore cannot be used to instantiate objects
+		 * that will impact SQL generation. e.g., {@link EOQualifier} and
+		 * {@link EOSortOrdering}.
+		 * </p>
+		 * <p>
+		 * <em>Note:</em> this ERXKey.Type is not recognized by the
+		 * {@link ERXKeyFilter#matches(ERXKey, Type)} and will not be included
+		 * in {@link ERXKeyFilter#includeAll()},
+		 * {@link ERXKeyFilter#includeAttributes()} nor
+		 * {@link ERXKeyFilter#includeAttributesAndToOneRelationships()}.
+		 * </p>
+		 * <p>
+		 * TODO: Additional work needs to be done to validate that ERRest's use
+		 * of ERXKeyFilter is compatible with this ERXKey.Type.
+		 * </p>
+		 */
+		NonModelToManyRelationship
 	}
 	
 	public interface ValueCoding {
@@ -1528,15 +1644,29 @@ public class ERXKey<T> {
 	}
 
 	/**
-	 * Constructs an ERXKey.
+	 * Constructs an ERXKey, specifying what {@link Type} it is.
+	 * 
+	 * You can have EOGenerator use this constructor by using the following code
+	 * in the EOGenerator template that generates your _Entity.java files.
+	 * Replace the existing code that creates the ERXKeys declarations for the
+	 * Entity's attributes, to-one relationships and to-many relationships.
+	 * 
+	 * <pre>
+	 *     public static final ERXKey<$attribute.javaClassName> ${attribute.uppercaseUnderscoreName} = new ERXKey<$attribute.javaClassName>("$attribute.name", ERXKey.Type.Attribute);
+	 * 
+	 *     public static final ERXKey<$relationship.actualDestination.classNameWithDefault> ${relationship.uppercaseUnderscoreName} = new ERXKey<$relationship.actualDestination.classNameWithDefault>("$relationship.name", ERXKey.Type.ToOneRelationship);
+	 * 
+	 *     public static final ERXKey<$relationship.actualDestination.classNameWithDefault> ${relationship.uppercaseUnderscoreName} = new ERXKey<$relationship.actualDestination.classNameWithDefault>("$relationship.name", ERXKey.Type.ToManyRelationship);
+	 * </pre>
 	 * 
 	 * @param key
-	 *            the underlying keypath
+	 *            the underlying key or keypath
 	 * @param type
+	 *            the {@link Type}
 	 */
 	public ERXKey(String key, Type type) {
 		_key = key;
-		setType(type);
+		_type = type;
 	}
 
 	/**
@@ -1549,6 +1679,23 @@ public class ERXKey<T> {
 	 */
 	public ERXKey(String key, String locale) {
 		_key = key + "_" + locale;
+	}
+
+	/**
+	 * Constructs a localized ERXKey, specifying what {@link Type} it is.
+	 * 
+	 * @param key
+	 *            the underlying keypath
+	 * @param locale
+	 *            the locale for the key
+	 * @param type
+	 *            the {@link Type}
+	 *            
+	 * @see #ERXKey(String, Type)
+	 */
+	public ERXKey(String key, String locale, Type type) {
+		_key = key + "_" + locale;
+		_type = type;
 	}
 
 	/**
@@ -2657,6 +2804,12 @@ public class ERXKey<T> {
 		return prefix(sortOrderings);
 	}
 
+	/**
+	 * See {@link #ERXKey(String, Type)} for information on how to automatically
+	 * set this.
+	 * 
+	 * @return the {@link Type}, if specified, for this key.
+	 */
 	public Type type() {
 		return _type;
 	}
@@ -2665,14 +2818,83 @@ public class ERXKey<T> {
 		_type = type;
 	}
 	
+	/**
+	 * Checks this key's {@link Type} to determine if it represents an
+	 * {@link EOAttribute}.
+	 * <p>
+	 * <em>Note:</em> if {@link #type()} has not been set, then this will return
+	 * <code>false</code>. To set it, you have the following options:
+	 * <ul>
+	 * <li>Set it manually using {@link #setType(Type)}</li>
+	 * <li>Set it using the {@link #ERXKey(String, Type)} constructor. If this
+	 * key was declared in code generated by EOGenerator (i.e. in a _Entity.java
+	 * class), you will need to modify your EOGenerator template. See
+	 * {@link #ERXKey(String, Type)} for details.</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @return <code>true</code> if {@link #type()} returns either
+	 *         {@link ERXKey.Type.Attribute} or
+	 *         {@link ERXKey.Type.NonModelAttribute}, <code>false</code>
+	 *         otherwise.
+	 *         
+	 * @see isToOneRelationship
+	 * @see isToManyRelationship
+	 */
 	public boolean isAttribute() {
 		return type() == ERXKey.Type.Attribute || type() == ERXKey.Type.NonModelAttribute;
 	}
 	
+	/**
+	 * Checks this key's {@link ERXKey.Type} to determine if it represents a
+	 * to-one {@link EORelationship}.
+	 * <p>
+	 * <em>Note:</em> if {@link #type()} has not been set, then this will return
+	 * <code>false</code>. To set it, you have the following options:
+	 * <ul>
+	 * <li>Set it manually using {@link #setType(Type)}</li>
+	 * <li>Set it using the {@link #ERXKey(String, Type)} constructor. If this
+	 * key was declared in code generated by EOGenerator (i.e. in a _Entity.java
+	 * class), you will need to modify your EOGenerator template. See
+	 * {@link #ERXKey(String, Type)} for details.</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @return <code>true</code> if {@link #type()} returns either
+	 *         {@link ERXKey.Type.ToOneRelationship} or
+	 *         {@link ERXKey.Type.NonModelToOneRelationship}, <code>false</code>
+	 *         otherwise.
+	 * 
+	 * @see isAttribute
+	 * @see isToManyRelationship
+	 */
 	public boolean isToOneRelationship() {
 		return type() == ERXKey.Type.ToOneRelationship || type() == ERXKey.Type.NonModelToOneRelationship;
 	}
 	
+	/**
+	 * Checks this key's {@link ERXKey.Type} to determine if it represents a
+	 * to-many {@link EORelationship}.
+	 * <p>
+	 * <em>Note:</em> if {@link #type()} has not been set, then this will return
+	 * <code>false</code>. To set it, you have the following options:
+	 * <ul>
+	 * <li>Set it manually using {@link #setType(Type)}</li>
+	 * <li>Set it using the {@link #ERXKey(String, Type)} constructor. If this
+	 * key was declared in code generated by EOGenerator (i.e. in a _Entity.java
+	 * class), you will need to modify your EOGenerator template. See
+	 * {@link #ERXKey(String, Type)} for details.</li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @return <code>true</code> if {@link #type()} returns either
+	 *         {@link ERXKey.Type.ToOneRelationship} or
+	 *         {@link ERXKey.Type.NonModelToOneRelationship}, <code>false</code>
+	 *         otherwise.
+	 *         
+	 * @see isAttribute
+	 * @see isToOneRelationship
+	 */
 	public boolean isToManyRelationship() {
 		return type() == ERXKey.Type.ToManyRelationship || type() == ERXKey.Type.NonModelToManyRelationship;
 	}


### PR DESCRIPTION
• Added "Operator", "NonModelAttribute", "NonModelToOneRelationship" and "NonModelToManyRelationship" Types to ERXKey and new constructors to allow them to be set when declared. (for example, by modifying the _Entity eogenerator template)

• Added valueForKey(ERXKey) to NSArray. This allows for type-safe valueForKey calls. Defaults to automatically flattens, makes distinct, and removes null values from the resulting array. This improves encapsulation and eliminates common errors caused by needing to write boilerplate code to check if the resulting array is in fact an array of arrays, or if there are null or duplicate elements.