### PR TITLE
Update maven pom to reflect classpath changes introduced in 68e8e60.

### DIFF
--- a/Frameworks/Core/ERExtensions/pom.xml
+++ b/Frameworks/Core/ERExtensions/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>JavaWOJSPServlet</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.webobjects</groupId>
+            <artifactId>JavaWebServicesSupport</artifactId>
+            <version>${webobjects.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
         </dependency>


### PR DESCRIPTION
Without this, the maven build fails.
