### PR TITLE
Bug fix in ERXRestFetchSpecification

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestFetchSpecification.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestFetchSpecification.java
@@ -433,7 +433,7 @@ public class ERXRestFetchSpecification<T extends EOEnterpriseObject> {
 				else {
 					range = new NSRange(offset, length);
 				}
-				results = objects.subarrayWithRange(range);
+				results = results.subarrayWithRange(range);
 			}
 		}
 		return results;


### PR DESCRIPTION
Just a small patch to ERXRestFetchSpecification. The method was filtering and sorting objects but then discarding what done so far by getting the subarray of the original parameter instead of the results array.
