### PR TITLE
Prevent NPE in ERXExistsQualifier

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
@@ -249,7 +249,7 @@ public class ERXExistsQualifier extends EOQualifier implements Cloneable, NSCodi
             }
 
             String srcEntityForeignKey = null;
-            NSArray<EOAttribute> sourceAttributes = relationship.sourceAttributes();
+            NSArray<EOAttribute> sourceAttributes = relationship != null ? relationship.sourceAttributes() : null;
             if (sourceAttributes != null && sourceAttributes.count() > 0) {
                 EOAttribute fk = sourceAttributes.lastObject();
                 srcEntityForeignKey = expression.sqlStringForAttribute(fk);
@@ -259,8 +259,14 @@ public class ERXExistsQualifier extends EOQualifier implements Cloneable, NSCodi
                 srcEntityForeignKey = expression.sqlStringForAttribute(pk);
             }
             
-            EOJoin parentChildJoin = ERXArrayUtilities.firstObject(relationship.joins());
-            String destEntityForeignKey = "." + expression.sqlStringForSchemaObjectName(parentChildJoin.destinationAttribute().columnName());
+            String destEntityForeignKey;
+            if (relationship != null) {
+                EOJoin parentChildJoin = ERXArrayUtilities.firstObject(relationship.joins());
+                destEntityForeignKey = "." + expression.sqlStringForSchemaObjectName(parentChildJoin.destinationAttribute().columnName());
+            } else {
+                EOAttribute pk = srcEntity.primaryKeyAttributes().lastObject();
+                destEntityForeignKey = "." + expression.sqlStringForSchemaObjectName(pk.columnName());
+            }
             
             EOQualifier qual = EOQualifierSQLGeneration.Support._schemaBasedQualifierWithRootEntity(subqualifier, destEntity);
             EOFetchSpecification fetchSpecification = new EOFetchSpecification(destEntity.name(), qual, null, false, true, null);


### PR DESCRIPTION
When baseKeyPath is null (which can happen as there is a constructor setting it to null), no relationship will be found during SQL generation. This condition was not fully handled and therefore an NPE was thrown when trying to access the (null) relationship.