### PR TITLE
Revert change to ERD2WModel

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WModel.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WModel.java
@@ -478,7 +478,7 @@ public class ERD2WModel extends D2WModel {
                         delayedDependendKeysPerKey.put(rhsKey, recipientForNewKeys);
                     }
                 }
-                NSArray extraKeys=((er.directtoweb.assignments.ERDLocalizedAssignment)r.rhs()).dependentKeys(rhsKey);
+                NSArray extraKeys=((ERDComputingAssignmentInterface)r.rhs()).dependentKeys(rhsKey);
                 if (extraKeys!=null) {
                     for (Enumeration e6=extraKeys.objectEnumerator(); e6.hasMoreElements(); ) {
                         String k=(String)e6.nextElement();


### PR DESCRIPTION
This would cause D2W model files to not get merged on startup. The change was part of #610.