### PR TITLE
Disabling ERXShutdownHook by default

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -859,7 +859,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	
 	// You should not use ERXShutdownHook when deploying as servlet.
 	protected static boolean enableERXShutdownHook() {
-		return ERXProperties.booleanForKeyWithDefault("er.extensions.ERXApplication.enableERXShutdownHook", false);
+		return ERXProperties.booleanForKeyWithDefault("er.extensions.ERXApplication.enableERXShutdownHook", true);
 	}
 
 	/**

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -866,7 +866,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	 * Called when the application starts up and saves the command line
 	 * arguments for {@link ERXConfigurationManager}.
 	 * 
-	 * @see WOApplication#String[], Class)
+	 * @see WOApplication#main(String[], Class)
 	 */
 	public static void main(String argv[], Class applicationClass) {
 		setup(argv);

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -111,6 +111,7 @@ import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXRuntimeUtilities;
 import er.extensions.foundation.ERXThreadStorage;
 import er.extensions.foundation.ERXTimestampUtilities;
+import er.extensions.foundation.ERXValueUtilities;
 import er.extensions.localization.ERXLocalizer;
 import er.extensions.migration.ERXMigrator;
 import er.extensions.statistics.ERXStats;
@@ -138,6 +139,7 @@ import er.extensions.statistics.ERXStats;
  * @property er.extensions.ERXApplication.StatisticsLogRotationFrequency
  * @property er.extensions.ERXApplication.developmentMode
  * @property er.extensions.ERXApplication.developmentMode
+ * @property er.extensions.ERXApplication.enableERXShutdownHook
  * @property er.extensions.ERXApplication.fixCachingEnabled
  * @property er.extensions.ERXApplication.lowMemBufferSize
  * @property er.extensions.ERXApplication.memoryLowThreshold
@@ -854,15 +856,25 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 		}
 	}
 	}
+	
+	// You should not use ERXShutdownHook when deploying as servlet.
+	protected static boolean enableERXShutdownHook() {
+		return ERXProperties.booleanForKeyWithDefault("er.extensions.ERXApplication.enableERXShutdownHook", false);
+	}
 
 	/**
 	 * Called when the application starts up and saves the command line
 	 * arguments for {@link ERXConfigurationManager}.
 	 * 
-	 * @see WOApplication#main(String[], Class)
+	 * @see WOApplication#String[], Class)
 	 */
 	public static void main(String argv[], Class applicationClass) {
 		setup(argv);
+		
+		if(enableERXShutdownHook()) {
+			ERXShutdownHook.initERXShutdownHook();
+		}
+
 		WOApplication.main(argv, applicationClass);
 	}
 
@@ -1047,7 +1059,10 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 		ERXConfigurationManager.defaultManager().setCommandLineArguments(argv);
 		ERXFrameworkPrincipal.setUpFrameworkPrincipalClass(ERXExtensions.class);
 		// NSPropertiesCoordinator.loadProperties();
-		ERXShutdownHook.useMe();
+		
+		if(enableERXShutdownHook()) {
+			ERXShutdownHook.useMe();
+		}
 	}
 
 	/**

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -1047,6 +1047,17 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	}
 
 	/**
+	 * This heuristic to determine if an application is deployed as servlet relays on the fact, 
+	 * that contextClassName() is set WOServletContext or ERXWOServletContext
+	 * 
+	 * @return true if the application is deployed as servlet.
+	 */
+	public boolean isDeployedAsServlet() {
+		return contextClassName().contains("Servlet"); // i.e one of WOServletContext or ERXWOServletContext
+	}
+
+
+	/**
 	 * Called prior to actually initializing the app. Defines framework load
 	 * order, class path order, checks patches etc.
 	 */
@@ -1064,7 +1075,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 			ERXShutdownHook.useMe();
 		}
 	}
-
+	
 	/**
 	 * Installs several bugfixes and enhancements to WODynamicElements. Sets the
 	 * Context class name to "er.extensions.ERXWOContext" if it is "WOContext".

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXShutdownHook.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXShutdownHook.java
@@ -33,10 +33,10 @@ import java.util.Set;
  *
  * <b>CAUTION</b><br><br>
  * You should not use this class when deploying the application as a J2EE servlet as it may interfere with other servlets running in the same VM. 
- * To enable this feature you have to provide the following start parameter to the java VM:
+ * To disable this feature you have to provide the following start parameter to the java VM:
  * 
  * <code>
- * -Der.extensions.ERXApplication.enableERXShutdownHook=true
+ * -Der.extensions.ERXApplication.enableERXShutdownHook=false
  * </code><br>
  *
  * @author Maik Musall, maik@selbstdenker.ag

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXShutdownHook.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXShutdownHook.java
@@ -29,6 +29,15 @@ import java.util.Set;
  *     }
  * };
  * </pre></blockquote></p>
+ * 
+ *
+ * <b>CAUTION</b><br><br>
+ * You should not use this class when deploying the application as a J2EE servlet as it may interfere with other servlets running in the same VM. 
+ * To enable this feature you have to provide the following start parameter to the java VM:
+ * 
+ * <code>
+ * -Der.extensions.ERXApplication.enableERXShutdownHook=true
+ * </code><br>
  *
  * @author Maik Musall, maik@selbstdenker.ag
  *
@@ -37,7 +46,8 @@ public abstract class ERXShutdownHook extends Thread {
 
 	static final Set<ERXShutdownHook> ALL_HOOKS = new HashSet<ERXShutdownHook>();
 	
-	static {
+	public static void initERXShutdownHook() {
+		System.out.println( "WILL ADD SHUTDOWNHOOK" );
 		Runtime.getRuntime().addShutdownHook( new Thread() {
 			@Override
 			public void run() {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXConfigurationManager.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXConfigurationManager.java
@@ -398,7 +398,7 @@ public class ERXConfigurationManager {
     }    
     
     /**
-     * Checks if the application is deployed as a servlet.
+     * Checks if the application <del>is</del> may be deployed as a servlet.
      * <p>
      * The current implementation only checks if the application  
      * is linked against <code>JavaWOJSPServlet.framework</code>. 


### PR DESCRIPTION
This patch disables the ERXShutdownHook by default.

The reason is, that ERXShutdownHook does not make any sense when you deploy the application in a servlet container:

When stopping a servlet, no shutdownHook notification will be send. If you relay on ERXShutdownHook to stop background tasks/threads, the application will only terminated completely, when you shutdown the whole application server. In real deployment scenarios, this is often not an option.

So, in servlet context, you have to relay on ApplicationWillTerminateNotification  instead. 

In addition, executing static code in a servlet is considered as bad practice, as the code effects not only the current servlet, but all the other servlets running in the same java VM.

To activate the ERXShutdownHook again, you should add 

-Der.extensions.ERXApplication.enableERXShutdownHook=true

to the VM start options.

Regards
    René
