### PR TITLE
ERComponentTour : Missing prinzipals

### DIFF
--- a/Examples/Misc/ERComponentTour/build.properties
+++ b/Examples/Misc/ERComponentTour/build.properties
@@ -1,11 +1,13 @@
+#Thu Dec 04 23:02:16 CET 2014
 classes.dir=bin
+component.inlineBindingPrefix=$
+component.inlineBindingSuffix=
+component.wellFormedTemplateRequired=false
+customInfoPListContent=
+eoAdaptorClassName=
+principalClass=er.examples.Application
 project.name=ERComponentTour
 project.name.lowercase=ercomponenttour
 project.type=application
-principalClass=er.examples..Application
-customInfoPListContent=
 webXML=false
 webXML_CustomContent=
-component.wellFormedTemplateRequired=false
-component.inlineBindingPrefix=$
-component.inlineBindingSuffix=

--- a/Frameworks/Core/JavaWOExtensions/Sources/com/webobjects/woextensions/JavaWOExtensionPrincipal.java
+++ b/Frameworks/Core/JavaWOExtensions/Sources/com/webobjects/woextensions/JavaWOExtensionPrincipal.java
@@ -1,0 +1,6 @@
+package com.webobjects.woextensions;
+
+
+public class JavaWOExtensionPrincipal  {
+
+}

--- a/Frameworks/Core/JavaWOExtensions/build.properties
+++ b/Frameworks/Core/JavaWOExtensions/build.properties
@@ -1,11 +1,14 @@
-#Mon Jun 12 13:51:51 CEST 2006
-webXML_CustomContent=
-project.name=JavaWOExtensions
-webXML=false
-eoAdaptorClassName=
-principalClass=
-use.wonder.core=false
+#Thu Dec 04 23:49:10 CET 2014
+component.inlineBindingPrefix=[
+component.inlineBindingSuffix=]
+component.wellFormedTemplateRequired=true
 customInfoPListContent=
+eoAdaptorClassName=
+eogeneratorArgs=
+principalClass=com.webobjects.woextensions.JavaWOExtensionPrincipal
+project.name=JavaWOExtensions
 project.principal.class=
 project.type=framework
-eogeneratorArgs=
+use.wonder.core=false
+webXML=false
+webXML_CustomContent=

--- a/Frameworks/Misc/ERCaptcha/Sources/er/captcha/ERCaptchaPrincipal.java
+++ b/Frameworks/Misc/ERCaptcha/Sources/er/captcha/ERCaptchaPrincipal.java
@@ -1,0 +1,18 @@
+package er.captcha;
+
+import er.extensions.ERXExtensions;
+import er.extensions.ERXFrameworkPrincipal;
+
+public class ERCaptchaPrincipal extends ERXFrameworkPrincipal {
+	public final static Class<?>[] REQUIRES = new Class[] { ERXExtensions.class };
+
+	static {
+		setUpFrameworkPrincipalClass(ERCaptchaPrincipal.class);
+	}
+
+	@Override
+	public void finishInitialization() {
+
+	}
+
+}

--- a/Frameworks/Misc/ERCaptcha/build.properties
+++ b/Frameworks/Misc/ERCaptcha/build.properties
@@ -1,6 +1,10 @@
-classes.dir = bin
-project.name = ERCaptcha
-project.type = framework
-principalClass =
-customInfoPListContent =
-eoAdaptorClassName =
+#Thu Dec 04 23:17:02 CET 2014
+classes.dir=bin
+component.inlineBindingPrefix=[
+component.inlineBindingSuffix=]
+component.wellFormedTemplateRequired=true
+customInfoPListContent=
+eoAdaptorClassName=
+principalClass=er.captcha.ERCaptchaPrincipal
+project.name=ERCaptcha
+project.type=framework


### PR DESCRIPTION
When starting the ERComponentTour example, I came across the following log messages:

Dez 01 17:32:42 N/A[N/A] WARN  NSLog  - Principal class '' not found in bundle JavaWOExtensions
Dez 01 17:32:42 N/A[N/A] WARN  NSLog  - Principal class '' not found in bundle ERCaptcha
Dez 01 17:32:42 N/A[N/A] WARN  NSLog  - Principal class 'er.examples..Application' not found in bundle ERComponentTour

The following pull request will eliminate them...