### PR TITLE
update openbase prototypes so that they do not use "VARCHAR" as the exte...

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -1895,6 +1895,50 @@ public class ERXSQLHelper {
 			// Openbase support for limiting result set
 			return sql + " return results " + start + " to " + end;
 		}
+		
+		/* OpenBase can only apply a index to one column at a time
+		 * OpenBase does not have named indexes
+		 * OpenBase will not accept an ALTER TABLE command where the table name is in quotes
+		 */
+		
+		public String sqlForCreateIndex(String tableName, String columnName, boolean uniqueIndex) {
+			
+			StringBuilder _builder = new StringBuilder("create ");
+			if (uniqueIndex)
+				_builder.append("unique ");
+			_builder.append("index " + tableName + " " + columnName);
+			
+			return _builder.toString();
+		}
+		
+		@Override
+		public String sqlForCreateUniqueIndex(String indexName, String tableName, ColumnIndex... columnIndexes) {
+			NSArray<String> columnNames = columnNamesFromColumnIndexes(columnIndexes);
+			String _onlyColumnName = columnNames.objectAtIndex(0);
+			return sqlForCreateIndex(tableName, _onlyColumnName, true);
+		}
+		
+		@Override
+		public String sqlForCreateIndex(String indexName, String tableName, ColumnIndex... columnIndexes) {
+			NSArray<String> columnNames = columnNamesFromColumnIndexes(columnIndexes);
+			String _onlyColumnName = columnNames.objectAtIndex(0);
+			return sqlForCreateIndex(tableName, _onlyColumnName, false);
+		}
+		
+		public String externalTypeForJDBCType(JDBCAdaptor adaptor, int jdbcType) {
+			
+			String _externalType = null;
+			switch (jdbcType) {
+			case Types.FLOAT:
+				_externalType = "float";
+				break;
+
+			default:
+				_externalType = super.externalTypeForJDBCType(adaptor, jdbcType);
+				break;
+			}
+			return _externalType;
+		}
 	}
 	
 	public static class H2SQLHelper extends ERXSQLHelper {

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCOpenBasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCOpenBasePrototypes.plist
@@ -37,7 +37,7 @@
         {
             adaptorValueConversionMethodName = toCryptoString; 
             columnName = cryptoString; 
-            externalType = VARCHAR; 
+            externalType = varchar; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = cryptoString; 
             valueClassName = "er.extensions.crypting.ERXCryptoString"; 
@@ -128,7 +128,7 @@
         }, 
         {
             columnName = ""; 
-            externalType = VARCHAR; 
+            externalType = varchar; 
             name = ipAddress; 
             valueClassName = NSString; 
             valueType = S; 
@@ -137,7 +137,7 @@
         {
             adaptorValueConversionMethodName = name; 
             columnName = ""; 
-            externalType = VARCHAR; 
+            externalType = varchar; 
             factoryMethodArgumentType = EOFactoryMethodArgumentIsNSString; 
             name = javaEnum; 
             valueClassName = "java.lang.Enum"; 

--- a/Frameworks/PlugIns/OpenBaseWOPKPlugIn/Sources/com/webobjects/jdbcadaptor/_OpenBasePlugIn.java
+++ b/Frameworks/PlugIns/OpenBaseWOPKPlugIn/Sources/com/webobjects/jdbcadaptor/_OpenBasePlugIn.java
@@ -398,6 +398,14 @@ public class _OpenBasePlugIn extends JDBCPlugIn {
 			return createStatements.arrayByAddingObjectsFromArray(otherStatements);
 		}
 		
+		public NSArray statementsToConvertColumnType(String columnName, String tableName, EOSchemaSynchronization.ColumnTypes type, EOSchemaSynchronization.ColumnTypes newType, EOSchemaGenerationOptions options) {
+     return new NSArray(this._expressionForString("alter table " + tableName + " add column " + columnName + " " + newType.name()));
+   }
+   
+   public NSArray statementsToDeleteColumnNamed(String columnName, String tableName, EOSchemaGenerationOptions options) {
+     return new NSArray(this._expressionForString("alter table " + tableName + " remove column " + columnName));
+		      }
+		
 		public NSArray statementsToModifyColumnNullRule(String columnName, String tableName, boolean allowsNull, EOSchemaGenerationOptions options) {
 			return new NSArray(this._expressionForString("alter table " + tableName + " add column " + columnName + " set " + (allowsNull ? "null" : "not null")));
 		}


### PR DESCRIPTION
...rnal type. This eliminates errors like "*** JDBCAdaptor : no type info found for VARCHAR"