### PR TITLE
generate complete URLs if secure mode changes

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
@@ -376,7 +376,7 @@ public class ERXWOForm extends com.webobjects.appserver._private.WOHTMLDynamicEl
 		boolean generatingCompleteURLs = context.doesGenerateCompleteURLs();
 		boolean requestIsSecure = context.secureMode();
 		boolean switchToCompleteURLs = secure ^ requestIsSecure;
-		if (switchToCompleteURLs) {
+		if (switchToCompleteURLs && !generatingCompleteURLs) {
 			context.generateCompleteURLs();
 		}
 		try {
@@ -407,7 +407,7 @@ public class ERXWOForm extends com.webobjects.appserver._private.WOHTMLDynamicEl
 			}
 		}
 		finally {
-			if (switchToCompleteURLs) {
+			if (switchToCompleteURLs && !generatingCompleteURLs) {
 				context.generateRelativeURLs();
 			}
 		}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
@@ -374,7 +374,9 @@ public class ERXWOForm extends com.webobjects.appserver._private.WOHTMLDynamicEl
 		WOComponent wocomponent = context.component();
 		super.appendAttributesToResponse(response, context);
 		boolean generatingCompleteURLs = context.doesGenerateCompleteURLs();
-		if (secure && !generatingCompleteURLs) {
+		boolean requestIsSecure = context.secureMode();
+		boolean switchToCompleteURLs = secure ^ requestIsSecure;
+		if (switchToCompleteURLs) {
 			context.generateCompleteURLs();
 		}
 		try {
@@ -405,7 +407,7 @@ public class ERXWOForm extends com.webobjects.appserver._private.WOHTMLDynamicEl
 			}
 		}
 		finally {
-			if (secure && !generatingCompleteURLs) {
+			if (switchToCompleteURLs) {
 				context.generateRelativeURLs();
 			}
 		}


### PR DESCRIPTION
ERXWOForm should only generate complete URLs if the request is unsecure but form submit should be secure and vice versa. The previous implementation generated always complete URLs as soon as the form submit should be secure. This resolves issue #641.