### PR TITLE
fix default submit button for IE

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXWOForm.java
@@ -423,13 +423,7 @@ public class ERXWOForm extends com.webobjects.appserver._private.WOHTMLDynamicEl
 				_appendOpenTagToResponse(response, context);
 				if (_multipleSubmit != null && _multipleSubmit.booleanValueInComponent(context.component())) {
 					if (_addDefaultSubmitButton != null && _addDefaultSubmitButton.booleanValueInComponent(context.component()) || (_addDefaultSubmitButton == null && addDefaultSubmitButtonDefault)) {
-						ERXBrowser browser = ERXBrowserFactory.factory().browserMatchingRequest(context.request());
-						boolean useDisplayNone = !(browser.isSafari() && browser.version().compareTo("3.0.3") > 0);
-						if(useDisplayNone) {
-							response._appendContentAsciiString("<div style=\"position: absolute; left: -10000px; display: none;\"><input type=\"submit\" name=\"WOFormDummySubmit\" value=\"WOFormDummySubmit\" /></div>");
-						} else {
-							response._appendContentAsciiString("<div style=\"position: absolute; left: -10000px; visibility: hidden\"><input type=\"submit\" name=\"WOFormDummySubmit\" value=\"WOFormDummySubmit\" /></div>");
-						}
+						response._appendContentAsciiString("<div style=\"position:absolute;left:-100000px\"><input type=\"submit\" name=\"WOFormDummySubmit\" value=\"WOFormDummySubmit\" /></div>");
 					}
 				}
 				appendChildrenToResponse(response, context);


### PR DESCRIPTION
In Internet Explorer the default submit button from ERXWOForm does not work, hitting return from within a form input does not submit the form. That browser seems to ignore elements that have either the attribute *display:none* or *visibility:hidden*. A fix is to remove those attributes for the default submit button. As the element has an absolute position it does not interfere with the text flow and thus won't break layout.

This has been successfully tested with IE9, IE10, Safari 7, Firefox 10, Firefox 38, Chrome 43.