### PR TITLE
Fix wrong argument order after refactoring

### DIFF
--- a/Archives/Examples/DevStudio/Sources/ag/kcmedia/Jode.java
+++ b/Archives/Examples/DevStudio/Sources/ag/kcmedia/Jode.java
@@ -21,6 +21,7 @@ import jode.decompiler.Decompiler;
 import jode.type.Type;
 
 import org.apache.log4j.Logger;
+import org.apache.commons.lang3.StringUtils;
 
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
@@ -28,7 +29,6 @@ import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSSelector;
 
-import er.extensions.foundation.ERXStringUtilities;
 import er.extensions.localization.ERXLocalizer;
 
 public class Jode extends Object {
@@ -271,7 +271,7 @@ public class Jode extends Object {
             } catch (Exception ex) {
                 log.error(ex);
             }
-            sourceCode = ERXStringUtilities.replaceStringByStringInString("\n\n", "<br>", sourceCode);
+            sourceCode = StringUtils.replace(sourceCode, "\n\n", "<br>");
             return sourceCode;
         }
 

--- a/Archives/Examples/DevStudio/Sources/ag/kcmedia/RuleEditor.java
+++ b/Archives/Examples/DevStudio/Sources/ag/kcmedia/RuleEditor.java
@@ -26,7 +26,8 @@ import com.webobjects.foundation.NSPropertyListSerialization;
 import com.webobjects.foundation.NSSet;
 
 import er.extensions.foundation.ERXArrayUtilities;
-import er.extensions.foundation.ERXStringUtilities;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class RuleEditor extends WOComponent {
     static final Logger log = Logger.getLogger(RuleEditor.class);
@@ -99,7 +100,7 @@ public class RuleEditor extends WOComponent {
     }
     public String fixString(Object o) {
         String fix = "'" + o + "'";
-        return ERXStringUtilities.replaceStringByStringInString("*", "[*]", fix);
+        return StringUtils.replace(fix, "*", "[*]");
     }
     public NSArray modelPages() {
         Enumeration e = model.publicDynamicPages().elements();

--- a/Build/build/build.xml
+++ b/Build/build/build.xml
@@ -953,6 +953,7 @@
 	<target name="PostgresqlPlugIn.all">
         <antcall target="global.framework.${build.action}">
             <param name="project.dir" value="Frameworks/PlugIns/PostgresqlPlugIn" />
+      		<param name="wo.external.root.bundles" value="ERJars" />
         </antcall>
     </target>
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/javascript/ERXJSFlyOver.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/javascript/ERXJSFlyOver.java
@@ -1,11 +1,10 @@
 package er.extensions.components.javascript;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.webobjects.appserver.WOContext;
 
 import er.extensions.components.ERXStatelessComponent;
-import er.extensions.foundation.ERXStringUtilities;
 
 public class ERXJSFlyOver extends ERXStatelessComponent {
 	/**
@@ -30,7 +29,7 @@ public class ERXJSFlyOver extends ERXStatelessComponent {
     }
    
     public String id() {
-        return StringUtils.replace(".", "_", context().elementID());
+        return StringUtils.replace(context().elementID(), ".", "_");
     }
     
     public String alignString() {

--- a/Frameworks/Misc/ERSelenium/Sources/er/selenium/SeleniumTestSuite.java
+++ b/Frameworks/Misc/ERSelenium/Sources/er/selenium/SeleniumTestSuite.java
@@ -23,7 +23,7 @@
 
 package er.selenium;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WODirectAction;
@@ -31,7 +31,6 @@ import com.webobjects.appserver.WORequest;
 
 import er.extensions.appserver.ERXHttpStatusCodes;
 import er.extensions.appserver.ERXResponse;
-import er.extensions.foundation.ERXStringUtilities;
 
 /**
  * Starts testing of a suite of tests (a directory)
@@ -57,7 +56,7 @@ public class SeleniumTestSuite extends WODirectAction {
 	    }
 
 	    SeleniumTestSuitePage page = (SeleniumTestSuitePage)pageWithName(SeleniumTestSuitePage.class.getName());
-	    page.setTestPath(StringUtils.replace(ERSelenium.SUITE_SEPERATOR, "/", anActionName));
+	    page.setTestPath(StringUtils.replace(anActionName, ERSelenium.SUITE_SEPERATOR, "/"));
 	    return page;
 	}
 }

--- a/Frameworks/PlugIns/DB2PlugIn/Sources/com/webobjects/jdbcadaptor/DB2Expression.java
+++ b/Frameworks/PlugIns/DB2PlugIn/Sources/com/webobjects/jdbcadaptor/DB2Expression.java
@@ -850,6 +850,7 @@ public class DB2Expression extends JDBCExpression {
      * @param newString to be inserted
      * @param buffer string to have the replacement done on it
      * @return string after having all of the replacement done.
+     * @deprecated use {@link StringUtils#replace(String, String, String)} instead
      */
     public static String replaceStringByStringInString(String old, String newString, String buffer) {
         int begin, end;

--- a/Frameworks/PlugIns/PostgresqlPlugIn/.classpath
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/.classpath
@@ -6,5 +6,6 @@
 	<classpathentry exported="true" kind="con" path="WOFramework/JavaFoundation"/>
 	<classpathentry exported="true" kind="con" path="WOFramework/JavaJDBCAdaptor"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="WOFramework/ERJars"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlExpression.java
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlExpression.java
@@ -1067,6 +1067,7 @@ public class PostgresqlExpression extends JDBCExpression {
      * @param newString to be inserted
      * @param buffer string to have the replacement done on it
      * @return string after having all of the replacement done.
+     * @deprecated use {@link StringUtils#replace(String, String, String)} instead
      */
     public static String replaceStringByStringInString(String old, String newString, String buffer) {
         int begin, end;

--- a/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlSynchronizationFactory.java
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlSynchronizationFactory.java
@@ -479,93 +479,97 @@ public class PostgresqlSynchronizationFactory extends EOSynchronizationFactory i
 
     @Override
     public String schemaCreationScriptForEntities(NSArray allEntities, NSDictionary options)
-    {
-/* 741*/        StringBuffer result = new StringBuffer();
-/* 744*/        if(options == null)
-/* 745*/            options = NSDictionary.EmptyDictionary;
-/* 747*/        NSArray statements = schemaCreationStatementsForEntities(allEntities, options);
-/* 748*/        int i = 0;
-/* 748*/        for(int count = statements.count(); i < count; i++)
-/* 749*/            appendExpressionToScript((EOSQLExpression)statements.objectAtIndex(i), result);
+ {
+        StringBuffer result = new StringBuffer();
+        if (options == null)
+            options = NSDictionary.EmptyDictionary;
+        NSArray statements = schemaCreationStatementsForEntities(allEntities, options);
+        int i = 0;
+        for (int count = statements.count(); i < count; i++)
+            appendExpressionToScript((EOSQLExpression) statements.objectAtIndex(i),
+                    result);
 
-/* 751*/        return result.toString();
+        return result.toString();
     }
 
     @Override
     public NSArray schemaCreationStatementsForEntities(NSArray allEntities, NSDictionary options)
-    {
-/* 879*/        NSMutableArray result = new NSMutableArray();
-/* 880*/        if(allEntities == null || allEntities.count() == 0)
-/* 881*/            return result;
-/* 883*/        if(options == null)
-/* 884*/            options = NSDictionary.EmptyDictionary;
-/* 889*/        NSDictionary connectionDictionary = ((EOEntity)allEntities.lastObject()).model().connectionDictionary();
-/* 892*/        boolean createDatabase = _NSDictionaryUtilities.boolValueForKeyDefault(options, "createDatabase", false);
-/* 893*/        boolean dropDatabase = _NSDictionaryUtilities.boolValueForKeyDefault(options, "dropDatabase", false);
-/* 895*/        if(createDatabase || dropDatabase)
-        {
-/* 896*/            boolean adminCommentsNeeded = false;
-/* 897*/            NSArray dropDatabaseStatements = null;
-/* 898*/            NSArray createDatabaseStatements = null;
-/* 900*/            if(dropDatabase)
-            {
-/* 901*/                dropDatabaseStatements = dropDatabaseStatementsForConnectionDictionary(connectionDictionary, null);
-/* 903*/                if(dropDatabaseStatements == null)
-/* 904*/                    dropDatabaseStatements = new NSArray(_expressionForString("/* The 'Drop Database' option is unavailable. */"));
-/* 907*/                else
-/* 907*/                    adminCommentsNeeded = true;
+ {
+        NSMutableArray result = new NSMutableArray();
+        if (allEntities == null || allEntities.count() == 0)
+            return result;
+        if (options == null)
+            options = NSDictionary.EmptyDictionary;
+        NSDictionary connectionDictionary = ((EOEntity) allEntities.lastObject()).model()
+                .connectionDictionary();
+        boolean createDatabase = _NSDictionaryUtilities.boolValueForKeyDefault(options,
+                "createDatabase", false);
+        boolean dropDatabase = _NSDictionaryUtilities.boolValueForKeyDefault(options,
+                "dropDatabase", false);
+        if (createDatabase || dropDatabase) {
+            boolean adminCommentsNeeded = false;
+            NSArray dropDatabaseStatements = null;
+            NSArray createDatabaseStatements = null;
+            if (dropDatabase) {
+                dropDatabaseStatements = dropDatabaseStatementsForConnectionDictionary(
+                        connectionDictionary, null);
+                if (dropDatabaseStatements == null)
+                    dropDatabaseStatements = new NSArray(
+                            _expressionForString("/* The 'Drop Database' option is unavailable. */"));
+                else
+                    adminCommentsNeeded = true;
             }
-/* 911*/            if(createDatabase)
-            {
-/* 912*/                createDatabaseStatements = createDatabaseStatementsForConnectionDictionary(connectionDictionary, null);
-/* 914*/                if(createDatabaseStatements == null)
-/* 915*/                    createDatabaseStatements = new NSArray(_expressionForString("/* The 'Create Database' option is unavailable. */"));
-/* 918*/                else
-/* 918*/                    adminCommentsNeeded = true;
+            if (createDatabase) {
+                createDatabaseStatements = createDatabaseStatementsForConnectionDictionary(
+                        connectionDictionary, null);
+                if (createDatabaseStatements == null)
+                    createDatabaseStatements = new NSArray(
+                            _expressionForString("/* The 'Create Database' option is unavailable. */"));
+                else
+                    adminCommentsNeeded = true;
             }
-/* 922*/            if(adminCommentsNeeded)
-/* 923*/                result.addObject(_expressionForString("/* connect as an administrator */"));
-/* 926*/            if(dropDatabaseStatements != null)
-/* 927*/                result.addObjectsFromArray(dropDatabaseStatements);
-/* 930*/            if(createDatabaseStatements != null)
-/* 931*/                result.addObjectsFromArray(createDatabaseStatements);
-/* 934*/            if(adminCommentsNeeded)
-/* 935*/                result.addObject(_expressionForString("/* connect as the user from the connection dictionary */"));
+            if (adminCommentsNeeded)
+                result.addObject(_expressionForString("/* connect as an administrator */"));
+            if (dropDatabaseStatements != null)
+                result.addObjectsFromArray(dropDatabaseStatements);
+            if (createDatabaseStatements != null)
+                result.addObjectsFromArray(createDatabaseStatements);
+            if (adminCommentsNeeded)
+                result.addObject(_expressionForString("/* connect as the user from the connection dictionary */"));
         }
-/* 939*/        if(_NSDictionaryUtilities.boolValueForKeyDefault(options, "dropPrimaryKeySupport", true))
-        {
-/* 940*/            NSArray entityGroups = primaryKeyEntityGroupsForEntities(allEntities);
-/* 941*/            result.addObjectsFromArray(dropPrimaryKeySupportStatementsForEntityGroups(entityGroups));
+        if (_NSDictionaryUtilities.boolValueForKeyDefault(options,
+                "dropPrimaryKeySupport", true)) {
+            NSArray entityGroups = primaryKeyEntityGroupsForEntities(allEntities);
+            result.addObjectsFromArray(dropPrimaryKeySupportStatementsForEntityGroups(entityGroups));
         }
-/* 944*/        if(_NSDictionaryUtilities.boolValueForKeyDefault(options, "dropTables", true))
-        {
-/* 945*/            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
-/* 946*/            result.addObjectsFromArray(dropTableStatementsForEntityGroups(entityGroups));
+        if (_NSDictionaryUtilities.boolValueForKeyDefault(options, "dropTables", true)) {
+            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
+            result.addObjectsFromArray(dropTableStatementsForEntityGroups(entityGroups));
         }
-/* 949*/        if(_NSDictionaryUtilities.boolValueForKeyDefault(options, "createTables", true))
-        {
-/* 950*/            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
-/* 951*/            result.addObjectsFromArray(createTableStatementsForEntityGroups(entityGroups));
+        if (_NSDictionaryUtilities.boolValueForKeyDefault(options, "createTables", true)) {
+            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
+            result.addObjectsFromArray(createTableStatementsForEntityGroups(entityGroups));
         }
-/* 954*/        if(_NSDictionaryUtilities.boolValueForKeyDefault(options, "createPrimaryKeySupport", true))
-        {
-/* 955*/            NSArray entityGroups = primaryKeyEntityGroupsForEntities(allEntities);
-/* 956*/            result.addObjectsFromArray(primaryKeySupportStatementsForEntityGroups(entityGroups));
-                }
-/* 959*/        if(_NSDictionaryUtilities.boolValueForKeyDefault(options, "primaryKeyConstraints", true))
-                {
-/* 960*/            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
-/* 961*/            result.addObjectsFromArray(primaryKeyConstraintStatementsForEntityGroups(entityGroups));
-                }
-/* 964*/        if(_NSDictionaryUtilities.boolValueForKeyDefault(options, "foreignKeyConstraints", false))
-                {
-/* 965*/            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
-/* 966*/            int i = 0;
-/* 966*/            for(int iCount = entityGroups.count(); i < iCount; i++)
-/* 967*/                result.addObjectsFromArray(_foreignKeyConstraintStatementsForEntityGroup((NSArray)entityGroups.objectAtIndex(i)));
+        if (_NSDictionaryUtilities.boolValueForKeyDefault(options,
+                "createPrimaryKeySupport", true)) {
+            NSArray entityGroups = primaryKeyEntityGroupsForEntities(allEntities);
+            result.addObjectsFromArray(primaryKeySupportStatementsForEntityGroups(entityGroups));
+        }
+        if (_NSDictionaryUtilities.boolValueForKeyDefault(options,
+                "primaryKeyConstraints", true)) {
+            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
+            result.addObjectsFromArray(primaryKeyConstraintStatementsForEntityGroups(entityGroups));
+        }
+        if (_NSDictionaryUtilities.boolValueForKeyDefault(options,
+                "foreignKeyConstraints", false)) {
+            NSArray entityGroups = tableEntityGroupsForEntities(allEntities);
+            int i = 0;
+            for (int iCount = entityGroups.count(); i < iCount; i++)
+                result.addObjectsFromArray(_foreignKeyConstraintStatementsForEntityGroup((NSArray) entityGroups
+                        .objectAtIndex(i)));
 
-                }
-/* 970*/        return result;
-            }
+        }
+        return result;
+    }
 
 }

--- a/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlSynchronizationFactory.java
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/Sources/com/webobjects/jdbcadaptor/PostgresqlSynchronizationFactory.java
@@ -1,5 +1,7 @@
 package com.webobjects.jdbcadaptor;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.webobjects.eoaccess.EOAdaptor;
 import com.webobjects.eoaccess.EOAttribute;
 import com.webobjects.eoaccess.EOEntity;
@@ -177,13 +179,13 @@ public class PostgresqlSynchronizationFactory extends EOSynchronizationFactory i
         NSArray<EOSQLExpression> superResults = super.foreignKeyConstraintStatementsForRelationship(relationship);
         for (EOSQLExpression expression : superResults) {
             String s = expression.statement();
-            s = replaceStringByStringInString(") INITIALLY DEFERRED", ") DEFERRABLE INITIALLY DEFERRED", s);
+            s = StringUtils.replace(s, ") INITIALLY DEFERRED", ") DEFERRABLE INITIALLY DEFERRED");
             expression.setStatement(s);
             results.addObject(expression);
             // timc 2006-11-06 check for enableIdentifierQuoting
             String tableNameWithoutSchemaName = externalNameForEntityWithoutSchema(relationship.entity());
             String tableName = expression.sqlStringForSchemaObjectName(expression.entity().externalName());
-            s = replaceStringByStringInString("ALTER TABLE " + tableNameWithoutSchemaName, "ALTER TABLE " + tableName, s);
+            s = StringUtils.replace(s, "ALTER TABLE " + tableNameWithoutSchemaName, "ALTER TABLE " + tableName);
             expression.setStatement(s);
             NSArray<String> columnNames = ((NSArray<String>) relationship.sourceAttributes().valueForKey("columnName"));
             StringBuilder sbColumnNames = new StringBuilder();
@@ -368,6 +370,7 @@ public class PostgresqlSynchronizationFactory extends EOSynchronizationFactory i
 	 * @param buffer
 	 *            string to have the replacement done on it
 	 * @return string after having all of the replacement done.
+	 * @deprecated use {@link StringUtils#replace(String, String, String)} instead
 	 */
     public static String replaceStringByStringInString(String old, String newString, String buffer) {
         int begin, end;

--- a/Frameworks/PlugIns/PostgresqlPlugIn/pom.xml
+++ b/Frameworks/PlugIns/PostgresqlPlugIn/pom.xml
@@ -26,6 +26,10 @@
 			<groupId>com.webobjects</groupId>
 			<artifactId>JavaFoundation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<sourceDirectory>Sources</sourceDirectory>


### PR DESCRIPTION
In #610, ERXStringUtilities.replaceStringByStringInString got removed. The replacement method from commons lang has a different method signature. This fixes the occurrences in ERXJSFlyOver and SeleniumTestSuite.

There were a few other references or separate implementations. These have been replaced with calls to the commons lang method or marked as deprecated.