### PR TITLE
Fix the auto-focus script of ERD2WTabInspectPage

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WTabInspectPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WTabInspectPage.java
@@ -123,14 +123,20 @@ public class ERD2WTabInspectPage extends ERD2WInspectPage implements ERDTabEditP
 		if (d2wContext().valueForKey(Keys.firstResponderKey) != null) {
             return scriptForFirstResponderActivation();
         } else {
-            String result = "";
             String formName = ERXWOForm.formName(context(), "EditForm");
-            if (formName != null) {
-                int pos = tabSectionsContents().count() - 1;
-                result = "var pos=0;\n if (document." + formName + ".elements.length>" + pos +
-                        ") pos=" + pos + ";\n var elem = document." + formName + ".elements[" + pos +
-                        "];\n if (elem!=null && (elem.type == 'text' || elem.type ==  'area')) elem.focus();";
-            }
+            String result = "var focusedElement = document.querySelector('form[name=\"" + formName + "\"] input:focus');"
+                    // only continue when no form element is focused, yet
+                    + "if (focusedElement == undefined) {"
+                    + "    var focusableElements = document.querySelectorAll('form[name=\"" + formName + "\"] input');"
+                    + "    var qualifiedTypes = ['text', 'textarea'];"
+                    + "    for (i = 0; i < focusableElements.length; i++) { "
+                    + "        var anElement = focusableElements[i];"
+                    + "        if (qualifiedTypes.include(anElement.type.toLowerCase())) {"
+                    + "            anElement.focus();"
+                    + "            break;"
+                    + "        }"
+                    + "    }"
+                    + "}";
             return result;
         }
     }

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODTabInspectPage.wo/ERMODTabInspectPage.html
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODTabInspectPage.wo/ERMODTabInspectPage.html
@@ -26,6 +26,9 @@
         <webobject name = "ErrorBlock"/>
         <webobject name = "AboveDisplayPropertyKeys" />
         <webobject name = "InspectPageRepetition" />
+        <webobject name = "useFocus">
+          <webobject name = "IsEditing"><webobject name = "Script" /></webobject>
+        </webobject>
       </webobject>
     </webobject>
     <webobject name = "ShowBottomActionBlock">
@@ -49,8 +52,5 @@
         <webobject name = "SecondaryActionBlock"/>
       </webobject>
     </webobject>
-  </webobject>
-  <webobject name = "useFocus">
-    <webobject name = "IsEditing"><webobject name = "Script" /></webobject>
   </webobject>
 </webobject>


### PR DESCRIPTION
The current implementation would select an input based on the number of tabs that are defined. If three tabs were defined, the third form element would be selected – if it happens to be of type text or textarea. This is fixed to select the first available form element of these types.

Also enables the auto-focusing when the tab switch is carried out via ajax.