### PR TITLE
Improve support for OGNL expressions in AjaxUpdateTrigger

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxUpdateTrigger.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxUpdateTrigger.java
@@ -1,6 +1,7 @@
 package er.ajax;
 
-import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
 
 import com.webobjects.appserver.WOAssociation;
 import com.webobjects.appserver.WOComponent;
@@ -8,9 +9,7 @@ import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WODynamicElement;
 import com.webobjects.appserver.WOElement;
 import com.webobjects.appserver.WOResponse;
-import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
-import com.webobjects.foundation.NSMutableArray;
 
 import er.extensions.components.ERXComponentUtilities;
 
@@ -45,12 +44,12 @@ public class AjaxUpdateTrigger extends WODynamicElement {
 	public void appendToResponse(WOResponse response, WOContext context) {
 		super.appendToResponse(response, context);
 		WOComponent component = context.component();
-		NSArray updateContainerIDs = (NSArray) _updateContainerIDs.valueInComponent(component);
-		if (updateContainerIDs != null && updateContainerIDs.count() > 0) {
+		List<String> updateContainerIDs = (List<String>) _updateContainerIDs.valueInComponent(component);
+		if (updateContainerIDs != null && updateContainerIDs.size() > 0) {
 			AjaxUtils.appendScriptHeader(response);
-			Enumeration updateContainerIDEnum = updateContainerIDs.objectEnumerator();
-			while (updateContainerIDEnum.hasMoreElements()) {
-				String updateContainerID = (String) updateContainerIDEnum.nextElement();
+			Iterator<String> updateContainerIDEnum = updateContainerIDs.iterator();
+			while (updateContainerIDEnum.hasNext()) {
+				String updateContainerID = updateContainerIDEnum.next();
 				// PROTOTYPE FUNCTIONS
 				Object evalScripts = ERXComponentUtilities.valueForBinding("evalScripts", "true", _associations, component);
 				response.appendContentString("if ($wi('" + updateContainerID + "')) { ");
@@ -60,7 +59,7 @@ public class AjaxUpdateTrigger extends WODynamicElement {
 			AjaxUtils.appendScriptFooter(response);
 	
 			if (_resetAfterUpdate != null && _resetAfterUpdate.booleanValueInComponent(component)) {
-				((NSMutableArray) updateContainerIDs).removeAllObjects();
+				updateContainerIDs.clear();
 			}
 		}
 	}


### PR DESCRIPTION
The `AjaxUpdateTrigger` accepts an array of `updateContainerIDs` that must be updated. The `updateContainerIDs` binding accepts a `NSArray` of `String`s. Creating `NSArray`s using OGNL expressions is cumbersome. This patch replaces the type of the `updateContainerIDs` binding from `NSArray` to `List`. This change allows a more natural definition of the array of containers to be updated as described below.

```
<wo:AjaxUpdateTrigger updateContainerIDs = "~ {\"container1\", \"container2\"}" />
```