### PR TITLE
Fixed ERXExistsQualifier in-memory evaluation for baseKeyPath == null

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
@@ -460,7 +460,7 @@ public class ERXExistsQualifier extends EOQualifier implements Cloneable, NSCodi
 		boolean match = false;
 		NSKeyValueCodingAdditions obj = (NSKeyValueCodingAdditions) object;
 		if (obj != null && subqualifier != null) {
-			NSKeyValueCodingAdditions finalObj = (NSKeyValueCodingAdditions) obj.valueForKeyPath(baseKeyPath);
+			NSKeyValueCodingAdditions finalObj = baseKeyPath != null ? (NSKeyValueCodingAdditions) obj.valueForKeyPath(baseKeyPath) : obj;
 			if (finalObj != null) {
 				if (finalObj instanceof NSArray) {
 					NSArray<NSKeyValueCoding> objArray = (NSArray<NSKeyValueCoding>) finalObj;


### PR DESCRIPTION
When baseKeyPath is null (which can happen as there is a constructor setting it to null), the in-memory evaluation of ERXExistsQualifier will always return false. The object itself should be used for evaluation instead.