### PR TITLE
Bugfix on resource url generation

### DIFF
--- a/Frameworks/Misc/ERJaxWS/Sources/er/extensions/appserver/ws/ERJaxWebService.java
+++ b/Frameworks/Misc/ERJaxWS/Sources/er/extensions/appserver/ws/ERJaxWebService.java
@@ -111,7 +111,7 @@ public class ERJaxWebService<T>
 
             WODynamicURL du = woRequest._uriDecomposed();
             String baseUri = String.format("%s/%s.woa/%s/%s",
-                    du.adaptorPath(),
+                    du.prefix(),
                     du.applicationName(),
                     du.requestHandlerKey(),
                     du.requestHandlerPath());


### PR DESCRIPTION
bugfix for a small stupid bug. Resource Url for WSDL relations might have been generated with wrong prefix
