### PR TITLE
Added support for 'displayVariant: omit' to ERModern

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDAttributeRepetition.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDAttributeRepetition.java
@@ -10,6 +10,7 @@ import com.webobjects.foundation.NSMutableArray;
 import er.directtoweb.ERD2WContainer;
 import er.directtoweb.ERDirectToWeb;
 import er.directtoweb.components.ERDCustomComponent;
+import er.directtoweb.pages.ERD2WPage;
 import er.extensions.appserver.ERXWOContext;
 
 /**
@@ -67,6 +68,26 @@ public class ERDAttributeRepetition extends ERDCustomComponent {
     
     public boolean hasPropertyName() {
         return !booleanValueForBinding("hidePropertyName");
+    }
+
+    /**
+     * Gets the <code>displayVariant</code> for the current property key.  The intention is that the display variant
+     * allows variation in the display method of property keys without needing different, slightly varying,
+     * <code>displayPropertyKeys</code> or <code>tabSectionsContents</code> rules.  Template support has been added for
+     * the <code>omit</code> and <code>blank</code> variants.  One could imagine others, such as <code>collapsed</code>,
+     * <code>ajax</code>, etc.
+     * @return the display variant, if specified
+     */
+    public String displayVariant() {
+        return (String)d2wContext().valueForKey(ERD2WPage.Keys.displayVariant);
+    }
+
+    /**
+     * Determines if display of the current property key should be <code>omitted</code>.
+     * @return true if key should be omitted
+     */
+    public boolean isKeyOmitted() {
+        return "omit".equals(displayVariant());
     }
 
     public NSArray<String> displayPropertyKeys() {

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDInspectPageRepetition.wo/ERMDInspectPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDInspectPageRepetition.wo/ERMDInspectPageRepetition.html
@@ -7,20 +7,22 @@
         </div>
       </webobject>
       <webobject name = "AttributeRepetition">
-        <webobject name = "LineDiv">
-          <div class = "LineInner">
-            <webobject name = "LabelWrapper">
-              <webobject name = "HasPropertyName"><webobject name = "PropertyName" /></webobject>
-              <webobject name = "HasNoPropertyName">
-                <webobject name = "EmptyLabelSpan">&#160;</webobject>
+        <webobject name = "IsNotOmitted">
+          <webobject name = "LineDiv">
+            <div class = "LineInner">
+              <webobject name = "LabelWrapper">
+                <webobject name = "HasPropertyName"><webobject name = "PropertyName" /></webobject>
+                <webobject name = "HasNoPropertyName">
+                  <webobject name = "EmptyLabelSpan">&#160;</webobject>
+                </webobject>
               </webobject>
-            </webobject>
-            <webobject name = "AttributeWrapper">
-              <span>
-                <webobject name = "SafeWrapper"><webobject name = "AttributeValue" /></webobject>
-              </span>
-            </webobject><div class="AttributeClear"></div>
-          </div>
+              <webobject name = "AttributeWrapper">
+                <span>
+                  <webobject name = "SafeWrapper"><webobject name = "AttributeValue" /></webobject>
+                </span>
+              </webobject><div class="AttributeClear"></div>
+            </div>
+          </webobject>
         </webobject>
       </webobject>
     </webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDInspectPageRepetition.wo/ERMDInspectPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDInspectPageRepetition.wo/ERMDInspectPageRepetition.wod
@@ -2,11 +2,17 @@ AttributeRepetitionDiv : WOGenericContainer {
 	elementName = "div";
 	class = d2wContext.classForAttributeRepetitionWrapper;
 }
+
 AttributeRepetition: WORepetition {
 	_unroll = true;
 	item = propertyKey;
 	list = currentSectionKeys;
 	index = index;
+}
+
+IsNotOmitted : WOConditional {
+	condition = isKeyOmitted;
+	negate = true;
 }
 
 AttributeValue: WOSwitchComponent { 
@@ -29,6 +35,7 @@ LabelWrapper : WOGenericContainer {
 	elementName = "span";
 	class = d2wContext.classForLabelSpan;
 }
+
 AttributeWrapper : WOGenericContainer {
 	elementName = "span";
 	class = d2wContext.classForAttributeValue;

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDListPageRepetition.wo/ERMDListPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDListPageRepetition.wo/ERMDListPageRepetition.html
@@ -2,7 +2,7 @@
 	<webobject name=ListTableHeaderRow>
 		<th>&nbsp;</th>
 		<webobject name=SectionRepetition><webobject name=ColumnLabelRepetition>
-				<th nowrap><webobject name = "TableHeaderSwitchComponent"/></th>
+				<webobject name = "IsNotOmitted"><th nowrap><webobject name = "TableHeaderSwitchComponent"/></th></webobject>
 			</webobject></webobject>
 		<th>&nbsp;</th>
 	</webobject>
@@ -31,7 +31,7 @@
 		</td>
 		<webobject name = "AttributeRow">
 			<webobject name=SectionRepetition><webobject name=AttributeRepetition>
-					<webobject name=AttributeCell><webobject name=AttributeDisplay></webobject></webobject>
+					<webobject name = "IsNotOmitted"><webobject name=AttributeCell><webobject name=AttributeDisplay></webobject></webobject></webobject>
 				</webobject></webobject>
 		</webobject>
 		<webobject name = "ExtraRow">

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDListPageRepetition.wo/ERMDListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDListPageRepetition.wo/ERMDListPageRepetition.wod
@@ -57,6 +57,11 @@ AttributeRepetition: WORepetition {
 	list = currentSectionKeys;
 }
 
+IsNotOmitted : WOConditional {
+	condition = isKeyOmitted;
+	negate = true;
+}
+
 ColumnLabelRepetition: WORepetition {
 	_unroll = true;
 	item = propertyKey;

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDQueryPageRepetition.wo/ERMDQueryPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDQueryPageRepetition.wo/ERMDQueryPageRepetition.html
@@ -10,16 +10,18 @@
       	<webobject name = "SectionName" />
       </webobject>
       <webobject name = "AttributeRepetition">
-      	<webobject name = "LineDiv">
-      	<div class="LineInner">
-      	<webobject name = "LabelWrapper">
-        	<webobject name = "HasPropertyName"> <webobject name = "PropertyName" /> </webobject>
-        	<webobject name = "HasNoPropertyName"><webobject name = "EmptyLabelSpan">&#160;</webobject></webobject>
-        </webobject>
-        <webobject name = "AttributeWrapper">&#160;
-        	<span><webobject name = "SafeWrapper"><webobject name = "AttributeValue" /></webobject></span>
-        </webobject>
-        </div>
+        <webobject name = "IsNotOmitted">
+          <webobject name = "LineDiv">
+          <div class="LineInner">
+          <webobject name = "LabelWrapper">
+              <webobject name = "HasPropertyName"> <webobject name = "PropertyName" /> </webobject>
+              <webobject name = "HasNoPropertyName"><webobject name = "EmptyLabelSpan">&#160;</webobject></webobject>
+          </webobject>
+          <webobject name = "AttributeWrapper">&#160;
+              <span><webobject name = "SafeWrapper"><webobject name = "AttributeValue" /></webobject></span>
+          </webobject>
+          </div>
+          </webobject>
         </webobject>
       </webobject>
     </webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDQueryPageRepetition.wo/ERMDQueryPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDQueryPageRepetition.wo/ERMDQueryPageRepetition.wod
@@ -5,6 +5,11 @@ AttributeRepetition: WORepetition {
 	index = index;
 }
 
+IsNotOmitted : WOConditional {
+	condition = isKeyOmitted;
+	negate = true;
+}
+
 AttributeRepetitionDiv : WOGenericContainer {
 	elementName = "div";
 	class = d2wContext.classForAttributeRepetitionWrapper;

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDReducedListPageRepetition.wo/ERMDReducedListPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDReducedListPageRepetition.wo/ERMDReducedListPageRepetition.html
@@ -13,7 +13,7 @@
       <webobject name = "SectionRepetition">
       <ul class="ObjAttributeList">
         <webobject name = "AttributeRepetition">
-          <webobject name = "AttColumnCell"><webobject name = "AttributeDisplay" /></webobject>
+          <webobject name = "IsNotOmitted"><webobject name = "AttColumnCell"><webobject name = "AttributeDisplay" /></webobject></webobject>
         </webobject>
       </ul>
       </webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDReducedListPageRepetition.wo/ERMDReducedListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDReducedListPageRepetition.wo/ERMDReducedListPageRepetition.wod
@@ -12,6 +12,11 @@ AttributeRepetition: WORepetition {
 	list = currentSectionKeys;
 }
 
+IsNotOmitted : WOConditional {
+	condition = isKeyOmitted;
+	negate = true;
+}
+
 ObjectsRepetition: WORepetition {
 	item = d2wContext.object;
 	list = ^displayGroup.displayedObjects;

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.html
@@ -3,8 +3,10 @@
     <webobject name = "HasLeftActionsConditional"><th class="ActionCell LftActionCell">&nbsp;</th></webobject>
     <webobject name = "SectionRepetition">
       <webobject name = "ColumnLabelRepetition">
-        <webobject name = "AttColumnHeader">
-          <webobject name = "TableHeaderSwitchComponent"/>
+        <webobject name = "IsNotOmitted">
+          <webobject name = "AttColumnHeader">
+            <webobject name = "TableHeaderSwitchComponent"/>
+          </webobject>
         </webobject>
       </webobject>
     </webobject>
@@ -23,7 +25,7 @@
       </webobject>
       <webobject name = "SectionRepetition">
         <webobject name = "AttributeRepetition">
-          <webobject name = "AttColumnCell"><webobject name = "AttributeDisplay" /></webobject>
+          <webobject name = "IsNotOmitted"><webobject name = "AttColumnCell"><webobject name = "AttributeDisplay" /></webobject></webobject>
         </webobject>
       </webobject>
       <webobject name = "HasRightActionsConditional">

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.wod
@@ -12,6 +12,11 @@ AttributeRepetition: WORepetition {
 	list = currentSectionKeys;
 }
 
+IsNotOmitted : WOConditional {
+	condition = isKeyOmitted;
+	negate = true;
+}
+
 ColumnLabelRepetition: WORepetition {
 	_unroll = true;
 	item = propertyKey;


### PR DESCRIPTION
This handles only the 'omit' variant, not the CSS manipulation. See the original commit by Travis Cripps: https://github.com/wocommunity/wonder/commit/0aa09a0cef93772fa7ba4629babac5130ff11a83
