### PR TITLE
Unlock editing contexts disposed by the ERXRouteController

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
@@ -1822,6 +1822,7 @@ public class ERXRouteController extends WODirectAction {
 	 */
 	public void dispose() {
 		if (_shouldDisposeEditingContext && _editingContext != null) {
+			ERXEC.unlockAllContextsForCurrentThread();
 			_editingContext.dispose();
 			_editingContext = null;
 		}


### PR DESCRIPTION
The ERXRouteController disposes the editing context at the end of the request handling. If the editing context is autoLocked during the request, at least one lock will remain open at disposal time (because of the coalesceAutoLocks property). This change unlocks the editing context before disposing it, avoiding inaccurate warnings when the tracing open locks option is enabled.
