### PR TITLE
changes to ERXMigrator to prevent a model that is listed in the skipMode...

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrator.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrator.java
@@ -167,7 +167,7 @@ public class ERXMigrator {
 	@SuppressWarnings("unchecked")
 	public void migrateToLatest() {
 		EOModelGroup modelGroup = EOModelGroup.defaultGroup();
-		NSArray<String> modelNames;
+		NSArray<String> modelNames = NSArray.EmptyArray;
 		String modelNamesStr = ERXProperties.stringForKey("er.migration.modelNames");
 		if (modelNamesStr == null) {
 			ERXMigrator.log.warn("er.migration.modelNames is not set, defaulting to modelGroup.models() order instead.");
@@ -181,6 +181,7 @@ public class ERXMigrator {
 		if (skipModelNamesStr != null) {
 			skipModelNames = NSArray.componentsSeparatedByString(skipModelNamesStr, ",");
 		}
+
 		Map<IERXMigration, ERXModelVersion> migrations = _buildDependenciesForModelsNamed(modelNames, skipModelNames);
 
 		Map<IERXPostMigration, ERXModelVersion> postMigrations = new LinkedHashMap<IERXPostMigration, ERXModelVersion>();
@@ -259,7 +260,9 @@ public class ERXMigrator {
 	}
 
 	protected Map<IERXMigration, ERXModelVersion> _buildDependenciesForModelsNamed(NSArray<String> modelNames, NSArray<String> skipModelNames) {
+		
 		Map<IERXMigration, ERXModelVersion> migrations = new LinkedHashMap<IERXMigration, ERXModelVersion>();
+
 		try {
 			Map<String, Integer> versions = new HashMap<String, Integer>();
 
@@ -272,7 +275,7 @@ public class ERXMigrator {
 					if (model == null) {
 						throw new IllegalArgumentException("There is no model named '" + modelName + "' in this model group.");
 					}
-					_buildDependenciesForModel(model, ERXMigrator.LATEST_VERSION, versions, migrations);
+					_buildDependenciesForModel(model, ERXMigrator.LATEST_VERSION, versions, migrations, skipModelNames);
 				}
 			}
 
@@ -289,7 +292,7 @@ public class ERXMigrator {
 						EOEntity parentEntity = entity.parentEntity();
 						if (parentEntity != null && !parentEntity.model().equals(model)) {
 							EOModel parentModel = parentEntity.model();
-							_buildDependenciesForModel(parentModel, LATEST_VERSION, versions, migrations);
+							_buildDependenciesForModel(parentModel, LATEST_VERSION, versions, migrations, skipModelNames);
 						}
 						Enumeration relationshipsEnum = entity.relationships().objectEnumerator();
 						while (relationshipsEnum.hasMoreElements()) {
@@ -297,11 +300,11 @@ public class ERXMigrator {
 							EOEntity destinationEntity = relationship.destinationEntity();
 							if (destinationEntity != null && !destinationEntity.model().equals(model)) {
 								EOModel destinationModel = destinationEntity.model();
-								_buildDependenciesForModel(destinationModel, LATEST_VERSION, versions, migrations);
+								_buildDependenciesForModel(destinationModel, LATEST_VERSION, versions, migrations, skipModelNames);
 							}
 						}
 					}
-					_buildDependenciesForModel(model, LATEST_VERSION, versions, migrations);
+					_buildDependenciesForModel(model, LATEST_VERSION, versions, migrations, skipModelNames);
 					processedModelNames.add(modelName);
 				}
 				pendingModelNames.addAll(versions.keySet());
@@ -335,12 +338,17 @@ public class ERXMigrator {
 		return false;
 	}
 	
-	protected void _buildDependenciesForModel(EOModel model, int migrateToVersion, Map<String, Integer> versions, Map<IERXMigration, ERXModelVersion> migrations) throws InstantiationException, IllegalAccessException {
+	protected void _buildDependenciesForModel(EOModel model, int migrateToVersion, Map<String, Integer> versions, Map<IERXMigration, ERXModelVersion> migrations,  NSArray<String> skipModelNames) throws InstantiationException, IllegalAccessException {
 		if (!canMigrateModel(model)) {
 			return;
 		}
-		
+
 		String modelName = model.name();
+		
+		if (skipModelNames.containsObject(modelName)) {
+			log.error(modelName + " was in skipModelNames, but got passed to the _buildDependenciesForModel anyway...");
+			return;
+		}
 
 		Integer migratorVersion = versions.get(modelName);
 		if (migratorVersion == null) {
@@ -374,7 +382,7 @@ public class ERXMigrator {
 							ERXModelVersion modelVersion = migrationDependenciesEnum.nextElement();
 							EOModel dependsOnModel = modelVersion.model();
 							int dependsOnVersion = modelVersion.version();
-							_buildDependenciesForModel(dependsOnModel, dependsOnVersion, versions, migrations);
+							_buildDependenciesForModel(dependsOnModel, dependsOnVersion, versions, migrations,  skipModelNames);
 						}
 					}
 

--- a/Frameworks/Misc/ERPDFGeneration/Documentation/README
+++ b/Frameworks/Misc/ERPDFGeneration/Documentation/README
@@ -1,9 +1,13 @@
 ERPDFGeneration provides both a utility class and a wrapper component for generating
-PDF documents from XHTML markup. Two PDF generation engines are currently supported, 
+PDF documents from XHTML markup. Three PDF generation engines are currently supported, 
 FlyingSaucer (xhtmlrenderer) [1] and Useful Java Application Components (UJAC) [2],
-however additional parser based engines like FOP could be added fairly easily. 
+and Apache FOP (Formatting Objects Processor) [3].
 This is still experimental and the API may change as it evolves. You should test
 thoroughly before using this in production.  
 
+See the ERPDFExamples application in Examples/Misc/ERPDFExamples for demonstrations
+and sample code to render XHTML and XML to PDF. 
+
 [1] http://xhtmlrenderer.dev.java.net/ 
 [2] http://ujac.sourceforge.net/
+[3] http://xmlgraphics.apache.org/fop/


### PR DESCRIPTION
...ls property from being included in the migrations map.

I added the skipModelNames array to _buildDependenciesForModel so that I didn't have to find that again, but if the model to be skipped is included in the dependency tree somewhere, _buildDependenciesForModel will exit early.
I'm treating the skipModels property as the final word, assuming that there is a reason to skip the migration and if that model is found as a dependency in another model, then you still would not want it to be part of the migration.