### PR TITLE
Bugfix for first migration when using ERXJDBCAdaptor

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXJDBCMigrationLock.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXJDBCMigrationLock.java
@@ -145,6 +145,7 @@ public class ERXJDBCMigrationLock implements IERXMigrationLock {
 		}
 		catch (Exception e) {
 			channel.adaptorContext().rollbackTransaction();
+			channel.adaptorContext().beginTransaction();
 			String createTableStatement = dbUpdaterCreateStatement(model, adaptor);
 			if (createTableIfMissing) {
 				try {


### PR DESCRIPTION
<b>Problem:</b> When starting an application with an empty database and the default adaptor, the _dbupdater table will be created automatically by ERXJDBCMigrationLock. However when using ERXJDBCAdaptor with a connection broker, this fails due to a NullPointerException. To test this the following properties must be set and the application must be started with an empty database.

<pre>
er.extensions.ERXJDBCAdaptor.className=er.extensions.jdbc.ERXJDBCAdaptor
er.extensions.ERXJDBCAdaptor.useConnectionBroker=true
</pre>


<b>Analysis:</b> The NPE happens because the context doesn't have a connection anymore, when trying to create the _dbupdater table (ERXJDBCMigrationLock._tryLock, last catch-block). This is because ERXJDBCAdaptor.Context.transactionDidRollback calls freeConnection, which simply sets _jdbcConnection to null when using connection broker.

<b>Solution:</b> Start a new transaction directly after rolling back the previous one. Actually it would be sufficient to begin the new transaction right before creating _dbupdater (so only if createTableIfMissing), but doing it after rollbackTransaction seems safer with future extensions in mind. The change has been tested successfully with the default adaptor and with ERXJDBCAdaptor (with and without a connection broker).
