### PR TITLE
Enhancements for ERProfiling

### DIFF
--- a/Frameworks/Misc/ERProfiling/Sources/er/profiling/delegates/PFHeatMap.java
+++ b/Frameworks/Misc/ERProfiling/Sources/er/profiling/delegates/PFHeatMap.java
@@ -60,24 +60,19 @@ public class PFHeatMap implements PFProfiler.Delegate {
         }
         if ("appendToResponse".equals(stats.name())) {
             double fValue = stats.percentage();
-            int r = 0;
-            int g = 0;
+            int r = 255;
+            int g = (int) (255 * (1.0 - fValue * fValue));
             int b = 0;
-            int a = 1;
-            if (fValue <= 0.01) {
-                // r = 255;
-                // g = 255;
-                // b = 255;
-                // response.appendContentString(".wo_p_" +
-                // duration.getKey() + " { background-color: rgba(" + r
-                // + "," + g + "," + b + "," + a + ") !important; }\n");
-            } else {
-                int value = (int) (255 * (1.0 - fValue * fValue));
-                r = 255;
-                g = value;
-                b = 0;
-                response.appendContentString("." + stats.cssID() + " { !important; border: 3px solid rgba(" + r + "," + g + "," + b + "," + a + ") !important; }\n");
+            int w = 1;
+            if (fValue > 0.75) {
+                w = 4;
+            } else if (fValue > 0.4) {
+                w = 3;
+            } else if (fValue > 0.1) {
+                w = 2;
             }
+            response.appendContentString("." + stats.cssID() + " { outline: " + w + "px solid rgb(" + r
+                    + "," + g + "," + b + ") !important; outline-offset: -" + w + "px !important }\n");
         }
 
     }

--- a/Frameworks/Misc/ERProfiling/Sources/er/profiling/delegates/PFMarkup.java
+++ b/Frameworks/Misc/ERProfiling/Sources/er/profiling/delegates/PFMarkup.java
@@ -5,6 +5,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOElement;
 import com.webobjects.appserver.WOMessage;
@@ -145,33 +147,27 @@ public class PFMarkup implements PFProfiler.Delegate {
                         }
 
                         if (tagIndex != -1) {
-                            int attributeOffset = -1;
-                            boolean spacesFound = false;
-                            for (int i = tagIndex; i < endIndex; i++) {
-                                char ch = contentStr.charAt(i);
-                                if (ch == ' ') {
-                                    spacesFound = true;
-                                } else if (ch == '>' || ch == '/') {
-                                    if (attributeOffset > tagIndex + 1) {
-                                        attributeOffset = i;
-                                    }
-                                    break;
-                                } else if (spacesFound) {
-                                    attributeOffset = i;
-                                    break;
-                                }
-                            }
-                            if (attributeOffset != -1) {
-                                String profilerID = markerStats._stats.cssID();
-                                String profilerIDAttributeName = "class";
-                                if (regionMatches(contentStr, attributeOffset, profilerIDAttributeName, 0, profilerIDAttributeName.length())) {
-                                    int openQuoteIndex = indexOf(contentStr, "\"", attributeOffset);
-                                    if (openQuoteIndex != -1) {
-                                        insert(contentStr, openQuoteIndex + 1, profilerID + " ");
-                                    }
+                            String profilerIDAttributeName = "class";
+                            String profilerIDAttributeStart = " " + profilerIDAttributeName + "=\"";
+                            boolean foundClassAttribute = false;
+                            int closeOffset = StringUtils.indexOf(contentStr, '>', tagIndex);
+                            int attributeOffset = StringUtils.indexOf(contentStr, profilerIDAttributeName, tagIndex);
+                            if (attributeOffset == -1 || attributeOffset > closeOffset) {
+                                char ch = contentStr.charAt(closeOffset - 1);
+                                if (ch == '/') {
+                                    attributeOffset = closeOffset - 1;
                                 } else {
-                                    insert(contentStr, attributeOffset, " " + profilerIDAttributeName + "=\"" + profilerID + "\" ");
+                                    attributeOffset = closeOffset;
                                 }
+                            } else {
+                                attributeOffset += profilerIDAttributeStart.length() -1;
+                                foundClassAttribute = true;
+                            }
+                            String profilerID = markerStats._stats.cssID();
+                            if (foundClassAttribute) {
+                                insert(contentStr, attributeOffset, profilerID + " ");
+                            } else {
+                                insert(contentStr, attributeOffset, profilerIDAttributeStart + profilerID + "\"");
                             }
                         }
                     }

--- a/Frameworks/Misc/ERProfiling/Sources/er/profiling/delegates/PFMarkup.java
+++ b/Frameworks/Misc/ERProfiling/Sources/er/profiling/delegates/PFMarkup.java
@@ -137,7 +137,7 @@ public class PFMarkup implements PFProfiler.Delegate {
                         for (int i = startIndex; i < endIndex; i++) {
                             char ch = contentStr.charAt(i);
                             if (ch == '<') {
-                                if (i < endIndex - 1 && contentStr.charAt(i + 1) != '/') {
+                                if (i < endIndex - 1 && contentStr.charAt(i + 1) != '/' && contentStr.charAt(i + 1) != '!') {
                                     tagIndex = i;
                                     break;
                                 }


### PR DESCRIPTION
This patch include several enhancements for ERProfiling:

* the doctype tag and any HTML comments won't get a class attribute anymore (future enhancement could be to exclude all tags that don't allow a class attribute)
* use CSS outline instead of border in order to not "destroy" your HTML layout as border will change either dimensions of element (box-sizing: content-box) or content (box-sizing: border-box)
* check if a tag already has a class attribute (former implementation looked up only first attribute, leading to tags with two class attributes which is not allowed and will formally delete the second one thus removing CSS classes you probably need…)