### PR TITLE
Extra restricting qualifier handling for ERD2WEditToOneRelationship

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToOneRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToOneRelationship.java
@@ -8,16 +8,18 @@ package er.directtoweb.components.relationships;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WEditToOneRelationship;
-import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.eoaccess.EOUtilities;
+import com.webobjects.eocontrol.EOFetchSpecification;
+import com.webobjects.eocontrol.EOQualifier;
 
-import er.extensions.foundation.ERXUtilities;
+import er.directtoweb.components.ERDCustomEditComponent;
 
 /**
  * Improves superclass by adding restrictions on the choices and uses ERXToOneRelationship, thus can handle localization
  * and has better layout options.
  * @d2wKey restrictedChoiceKey keypath off the component that returns the list of objects to display
  * @d2wKey restrictingFetchSpecification name of the fetchSpec to use for the list of objects.
+ * @d2wKey extraRestrictingQualifier pass a qualifier using @ERDDelayedExtraQualifierAssignment
  * @d2wKey sortKey
  * @d2wKey numCols
  * @d2wKey propertyKey
@@ -34,12 +36,35 @@ import er.extensions.foundation.ERXUtilities;
  * @d2wKey goingVertically
  */
 public class ERD2WEditToOneRelationship extends D2WEditToOneRelationship {
-	/**
+
+    /**
 	 * Do I need to update serialVersionUID?
 	 * See section 5.6 <cite>Type Changes Affecting Serialization</cite> on page 51 of the 
 	 * <a href="http://java.sun.com/j2se/1.4/pdf/serial-spec.pdf">Java Object Serialization Spec</a>
 	 */
 	private static final long serialVersionUID = 1L;
+  
+	public interface Keys extends ERDCustomEditComponent.Keys {
+	    public static final String restrictedChoiceKey = "restrictedChoiceKey";
+	    public static final String restrictingFetchSpecification = "restrictingFetchSpecification";
+	    public static final String extraRestrictingQualifier = "extraRestrictingQualifier";
+	    public static final String sortKey = "sortKey";
+	    public static final String numCols = "numCols";
+	    public static final String propertyKey = "propertyKey";
+	    public static final String size = "size";
+	    public static final String toOneUIStyle = "toOneUIStyle";
+	    public static final String noSelectionString = "noSelectionString";
+	    public static final String popupName = "popupName";
+	    public static final String localizeDisplayKeys = "localizeDisplayKeys";
+	    public static final String uniqueID = "uniqueID";
+	    public static final String destinationEntityName = "destinationEntityName";
+	    public static final String sortCaseInsensitive = "sortCaseInsensitive";
+	    public static final String id = "id";
+	    public static final String title = "title";
+	    public static final String goingVertically = "goingVertically";
+	}
+	
+	private EOQualifier _extraQualifier;
 
     public ERD2WEditToOneRelationship(WOContext context) {
         super(context);
@@ -52,15 +77,28 @@ public class ERD2WEditToOneRelationship extends D2WEditToOneRelationship {
     }
 
     public Object restrictedChoiceList() {
-        String restrictedChoiceKey=(String)d2wContext().valueForKey("restrictedChoiceKey");
+        String restrictedChoiceKey=(String)d2wContext().valueForKey(Keys.restrictedChoiceKey);
         if( restrictedChoiceKey!=null &&  restrictedChoiceKey.length()>0 )
             return valueForKeyPath(restrictedChoiceKey);
-        String fetchSpecName=(String)d2wContext().valueForKey("restrictingFetchSpecification");
+        String fetchSpecName=(String)d2wContext().valueForKey(Keys.restrictingFetchSpecification);
         if(fetchSpecName != null) {
-            EORelationship relationship = ERXUtilities.relationshipWithObjectAndKeyPath(object(),
-                                                                                        (String)d2wContext().valueForKey("propertyKey"));
-            return EOUtilities.objectsWithFetchSpecificationAndBindings(object().editingContext(), relationship.destinationEntity().name(),fetchSpecName,null);
+            return EOUtilities.objectsWithFetchSpecificationAndBindings(object()
+                    .editingContext(), relationship().destinationEntity().name(),
+                    fetchSpecName, null);
+        }
+        if (extraQualifier() != null) {
+            EOFetchSpecification fs = new EOFetchSpecification(relationship()
+                    .destinationEntity().name(), extraQualifier(), null);
+            return object().editingContext().objectsWithFetchSpecification(fs);
         }
         return null;
     }
+    
+    public EOQualifier extraQualifier() {
+        if (_extraQualifier == null) {
+            _extraQualifier = (EOQualifier)valueForBinding(Keys.extraRestrictingQualifier);
+        }
+        return _extraQualifier;
+    }
+
 }


### PR DESCRIPTION
Add ability to specify the restricted choice list via a rule making use of ERDDelayedExtraQualifierAssignment. This is a more flexible alternative to the use of a named fetch specification.