### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+jdk:
+  - oraclejdk8
+
+env:
+  # set NEXT_ROOT, so apps will start
+  - NEXT_ROOT=/home/travis/build
+
+script: "mvn verify"
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Adds a basic configuration file for running the maven build via the https://travis-ci.org continuous integration service. Unlike the community jenkins server, this allows for automated [building of pull requests](https://docs.travis-ci.com/user/pull-requests), without any security concerns for us.

To make this useful, a committer will have to create an account with Travis CI.