### PR TITLE
Changes to make use of EOSchemaSynchronizationFactory

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOAccessUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOAccessUtilities.java
@@ -36,6 +36,7 @@ import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.eoaccess.EOSQLExpression;
 import com.webobjects.eoaccess.EOSQLExpressionFactory;
 import com.webobjects.eoaccess.EOUtilities;
+import com.webobjects.eoaccess.synchronization.EOSchemaGenerationOptions;
 import com.webobjects.eocontrol.EOAndQualifier;
 import com.webobjects.eocontrol.EOClassDescription;
 import com.webobjects.eocontrol.EOEditingContext;
@@ -708,9 +709,9 @@ public class ERXEOAccessUtilities {
      * @return a <code>String</code> containing SQL statements to create
 	 *         tables
      * 
-     * @see er.extensions.jdbc.ERXSQLHelper#createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray, String, NSDictionary)
+     * @see er.extensions.jdbc.ERXSQLHelper#createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray, String, EOSchemaGenerationOptions)
      */
-    public static String createSchemaSQLForEntitiesInModelWithNameAndOptionsForOracle9(NSArray entities, String modelName, NSDictionary optionsCreate) {
+    public static String createSchemaSQLForEntitiesInModelWithNameAndOptionsForOracle9(NSArray entities, String modelName, EOSchemaGenerationOptions optionsCreate) {
         EODatabaseContext dc = EOUtilities.databaseContextForModelNamed(ERXEC.newEditingContext(), modelName);
         return ERXSQLHelper.newSQLHelper(dc).createSchemaSQLForEntitiesInModelWithNameAndOptions(entities, modelName, optionsCreate);
     }
@@ -746,7 +747,7 @@ public class ERXEOAccessUtilities {
      * @deprecated
      */
     @Deprecated
-    public static String createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray entities, String modelName, NSDictionary optionsCreate) {
+    public static String createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray entities, String modelName, EOSchemaGenerationOptions optionsCreate) {
         EODatabaseContext dc = EOUtilities.databaseContextForModelNamed(ERXEC.newEditingContext(), modelName);
         return ERXSQLHelper.newSQLHelper(dc).createSchemaSQLForEntitiesInModelWithNameAndOptions(entities, modelName, optionsCreate);
     }
@@ -761,7 +762,7 @@ public class ERXEOAccessUtilities {
      * @deprecated
      */
     @Deprecated
-    public static String createSchemaSQLForEntitiesWithOptions(NSArray entities, EODatabaseContext databaseContext, NSDictionary optionsCreate) {
+    public static String createSchemaSQLForEntitiesWithOptions(NSArray entities, EODatabaseContext databaseContext, EOSchemaGenerationOptions optionsCreate) {
     	return ERXSQLHelper.newSQLHelper(databaseContext).createSchemaSQLForEntitiesWithOptions(entities, databaseContext, optionsCreate);
     }
     

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -34,9 +34,9 @@ import com.webobjects.eoaccess.EOQualifierSQLGeneration;
 import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.eoaccess.EOSQLExpression;
 import com.webobjects.eoaccess.EOSQLExpressionFactory;
-import com.webobjects.eoaccess.EOSchemaGeneration;
-import com.webobjects.eoaccess.EOSynchronizationFactory;
 import com.webobjects.eoaccess.EOUtilities;
+import com.webobjects.eoaccess.synchronization.EOSchemaGenerationOptions;
+import com.webobjects.eoaccess.synchronization.EOSchemaSynchronizationFactory;
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOFetchSpecification;
 import com.webobjects.eocontrol.EOObjectStoreCoordinator;
@@ -46,7 +46,6 @@ import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSForwardException;
 import com.webobjects.foundation.NSMutableArray;
-import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSSelector;
 import com.webobjects.foundation.NSSet;
 import com.webobjects.foundation.NSTimestamp;
@@ -121,7 +120,7 @@ public class ERXSQLHelper {
 	 * @return a <code>String</code> containing SQL statements to create
 	 *         tables
 	 */
-	public String createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray<EOEntity> entities, String modelName, NSDictionary optionsCreate) {
+	public String createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray<EOEntity> entities, String modelName, EOSchemaGenerationOptions optionsCreate) {
 		EOModel m = ERXEOAccessUtilities.modelGroup(null).modelNamed(modelName);
 		return createSchemaSQLForEntitiesInModelAndOptions(entities, m, optionsCreate);
 	}
@@ -170,7 +169,7 @@ public class ERXSQLHelper {
 	 *         tables
 	 */
 	@SuppressWarnings("unchecked")
-	public String createSchemaSQLForEntitiesInModelAndOptions(NSArray<EOEntity> entities, EOModel model, NSDictionary optionsCreate) {
+	public String createSchemaSQLForEntitiesInModelAndOptions(NSArray<EOEntity> entities, EOModel model, EOSchemaGenerationOptions optionsCreate) {
 		EOEditingContext ec = ERXEC.newEditingContext();
 		ec.lock();
 		try {
@@ -217,7 +216,7 @@ public class ERXSQLHelper {
 	 *            createSchemaSQLForEntitiesInModelWithNameAndOptions)
 	 * @return a sql script
 	 */
-	public String createSchemaSQLForEntitiesWithOptions(NSArray<EOEntity> entities, EODatabaseContext databaseContext, NSDictionary<String, String> optionsCreate) {
+	public String createSchemaSQLForEntitiesWithOptions(NSArray<EOEntity> entities, EODatabaseContext databaseContext, EOSchemaGenerationOptions optionsCreate) {
 		return createSchemaSQLForEntitiesWithOptions(entities, databaseContext.adaptorContext().adaptor(), optionsCreate);
 	}
 
@@ -230,18 +229,19 @@ public class ERXSQLHelper {
 	 * @return the sql script
 	 */
 	public String createDependentSchemaSQLForEntities(NSArray<EOEntity> entities, EOAdaptor adaptor) {
-		NSMutableDictionary<String, String> optionsCreateTables = new NSMutableDictionary<String, String>();
-		optionsCreateTables.setObjectForKey("NO", EOSchemaGeneration.DropTablesKey);
-		optionsCreateTables.setObjectForKey("NO", EOSchemaGeneration.DropPrimaryKeySupportKey);
-		optionsCreateTables.setObjectForKey("YES", EOSchemaGeneration.CreateTablesKey);
-		optionsCreateTables.setObjectForKey("YES", EOSchemaGeneration.CreatePrimaryKeySupportKey);
-		optionsCreateTables.setObjectForKey("YES", EOSchemaGeneration.PrimaryKeyConstraintsKey);
-		optionsCreateTables.setObjectForKey("NO", EOSchemaGeneration.ForeignKeyConstraintsKey);
-		optionsCreateTables.setObjectForKey("NO", EOSchemaGeneration.CreateDatabaseKey);
-		optionsCreateTables.setObjectForKey("NO", EOSchemaGeneration.DropDatabaseKey);
+		EOSchemaGenerationOptions optionsCreateTables = new EOSchemaGenerationOptions();
+		optionsCreateTables.setDropTables(false);
+		optionsCreateTables.setDropPrimaryKeySupport(false);
+		optionsCreateTables.setCreateTables(true);
+		optionsCreateTables.setCreatePrimaryKeySupport(true);
+		optionsCreateTables.setPrimaryKeyConstraints(true);
+		optionsCreateTables.setForeignKeyConstraints(false);
+		optionsCreateTables.setCreateDatabase(false);
+		optionsCreateTables.setDropDatabase(false);
 		StringBuilder sqlBuffer = new StringBuilder();
-		EOSynchronizationFactory sf = ((JDBCAdaptor) adaptor).plugIn().synchronizationFactory();
-		String creationScript = sf.schemaCreationScriptForEntities(entities, optionsCreateTables);
+		EOSchemaSynchronizationFactory sf = ((JDBCAdaptor) adaptor).plugIn().schemaSynchronizationFactory();
+		
+		NSArray<EOSQLExpression> creationScript = sf.schemaCreationStatementsForEntities(entities, optionsCreateTables);
 		sqlBuffer.append(creationScript);
 		
 		NSMutableArray<EOEntity> foreignKeyEntities = entities.mutableClone();
@@ -256,15 +256,15 @@ public class ERXSQLHelper {
 			}
 		}
 		
-		NSMutableDictionary<String, String> optionsCreateForeignKeys = new NSMutableDictionary<String, String>();
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.DropTablesKey);
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.DropPrimaryKeySupportKey);
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.CreateTablesKey);
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.CreatePrimaryKeySupportKey);
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.PrimaryKeyConstraintsKey);
-		optionsCreateForeignKeys.setObjectForKey("YES", EOSchemaGeneration.ForeignKeyConstraintsKey);
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.CreateDatabaseKey);
-		optionsCreateForeignKeys.setObjectForKey("NO", EOSchemaGeneration.DropDatabaseKey);
+		EOSchemaGenerationOptions optionsCreateForeignKeys = new EOSchemaGenerationOptions();
+		optionsCreateForeignKeys.setDropTables(false);
+		optionsCreateForeignKeys.setDropPrimaryKeySupport(false);
+		optionsCreateForeignKeys.setCreateTables(false);
+		optionsCreateForeignKeys.setCreatePrimaryKeySupport(true);
+		optionsCreateForeignKeys.setPrimaryKeyConstraints(false);
+		optionsCreateForeignKeys.setForeignKeyConstraints(true);
+		optionsCreateForeignKeys.setCreateDatabase(false);
+		optionsCreateForeignKeys.setDropDatabase(false);
 		String foreignKeyScript = sf.schemaCreationScriptForEntities(foreignKeyEntities, optionsCreateForeignKeys);
 		sqlBuffer.append(foreignKeyScript);
 		
@@ -277,14 +277,14 @@ public class ERXSQLHelper {
 	 *            the entities to create sql for
 	 * @param adaptor
 	 *            the adaptor to use
-	 * @param optionsDictionary
+	 * @param options
 	 *            the options (@see
 	 *            createSchemaSQLForEntitiesInModelWithNameAndOptions)
 	 * @return a sql script
 	 */
-	public String createSchemaSQLForEntitiesWithOptions(NSArray<EOEntity> entities, EOAdaptor adaptor, NSDictionary<String, String> optionsDictionary) {
-		EOSynchronizationFactory sf = ((JDBCAdaptor) adaptor).plugIn().synchronizationFactory();
-		String creationScript = sf.schemaCreationScriptForEntities(entities, optionsDictionary);  
+	public String createSchemaSQLForEntitiesWithOptions(NSArray<EOEntity> entities, EOAdaptor adaptor, EOSchemaGenerationOptions options) {
+		EOSchemaSynchronizationFactory sf = ((JDBCAdaptor) adaptor).plugIn().schemaSynchronizationFactory();
+		String creationScript = sf.schemaCreationScriptForEntities(entities, options);
 		return creationScript;
 	}
 
@@ -349,16 +349,16 @@ public class ERXSQLHelper {
 	 * @return a <code>String</code> containing SQL statements to create
 	 *         tables
 	 */
-	public NSMutableDictionary<String, String> defaultOptionDictionary(boolean create, boolean drop) {
-		NSMutableDictionary<String, String> optionsCreate = new NSMutableDictionary<String, String>();
-		optionsCreate.setObjectForKey((drop) ? "YES" : "NO", EOSchemaGeneration.DropTablesKey);
-		optionsCreate.setObjectForKey((drop) ? "YES" : "NO", EOSchemaGeneration.DropPrimaryKeySupportKey);
-		optionsCreate.setObjectForKey((create) ? "YES" : "NO", EOSchemaGeneration.CreateTablesKey);
-		optionsCreate.setObjectForKey((create) ? "YES" : "NO", EOSchemaGeneration.CreatePrimaryKeySupportKey);
-		optionsCreate.setObjectForKey((create) ? "YES" : "NO", EOSchemaGeneration.PrimaryKeyConstraintsKey);
-		optionsCreate.setObjectForKey((create) ? "YES" : "NO", EOSchemaGeneration.ForeignKeyConstraintsKey);
-		optionsCreate.setObjectForKey("NO", EOSchemaGeneration.CreateDatabaseKey);
-		optionsCreate.setObjectForKey("NO", EOSchemaGeneration.DropDatabaseKey);
+	public EOSchemaGenerationOptions defaultOptionDictionary(boolean create, boolean drop) {
+		EOSchemaGenerationOptions optionsCreate = new EOSchemaGenerationOptions();
+		optionsCreate.setDropTables(drop);
+		optionsCreate.setDropPrimaryKeySupport(drop);
+		optionsCreate.setCreateTables(create);
+		optionsCreate.setCreatePrimaryKeySupport(create);
+		optionsCreate.setPrimaryKeyConstraints(create);
+		optionsCreate.setForeignKeyConstraints(create);
+		optionsCreate.setCreateDatabase(false);
+		optionsCreate.setDropDatabase(false);
 		return optionsCreate;
 	}
 
@@ -416,7 +416,7 @@ public class ERXSQLHelper {
 				String key = keys.nextElement();
 				if (key.startsWith("index")) {
 					String numbers = key.substring("index".length());
-					if (ERXStringUtilities.isDigitsOnly(numbers)) {
+					if (StringUtils.isNumeric(numbers)) {
 						String attributeNames = (String) d.objectForKey(key);
 						if (ERXStringUtilities.stringIsNullOrEmpty(attributeNames)) {
 							continue;
@@ -1678,7 +1678,19 @@ public class ERXSQLHelper {
 			return sqlHelper;
 		}
 	}
-
+	
+	static protected String extractSchemaName(String fullName, char delimiter) {
+		String splitted[] = fullName.split("\\."); 
+		if (splitted.length == 1)
+			return null;
+		return delimiter + splitted[0] + delimiter + '.';
+	}
+	
+	static protected String extractTableName(String fullName, char delimiter) {
+		String splitted[] = fullName.split("\\."); 
+		return delimiter + splitted[0] + delimiter;
+	}
+	
 	public static class EROracleSQLHelper extends ERXSQLHelper.OracleSQLHelper {
 	}
 
@@ -1716,7 +1728,7 @@ public class ERXSQLHelper {
 		 * @see ERXSQLHelper#createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray, String, NSDictionary)
 		 */
 		@Override
-		public String createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray<EOEntity> entities, String modelName, NSDictionary optionsCreate) {
+		public String createSchemaSQLForEntitiesInModelWithNameAndOptions(NSArray<EOEntity> entities, String modelName, EOSchemaGenerationOptions optionsCreate) {
 			String oldConstraintName = null;
 			int i = 0;
 			String s = super.createSchemaSQLForEntitiesInModelWithNameAndOptions(entities, modelName, optionsCreate);
@@ -2067,13 +2079,17 @@ public class ERXSQLHelper {
 		@Override
 		public String sqlForCreateUniqueIndex(String indexName, String tableName, ColumnIndex... columnIndexes) {
 			NSMutableArray<String> columnNames = columnNamesFromColumnIndexes(columnIndexes);
-			return "ALTER TABLE \"" + tableName + "\" ADD CONSTRAINT \"" + indexName + "\" UNIQUE(\"" + new NSArray<String>(columnNames).componentsJoinedByString("\", \"") + "\") DEFERRABLE INITIALLY DEFERRED";
+			String schemaName = extractSchemaName(tableName, '"');
+			tableName = extractTableName(tableName, '"');
+			return "ALTER TABLE " + schemaName +  tableName + " ADD CONSTRAINT " + tableName + ".\"" + indexName + "\" UNIQUE(\"" + new NSArray<String>(columnNames).componentsJoinedByString("\", \"") + "\") DEFERRABLE INITIALLY DEFERRED";
 		}
 
 		@Override
 		public String sqlForCreateIndex(String indexName, String tableName, ColumnIndex... columnIndexes) {
 			NSMutableArray<String> columnNames = columnNamesFromColumnIndexes(columnIndexes);
-			return "CREATE INDEX \""+indexName+"\" ON \""+tableName+"\" (\""+new NSArray<String>(columnNames).componentsJoinedByString("\", \"")+"\")";
+			String schemaName = extractSchemaName(tableName, '"');
+			tableName = extractTableName(tableName, '"');
+			return "CREATE INDEX "+tableName+".\""+indexName+"\" ON "+schemaName+tableName+" (\""+new NSArray<String>(columnNames).componentsJoinedByString("\", \"")+"\")";
 		}
 
 		@Override
@@ -2144,7 +2160,7 @@ public class ERXSQLHelper {
 			if (columnName == null)
 				return null;
 
-			int i = columnName.lastIndexOf(46);
+			int i = columnName.lastIndexOf('.');
 			
 			if (i == -1)
 				return "\"" + columnName + "\"";
@@ -2248,7 +2264,8 @@ public class ERXSQLHelper {
 		@Override
 		public String sqlForCreateUniqueIndex(String indexName, String tableName, ColumnIndex... columnIndexes) {
 			StringBuffer sql = new StringBuffer();
-			sql.append("ALTER TABLE `" + tableName + "` ADD UNIQUE `" + indexName + "` (");
+			tableName = tableName.replaceAll("\\.", "`\\.`");
+			sql.append("ALTER TABLE `" + tableName + "` ADD UNIQUE `" + tableName + "`.`" + indexName + "` (");
 			_appendIndexColNames(sql, columnIndexes);
 			sql.append(')');
 			return sql.toString();
@@ -2257,10 +2274,11 @@ public class ERXSQLHelper {
 		@Override
 		public String sqlForCreateIndex(String indexName, String tableName, ColumnIndex... columnIndexes) {
 			StringBuffer sql = new StringBuffer();
-			sql.append("CREATE INDEX `"+ indexName + "` ON `"+tableName+"` (");
+			sql.append("CREATE INDEX `" + indexName + "` ON `" + tableName + "` (");
 			_appendIndexColNames(sql, columnIndexes);
 			sql.append(')');
-			return sql.toString();
+			String temp = sql.toString();
+			return temp.replaceAll("(CREATE.*)\\.(.*)", "$1`.`$2");
 		}
 
 		private void _appendIndexColNames(StringBuffer sql, ColumnIndex... columnIndexes) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2283,7 +2283,7 @@ public class ERXSQLHelper {
 			StringBuffer sql = new StringBuffer();
 			String schemaName = extractSchemaName(tableName, "`");
 			tableName = extractTableName(tableName, "`");
-			sql.append("ALTER TABLE `" + schemaName + tableName + "` ADD UNIQUE `" + tableName + "`.`" + indexName + "` (");
+			sql.append("ALTER TABLE " + schemaName + tableName + " ADD UNIQUE " + tableName + ".`" + indexName + "` (");
 			_appendIndexColNames(sql, columnIndexes);
 			sql.append(')');
 			return sql.toString();
@@ -2294,7 +2294,7 @@ public class ERXSQLHelper {
 			StringBuffer sql = new StringBuffer();
 			String schemaName = extractSchemaName(tableName, "`");
 			tableName = extractTableName(tableName, "`");
-			sql.append("CREATE INDEX `" + indexName + "` ON `" + schemaName + tableName + "` (");
+			sql.append("CREATE INDEX `" + indexName + "` ON " + schemaName + tableName + " (");
 			_appendIndexColNames(sql, columnIndexes);
 			sql.append(')');
 			String temp = sql.toString();

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXJDBCMigrationLock.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXJDBCMigrationLock.java
@@ -10,7 +10,7 @@ import com.webobjects.eoaccess.EOEntity;
 import com.webobjects.eoaccess.EOGeneralAdaptorException;
 import com.webobjects.eoaccess.EOModel;
 import com.webobjects.eoaccess.EOModelGroup;
-import com.webobjects.eoaccess.EOSchemaGeneration;
+import com.webobjects.eoaccess.synchronization.EOSchemaGenerationOptions;
 import com.webobjects.eocontrol.EOFetchSpecification;
 import com.webobjects.eocontrol.EOKeyValueQualifier;
 import com.webobjects.eocontrol.EOQualifier;
@@ -358,16 +358,17 @@ public class ERXJDBCMigrationLock implements IERXMigrationLock {
 
 	protected String dbUpdaterCreateStatement(EOModel model, JDBCAdaptor adaptor) {
 		EOModel dbUpdaterModel = dbUpdaterModelWithModel(model, adaptor);
-		NSMutableDictionary<String, String> flags = new NSMutableDictionary<String, String>();
-		flags.setObjectForKey("NO", EOSchemaGeneration.DropTablesKey);
-		flags.setObjectForKey("NO", EOSchemaGeneration.DropPrimaryKeySupportKey);
-		flags.setObjectForKey("YES", EOSchemaGeneration.CreateTablesKey);
-		flags.setObjectForKey("NO", EOSchemaGeneration.CreatePrimaryKeySupportKey);
-		flags.setObjectForKey("YES", EOSchemaGeneration.PrimaryKeyConstraintsKey);
-		flags.setObjectForKey("NO", EOSchemaGeneration.ForeignKeyConstraintsKey);
-		flags.setObjectForKey("NO", EOSchemaGeneration.CreateDatabaseKey);
-		flags.setObjectForKey("NO", EOSchemaGeneration.DropDatabaseKey);
-		String createTableScript = ERXSQLHelper.newSQLHelper(adaptor).createSchemaSQLForEntitiesWithOptions(new NSArray<EOEntity>(dbUpdaterModel.entityNamed(migrationTableName(adaptor))), adaptor, flags);
+		EOSchemaGenerationOptions flags = new EOSchemaGenerationOptions();
+		flags.setDropTables(false);
+		flags.setDropPrimaryKeySupport(false);
+		flags.setCreateTables(true);
+		flags.setCreatePrimaryKeySupport(false);
+		flags.setPrimaryKeyConstraints(true);
+		flags.setForeignKeyConstraints(false);
+		flags.setCreateDatabase(false);
+		flags.setDropDatabase(false);
+		ERXSQLHelper helper = ERXSQLHelper.newSQLHelper(model);
+		String createTableScript = helper.createSchemaSQLForEntitiesWithOptions(new NSArray<EOEntity>(dbUpdaterModel.entityNamed(migrationTableName(adaptor))), adaptor, flags);
 		return createTableScript;
 	}
 }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationDatabase.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationDatabase.java
@@ -6,7 +6,7 @@ import com.webobjects.eoaccess.EOAdaptor;
 import com.webobjects.eoaccess.EOAdaptorChannel;
 import com.webobjects.eoaccess.EOModel;
 import com.webobjects.eoaccess.EOSQLExpression;
-import com.webobjects.eoaccess.EOSynchronizationFactory;
+import com.webobjects.eoaccess.synchronization.EOSchemaSynchronizationFactory;
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOKeyValueQualifier;
 import com.webobjects.eocontrol.EOQualifier;
@@ -151,8 +151,8 @@ public class ERXMigrationDatabase {
 	 * 
 	 * @return the synchronization factory for this adaptor
 	 */
-	public EOSynchronizationFactory synchronizationFactory() {
-		return (EOSynchronizationFactory) adaptor().synchronizationFactory();
+	public EOSchemaSynchronizationFactory synchronizationFactory() {
+		return adaptor().schemaSynchronizationFactory();
 	}
 
 	/**

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationTable.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationTable.java
@@ -1,6 +1,7 @@
 package er.extensions.migration;
 
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -10,8 +11,7 @@ import com.webobjects.eoaccess.EOJoin;
 import com.webobjects.eoaccess.EOModel;
 import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.eoaccess.EOSQLExpression;
-import com.webobjects.eoaccess.EOSchemaGeneration;
-import com.webobjects.eoaccess.EOSchemaSynchronization;
+import com.webobjects.eoaccess.synchronization.EOSchemaSynchronizationFactory;
 import com.webobjects.eocontrol.EOKeyValueQualifier;
 import com.webobjects.eocontrol.EOQualifier;
 import com.webobjects.foundation.NSArray;
@@ -920,7 +920,7 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _createExpressions() {
-		EOSchemaGeneration schemaGeneration = _database.synchronizationFactory();
+		EOSchemaSynchronizationFactory schemaGeneration = _database.synchronizationFactory();
 		NSArray<EOSQLExpression> expressions = schemaGeneration.createTableStatementsForEntityGroup(new NSArray<EOEntity>(_newEntity()));
 		ERXMigrationDatabase._ensureNotEmpty(expressions, "create table", true);
 		return expressions;
@@ -964,7 +964,7 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _dropExpressions() {
-		EOSchemaGeneration schemaGeneration = _database.synchronizationFactory();
+		EOSchemaSynchronizationFactory schemaGeneration = _database.synchronizationFactory();
 		NSArray<EOSQLExpression> expressions = schemaGeneration.dropTableStatementsForEntityGroup(new NSArray<EOEntity>(_blankEntity()));
 		ERXMigrationDatabase._ensureNotEmpty(expressions, "drop table", true);
 		return expressions;
@@ -990,8 +990,8 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _renameToExpressions(String newName) {
-		EOSchemaSynchronization schemaSynchronization = _database.synchronizationFactory();
-		NSArray<EOSQLExpression> expressions = schemaSynchronization.statementsToRenameTableNamed(name(), newName, NSDictionary.EmptyDictionary);
+		EOSchemaSynchronizationFactory schemaSynchronization = _database.synchronizationFactory();
+		NSArray<EOSQLExpression> expressions = schemaSynchronization.statementsToRenameTableNamed(name(), newName, null);
 		ERXMigrationDatabase._ensureNotEmpty(expressions, "rename table", true);
 		return expressions;
 	}
@@ -1018,7 +1018,7 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _setPrimaryKeyExpressions(ERXMigrationColumn... columns) {
-		EOSchemaGeneration schemaGeneration = _database.synchronizationFactory();
+		EOSchemaSynchronizationFactory schemaGeneration = _database.synchronizationFactory();
 		EOEntity entity = columns[0].table()._blankEntity();
 		NSMutableArray<EOAttribute> attributes = new NSMutableArray<EOAttribute>();
 		for (ERXMigrationColumn column : columns) {
@@ -1301,7 +1301,7 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _addForeignKeyExpressions(ERXMigrationColumn sourceColumn, ERXMigrationColumn destinationColumn) {
-		EOSchemaGeneration schemaGeneration = _database.synchronizationFactory();
+		EOSchemaSynchronizationFactory schemaGeneration = _database.synchronizationFactory();
 		NSArray<EOSQLExpression> expressions = schemaGeneration.foreignKeyConstraintStatementsForRelationship(_newRelationship(new ERXMigrationColumn[] { sourceColumn }, new ERXMigrationColumn[] { destinationColumn }));
 		ERXMigrationDatabase._ensureNotEmpty(expressions, "add foreign key", false);
 		return expressions;
@@ -1317,7 +1317,7 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _addForeignKeyExpressions(ERXMigrationColumn[] sourceColumns, ERXMigrationColumn[] destinationColumns) {
-		EOSchemaGeneration schemaGeneration = _database.synchronizationFactory();
+		EOSchemaSynchronizationFactory schemaGeneration = _database.synchronizationFactory();
 		NSArray<EOSQLExpression> expressions = schemaGeneration.foreignKeyConstraintStatementsForRelationship(_newRelationship(sourceColumns, destinationColumns));
 		ERXMigrationDatabase._ensureNotEmpty(expressions, "add foreign key", false);
 		return expressions;
@@ -1408,7 +1408,7 @@ public class ERXMigrationTable {
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<EOSQLExpression> _dropPrimaryKeyExpressions(ERXMigrationColumn... columns) {
-		EOSchemaGeneration schemaGeneration = _database.synchronizationFactory();
+		EOSchemaSynchronizationFactory schemaGeneration = _database.synchronizationFactory();
 		EOEntity entity = columns[0].table()._blankEntity();
 		NSMutableArray<EOAttribute> attributes = new NSMutableArray<EOAttribute>();
 		for (ERXMigrationColumn column : columns) {

--- a/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
+++ b/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
@@ -595,6 +595,13 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 		return splitted[0];
 	}
 	
+	static protected String extractQuotedTableName(String fullName) {
+		if (fullName == null)
+			return null;
+		String splitted[] = fullName.split("\\."); 
+		return '"' + splitted[0] + '"';
+	}
+	
 	protected static String notNullConstraintName(EOAttribute attribute) {
 		return notNullConstraintName(extractQuotedSchemaName(attribute.entity().externalName()), attribute.entity().externalName(), attribute.columnName());
 	}
@@ -605,7 +612,7 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 		String splitted[] = fullName.split("\\.");
 		if (splitted.length == 1)
 			return '"' + splitted[0] + '"';
-		return '"' + splitted[0] + "\".\"" + splitted[1];
+		return '"' + splitted[0] + "\".\"" + splitted[1]+ '"';
 		}
 
 	protected static String notNullConstraintName(String schemaName, String externalName, String columnName) {
@@ -830,9 +837,9 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 					if (unique == null) {
 						unique = "1000000";
 					}
-					result.addObject(_expressionForString("SET UNIQUE = " + unique + " FOR " + extractQuotedSchemaName(externalName) + extractTableName(externalName)));
-					result.addObject(_expressionForString("ALTER TABLE " + extractQuotedSchemaName(externalName) + extractTableName(externalName)
-							+ " ALTER " + extractTableName(externalName) + priKeyAttribute.name() + " SET DEFAULT UNIQUE"));
+					result.addObject(_expressionForString("SET UNIQUE = " + unique + " FOR " + extractQuotedSchemaName(externalName) + extractQuotedTableName(externalName)));
+					result.addObject(_expressionForString("ALTER TABLE " + extractQuotedSchemaName(externalName) + extractQuotedTableName(externalName)
+							+ " ALTER \"" + priKeyAttribute.name() + "\" SET DEFAULT UNIQUE"));
 				}
 			}
 			return result;
@@ -1049,10 +1056,10 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 			}
 			else {
 				if (USE_NAMED_CONSTRAINTS) {
-					statements = new NSArray<EOSQLExpression>(_expressionForString("ALTER TABLE " + quoteFullName(tableName) + " ADD CONSTRAINT " + notNullConstraintName(_schemaName, _tableName, columnName) + " CHECK (" + extractTableName(_tableName) + "\"." + columnName + " IS NOT NULL)"));
+					statements = new NSArray<EOSQLExpression>(_expressionForString("ALTER TABLE " + quoteFullName(tableName) + " ADD CONSTRAINT " + notNullConstraintName(_schemaName, _tableName, columnName) + " CHECK (" + extractQuotedTableName(_tableName) + ".\"" + columnName + "\" IS NOT NULL)"));
 				}
 				else {
-					statements = new NSArray<EOSQLExpression>(_expressionForString("ALTER TABLE " + quoteFullName(tableName) + " ADD CHECK (" + extractTableName(_tableName) + "\"." + columnName + " IS NOT NULL)"));
+					statements = new NSArray<EOSQLExpression>(_expressionForString("ALTER TABLE " + quoteFullName(tableName) + " ADD CHECK (" + extractQuotedTableName(_tableName) + ".\"" + columnName + "\" IS NOT NULL)"));
 				}
 			}
 			return statements;
@@ -1212,7 +1219,7 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 
 			sql.append('"');
 			sql.append(attribute.columnName());
-			sql.append('"');
+			sql.append("\" ");
 			sql.append(columnTypeStringForAttribute(attribute));
 
 			NSDictionary dictionary = attribute.userInfo();


### PR DESCRIPTION
Changes to make use of EOSchemaSynchronizationFactory instead of deprecated and troubled EOSynchronizationFactory solves a series of SQL generation issues with different JDBC plug-ins (at least I tested with MySQL and FrontBase) and with migrations.

Also added some code to deal with fully qualified database (schema) and table names, like "ALTER TABLE "MyDatabaseSchema"."SomeTable" ..." when the fully qualified name is used as the table name in ERXMigrationTable newTableNamed(String name) for example.