### PR TITLE
Improve ERD2W tab switching behaviour

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WContainer.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WContainer.java
@@ -50,4 +50,27 @@ public class ERD2WContainer implements Serializable {
         sb.append(keys);
         return sb.toString();
     }
+    
+    public boolean equals(Object something) {
+        boolean equals = true;
+        if (something == null) {
+            equals = false;
+        }
+        if (equals && !getClass().equals(something.getClass())) {
+            equals = false;
+        }
+        if (equals) {
+            ERD2WContainer other = (ERD2WContainer) something;
+            // verify name equality
+            if (name == null && other.name != null) {
+                equals = false;
+            }
+            if (equals && name != null && !name.equals(other.name)) {
+                equals = false;
+            }
+            // we don't verify display name and keys equality
+        }
+        return equals;
+    }
+    
 }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WInspectPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WInspectPage.java
@@ -22,6 +22,7 @@ import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSValidation;
 
+import er.directtoweb.ERD2WContainer;
 import er.directtoweb.ERD2WFactory;
 import er.directtoweb.interfaces.ERDEditPageInterface;
 import er.directtoweb.interfaces.ERDFollowPageInterface;
@@ -136,6 +137,15 @@ public class ERD2WInspectPage extends ERD2WPage implements InspectPageInterface,
 	    	EOEnterpriseObject object = ERXEOControlUtilities.editableInstanceOfObject(object(), createNestedContext);
 	    	editPage.setObject(object);
             editPage.setNextPage(nextPage());
+	    	if (currentTab() != null && editPage instanceof ERD2WPage) {
+	    	    // try to keep the current tab selection
+	    	    ERD2WPage tabPage = (ERD2WPage) editPage;
+	    	    for (ERD2WContainer aTab : tabPage.tabSectionsContents()) {
+	    	        if (aTab.equals(currentTab())) {
+	    	            tabPage.setCurrentTab(aTab);
+	    	        }
+	    	    }
+	    	}
             returnPage = (WOComponent)editPage;
         }
         return returnPage != null ? returnPage : previousPage();

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPage.java
@@ -992,14 +992,16 @@ public abstract class ERD2WPage extends D2WPage implements ERXExceptionHolder, E
 
     /** Returns the {@link er.directtoweb.ERD2WContainer} defining the current tab. */
     public ERD2WContainer currentTab() {
-        if (_currentTab == null && tabSectionsContents() != null && tabSectionsContents().count() > 0) {
-            //If firstTab is not null, then try to find the tab named firstTab
-        	Integer tabIndex = (Integer) d2wContext().valueForKey(Keys.tabIndex);
-            if(tabIndex!=null && tabIndex.intValue() <= tabSectionsContents().count()){
-                setCurrentTab(tabSectionsContents().objectAtIndex(tabIndex.intValue()));
-            }
-            if(_currentTab==null)
-                setCurrentTab(tabSectionsContents().objectAtIndex(0));
+        String tabName = (String) d2wContext().valueForKey(Keys.tabKey); 
+        if (_currentTab == null && !ERXStringUtilities.stringIsNullOrEmpty(tabName)) {
+           for (ERD2WContainer aTab : tabSectionsContents()) {
+               if (tabName.equals(aTab.name)) {
+                   setCurrentTab(aTab);
+               }
+           }
+        }
+        if (_currentTab == null) {
+            _currentTab = tabSectionsContents().objectAtIndex(0);
         }
         return _currentTab;
     }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPage.java
@@ -953,7 +953,6 @@ public abstract class ERD2WPage extends D2WPage implements ERXExceptionHolder, E
             _tabSectionsContents = tabSectionsContentsFromRuleResult(tabSectionContentsFromRule);
             ERXStats.markEnd("D2W", statsKey);
             
-            d2wContext().takeValueForKey(tabSectionContentsFromRule, "tabSectionsContents");
             // Once calculated we then determine any displayNameForTabKey
             String currentTabKey = (String) d2wContext().valueForKey(Keys.tabKey);
             for (Enumeration e = _tabSectionsContents.objectEnumerator(); e.hasMoreElements();) {
@@ -977,6 +976,7 @@ public abstract class ERD2WPage extends D2WPage implements ERXExceptionHolder, E
      */
     protected void clearTabSectionsContents() {
     	_tabSectionsContents = null;
+    	_currentTab = null;
     }
 
     /** Dummy denoting to sections. */

--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODTabInspectPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODTabInspectPage.java
@@ -8,7 +8,6 @@ import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
 
-import er.directtoweb.ERD2WContainer;
 import er.directtoweb.pages.templates.ERD2WTabInspectPageTemplate;
 import er.extensions.eof.ERXEC;
 import er.extensions.eof.ERXEOControlUtilities;
@@ -114,11 +113,7 @@ public class ERMODTabInspectPage extends ERD2WTabInspectPageTemplate {
 	 */
 	@Override
 	public void setObject(EOEnterpriseObject eoenterpriseobject) {
-		// If we are getting a new EO, then reset the current step.
-		if (eoenterpriseobject != null && !eoenterpriseobject.equals(object())) {
-			ERD2WContainer tab = tabSectionsContents().objectAtIndex(0);
-			setTabByName(tab.name);
-		}
+	    clearTabSectionsContents();
 		super.setObject(eoenterpriseobject);
 	}
 	


### PR DESCRIPTION
The current tab page implementation has some issues, especially when using ajax. When a new ERD2WContainer is instantiated, the navigation will fail, as the default equals() implementation then always returns false. The selected tab is lost when switching from inspect to edit. Changes to the tabSectionsContents (addition or removal of tabs or property keys) will not be honored on switching via ajax from inspect to edit mode.

To remedy these, the tab name is used as the identifier instead of the index of the tab in the tab sections contents. An equals() implementation that compares only the names is added. The caching behaviour is modified to prevent stale tab sections contents from being returned.