### PR TITLE
prevent exceptions with empty and- and or-qualifiers in ERXPrefixQualifierTraversal

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXPrefixQualifierTraversal.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXPrefixQualifierTraversal.java
@@ -60,19 +60,27 @@ public class ERXPrefixQualifierTraversal extends ERXQualifierTraversal {
 
 	@Override
 	protected boolean traverseOrQualifier(EOOrQualifier q) {
-		NSRange range = new NSRange(_qualifiers.count() - q.qualifiers().count(), q.qualifiers().count());
-		ERXOrQualifier oq = new ERXOrQualifier(_qualifiers.subarrayWithRange(range));
-		_qualifiers.removeObjectsInRange(range);
-		_qualifiers.addObject(oq);
+		if (q.qualifiers().isEmpty()) {
+			_qualifiers.addObject(new ERXOrQualifier());
+		} else {
+			NSRange range = new NSRange(_qualifiers.count() - q.qualifiers().count(), q.qualifiers().count());
+			ERXOrQualifier oq = new ERXOrQualifier(_qualifiers.subarrayWithRange(range));
+			_qualifiers.removeObjectsInRange(range);
+			_qualifiers.addObject(oq);
+		}
 		return true;
 	}
 
 	@Override
 	protected boolean traverseAndQualifier(EOAndQualifier q) {
-		NSRange range = new NSRange(_qualifiers.count() - q.qualifiers().count(), q.qualifiers().count());
-		ERXAndQualifier aq = new ERXAndQualifier(_qualifiers.subarrayWithRange(range));
-		_qualifiers.removeObjectsInRange(range);
-		_qualifiers.addObject(aq);
+		if (q.qualifiers().isEmpty()) {
+			_qualifiers.addObject(new ERXAndQualifier());
+		} else {
+			NSRange range = new NSRange(_qualifiers.count() - q.qualifiers().count(), q.qualifiers().count());
+			ERXAndQualifier aq = new ERXAndQualifier(_qualifiers.subarrayWithRange(range));
+			_qualifiers.removeObjectsInRange(range);
+			_qualifiers.addObject(aq);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
In Wonder it is legal to create **empty ERXAndQualifier and ERXOrQualifiers**. This is convenient when creating complex qualifiers dynamically, which depend on user input and whether certain sub-qualifiers shall be included or not.

However when trying to **prefix** a qualifier structure, which contains empty ERXAndQualifier and ERXOrQualifiers, an exception is thrown due to an invalid NSRange. Sample code (both lines generate an exception):

```java
  System.out.println(new ERXKey("prefix").dot(ERXQ.and()));
  System.out.println(new ERXKey("prefix").dot(ERXQ.and(ERXQ.equals("foo", "bar"), ERXQ.or())));
```

This patch solves the issue in ERXPrefixQualifierTraversal.