### PR TITLE
Corrects a trivial typo. #676

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXHttpStatusCodes.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXHttpStatusCodes.java
@@ -102,7 +102,7 @@ public class ERXHttpStatusCodes {
 	 * 403 Forbidden 
 	 * The server understood the request, but is refusing to fulfill it. Authorization will not help and the request SHOULD NOT be repeated.
 	 */
-	public static final int STATUS_FORBIDDEN = WOMessage.HTTP_STATUS_FORBIDDEN;
+	public static final int FORBIDDEN = WOMessage.HTTP_STATUS_FORBIDDEN;
 
 	/** 
 	 * 404 Not Found 


### PR DESCRIPTION
This is a _completely trivial_ backwards-incompatible change for Wonder 7. This is solely to make the naming of constants consistent. The other constants copied over from `WOMessage` have all (very reasonably) had the prepended `HTTP_STATUS_` part deleted. `FORBIDDEN` missed out, and was labelled `STATUS_FORBIDDEN`. This just makes all the constant names consistent.