### PR TITLE
Unlock the editing context disposed by the ERXRouteController

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteController.java
@@ -1822,6 +1822,10 @@ public class ERXRouteController extends WODirectAction {
 	 */
 	public void dispose() {
 		if (_shouldDisposeEditingContext && _editingContext != null) {
+			if(_editingContext instanceof ERXEC && ((ERXEC) _editingContext).isAutoLocked()) {
+				_editingContext.unlock();
+			}
+
 			_editingContext.dispose();
 			_editingContext = null;
 		}


### PR DESCRIPTION
The ERXRouteController disposes the editing context at the end of the route request handling. If the editing context is autoLocked during the request, at least one lock will remain open at disposal time (because of the coalesceAutoLocks property). This change unlocks the editing context before disposing it, avoiding inaccurate warnings when the tracing open locks option is enabled.

`ERROR er.extensions.eof.ERXEC  - ERXEC@1877591773 Disposed with 1 locks (finalizing = false)`

Which was created by the ERXRouteController:

``` java
ERROR er.extensions.eof.ERXEC  - ERXEC@1877591773 Created:
java.lang.Exception: Creation
    at er.extensions.eof.ERXEC.<init>(ERXEC.java:471)
    at sun.reflect.GeneratedConstructorAccessor28.newInstance(Unknown Source)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
    at er.extensions.eof.ERXEC$DefaultFactory._createEditingContext(ERXEC.java:1807)
    at er.extensions.eof.ERXEC$DefaultFactory._newEditingContext(ERXEC.java:1741)
    at er.extensions.eof.ERXEC$DefaultFactory._newEditingContext(ERXEC.java:1720)
    at er.extensions.eof.ERXEC.newEditingContext(ERXEC.java:1874)
    at er.rest.routes.ERXRouteController.newEditingContext(ERXRouteController.java:264)
    at er.rest.routes.ERXRouteController.editingContext(ERXRouteController.java:252)
```

This solution is more specific than the solution provided in the pull request #593 and reverted by the pull request #594. It unlocks ONLY the editing context created by the ERXRouteController, rather than unlocking all editing contexts in the current thread.
