### PR TITLE
ERXExistsQualifier-support in ERXQualifierTraversal

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXPrefixQualifierTraversal.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXPrefixQualifierTraversal.java
@@ -11,6 +11,7 @@ import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSRange;
 
 import er.extensions.eof.ERXKey;
+import er.extensions.eof.qualifiers.ERXExistsQualifier;
 
 /**
  * Takes a qualifier, traverses every subqualifier, and prepends every keypath
@@ -107,6 +108,13 @@ public class ERXPrefixQualifierTraversal extends ERXQualifierTraversal {
 	@Override
 	protected boolean traverseTrueQualifier(ERXTrueQualifier q) {
 		_qualifiers.addObject(q);
+		return true;
+	}
+
+	@Override
+	protected boolean traverseExistsQualifier(ERXExistsQualifier q) {
+		String newBaseKeyPath = q.baseKeyPath() != null ? _prefix + q.baseKeyPath() : _prefix.substring(0, _prefix.length() - 1);
+		_qualifiers.add(new ERXExistsQualifier(q.subqualifier(), newBaseKeyPath, q.usesInQualInstead()));
 		return true;
 	}
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXQualifierTraversal.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/qualifiers/ERXQualifierTraversal.java
@@ -17,6 +17,8 @@ import com.webobjects.eocontrol.EONotQualifier;
 import com.webobjects.eocontrol.EOOrQualifier;
 import com.webobjects.eocontrol.EOQualifierEvaluation;
 
+import er.extensions.eof.qualifiers.ERXExistsQualifier;
+
 /**
  * Traverse a network of qualifiers until a traversal method returns false.
  * Subclass and implement the methods you need.
@@ -126,6 +128,17 @@ public class ERXQualifierTraversal {
 	}
 
 	/**
+	 * Should traverse exists qualifier?
+	 *
+	 * @param q
+	 *            the qualifier to process
+	 * @return should traverse exists qualifier
+	 */
+	protected boolean traverseExistsQualifier(ERXExistsQualifier q) {
+		return true;
+	}
+
+	/**
 	 * Traverses the supplied qualifier
 	 * 
 	 * @param q
@@ -198,6 +211,9 @@ public class ERXQualifierTraversal {
 			}
 			else if (q instanceof ERXFalseQualifier) {
 				result = traverseFalseQualifier((ERXFalseQualifier) q) ? Boolean.TRUE : Boolean.FALSE;
+			}
+			else if (q instanceof ERXExistsQualifier) {
+				result = traverseExistsQualifier((ERXExistsQualifier) q) ? Boolean.TRUE : Boolean.FALSE;
 			}
 			else {
 				result = traverseUnknownQualifier(q) ? Boolean.TRUE : Boolean.FALSE;


### PR DESCRIPTION
ERXQualifierTraversal did not handle ERXExistsQualifier. This support was added both in the base class ERXQualifierTraversal and in ERXPrefixQualifierTraversal.