### PR TITLE
Fix for bug in ERMoviesLogic migration

### DIFF
--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/migrations/Movies1.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/migrations/Movies1.java
@@ -1,11 +1,9 @@
 package webobjectsexamples.businesslogic.movies.migrations;
 
 import com.webobjects.eocontrol.EOEditingContext;
-import com.webobjects.foundation.NSArray;
 
 import er.attachment.migrations.ERAttachmentMigration;
 import er.extensions.migration.ERXMigrationDatabase;
-import er.extensions.migration.ERXModelVersion;
 
 public class Movies1 extends ERAttachmentMigration {
 	
@@ -13,11 +11,6 @@ public class Movies1 extends ERAttachmentMigration {
 		super("movie", "poster_AttachmentID", true);
 	}
 
-	@Override
-	public NSArray<ERXModelVersion> modelDependencies() {
-		return null;
-	}
-  
 	@Override
 	public void downgrade(EOEditingContext editingContext, ERXMigrationDatabase database) throws Throwable {
 		// DO NOTHING


### PR DESCRIPTION
Fixes ERMoviesLogic migration bug that caused the dependency on ERAttachment to be skipped, due to an override returning null.