### PR TITLE
When ERXWOComponentContent has a single children WODynamicElement, th…

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXWOComponentContent.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXWOComponentContent.java
@@ -154,7 +154,7 @@ public class ERXWOComponentContent extends WODynamicElement {
     	WOElement content =  component._childTemplate();
     	WOElement result = null;
     	String templateName = (_templateName == null) ? null : (String) _templateName.valueInComponent(component);
-    	if (content instanceof WODynamicGroup) {
+    	if (content.getClass() == WODynamicGroup.class) {
 			WODynamicGroup group = (WODynamicGroup) content;
 			if (templateName == null) {
 				// MS: If you don't set a template name, then let's construct all the children of 
@@ -190,7 +190,7 @@ public class ERXWOComponentContent extends WODynamicElement {
     		if(name.equals(templateName)) {
     			result = template;
     		}
-		} else if (content instanceof WOHTMLBareString && templateName == null) {
+		} else if (templateName == null) {
 			result=content;
 		}
     	return result;


### PR DESCRIPTION
Based on wonder_6 branch.

This fix situation like this:
<wo:PageContainer><wo:AjaxUpdateContainer id="xxx">
  ....content ....
</wo:AjaxUpdateContainer></wo:PageContainer>

Where the actual code skip the AjaxUpdateContainer completely.