### PR TITLE
Alternate Header for  "x-forwarded-proto"

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
@@ -39,6 +39,7 @@ public  class ERXRequest extends WORequest {
     public static final String UNKNOWN_HOST = "UNKNOWN";
 
     public static final String X_FORWARDED_PROTO_FOR_SSL = ERXProperties.stringForKeyWithDefault("er.extensions.appserver.ERXRequest.xForwardedProtoForSsl", "https");
+    public static final String X_FORWARDED_PROTO_HEADER_KEY_FOR_SSL = ERXProperties.stringForKeyWithDefault("er.extensions.appserver.ERXRequest.xForwardedProtoHeaderKeyForSsl", "x-forwarded-proto");
 
     protected static Boolean isBrowserFormValueEncodingOverrideEnabled;
 
@@ -337,7 +338,7 @@ public  class ERXRequest extends WORequest {
 	        
 	        // Check if we've got an x-forwarded-proto header which is typically sent by a load balancer that is 
 	        // implementing ssl termination to indicate the request on the public side of the load balancer is secure.
-	        else if (X_FORWARDED_PROTO_FOR_SSL.equals(request.headerForKey("x-forwarded-proto"))) {
+	        else if (X_FORWARDED_PROTO_FOR_SSL.equals(request.headerForKey(X_FORWARDED_PROTO_HEADER_KEY_FOR_SSL))) {
 	    		isRequestSecure = true;
 	        }
         }


### PR DESCRIPTION
An _x-forwarded-proto_ header which is typically sent by a load balancer that is implementing ssl termination to indicate the request on the public side of the load balancer is secure.

But there are cases (e.g. the combo "IHS" (= IBM Apache Clone) and "WebSphere" ) where an other header is sent instead (e.g.  _$wssc_)

This patch allows to define the name of the header via the property

```
er.extensions.appserver.ERXRequest.xForwardedProtoHeaderKeyForSsl=x-forwarded-proto
```
