### PR TITLE
Include the additional mime types contributed by the ERXResourceManager class when asking for the content types dictionary

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXResourceManager.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXResourceManager.java
@@ -22,6 +22,7 @@ import com.webobjects.foundation.NSPathUtilities;
 import com.webobjects.foundation._NSStringUtilities;
 import com.webobjects.foundation._NSThreadsafeMutableDictionary;
 
+import er.extensions.foundation.ERXDictionaryUtilities;
 import er.extensions.foundation.ERXFileUtilities;
 import er.extensions.foundation.ERXMutableURL;
 import er.extensions.foundation.ERXProperties;
@@ -237,6 +238,18 @@ public class ERXResourceManager extends WOResourceManager {
 			wourlvaluedelementdata = cachedDataForKey(key);
 		}
 		return wourlvaluedelementdata;
+	}
+
+	/**
+	 * Overrides the original implementation appending the additionalMimeTypes to the content types dictionary.
+	 *
+	 * @return a dictionary containing the original mime types supported along with the additional mime types
+	 * contributed by this class.
+	 * @see com.webobjects.appserver.WOResourceManager#_contentTypesDictionary()
+	 */
+	@Override
+	public NSDictionary _contentTypesDictionary() {
+		return ERXDictionaryUtilities.dictionaryWithDictionaryAndDictionary(_mimeTypes, super._contentTypesDictionary());
 	}
 
 	/**


### PR DESCRIPTION
Without this fix, the _contentTypesDictionary method returns a dictionary containing only the mime types provided by the original WOResourceManager class. This fix includes the additional mime types into the content types dictionary.
