### PR TITLE
Revert change caused "Should pop, but ec not found in Vector" errors in ...

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
@@ -1822,7 +1822,6 @@ public class ERXRouteController extends WODirectAction {
 	 */
 	public void dispose() {
 		if (_shouldDisposeEditingContext && _editingContext != null) {
-			ERXEC.unlockAllContextsForCurrentThread();
 			_editingContext.dispose();
 			_editingContext = null;
 		}


### PR DESCRIPTION
Reverted change caused "Should pop, but ec not found in Vector" errors in RestAPI.
- ERXApplication._endRequest() will call ERXEC.unlockAllContextsForCurrentThread() at proper time
- It's became to be possible to have unlocked ECs, not being disposed by this RouteController. It's causes unexpected side effects
