### PR TITLE
Add character encoding to REST responses

### DIFF
--- a/Examples/Misc/ERRestRouteExample/Components/Main.wo/Main.html
+++ b/Examples/Misc/ERRestRouteExample/Components/Main.wo/Main.html
@@ -11,6 +11,9 @@ The source for ERXRestRouteExample is intended to be browsed. To fully understan
 	<li><b><wo:ERXRouteLink entityName="Company" action="index" format="plist">Show all Companies in plist format</wo:ERXRouteLink></b><br/>
 			curl <wo:ERXRouteURL entityName="Company" format="plist" absolute="$true"/></li>
 
+	<li><b><wo:ERXRouteLink entityName="Company" action="index" format="bplist">Show all Companies in binary plist format</wo:ERXRouteLink></b><br/>
+			curl <wo:ERXRouteURL entityName="Company" format="bplist" absolute="$true"/></li>
+
 	<li><b><wo:ERXRouteLink entityName="Company" action="index" format="xml">Show all Companies in XML format</wo:ERXRouteLink></b><br/>
 			curl <wo:ERXRouteURL entityName="Company" format="xml" absolute="$true"/></li>
 
@@ -20,8 +23,8 @@ The source for ERXRestRouteExample is intended to be browsed. To fully understan
 	<li><b><wo:ERXRouteLink entityName="Company" action="index" format="sc">Show all Companies in SproutCore format</wo:ERXRouteLink></b><br/>
 			curl <wo:ERXRouteURL entityName="Company" format="sc" absolute="$true"/></li>
 
-	<li><b><wo:ERXRouteLink entityName="Company" action="index" format="gndp">Show all Companies in Gianduia format</wo:ERXRouteLink></b><br/>
-			curl <wo:ERXRouteURL entityName="Company" format="gndp" absolute="$true"/></li>
+	<li><b><wo:ERXRouteLink entityName="Company" action="index" format="ember">Show all Companies in Ember format</wo:ERXRouteLink></b><br/>
+			curl <wo:ERXRouteURL entityName="Company" format="ember" absolute="$true"/></li>
 
 	<li><b><wo:ERXRouteLink entityName="Person" id="1" action="show" format="plist">Show Person 1 in plist format</wo:ERXRouteLink></b><br/>
 			curl <wo:ERXRouteURL entityName="Person" id="1" action="show" format="plist" absolute="$true"/></li>

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXBinaryPListRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXBinaryPListRestWriter.java
@@ -10,19 +10,26 @@ import er.extensions.foundation.ERXPropertyListSerialization;
 import er.rest.ERXRestContext;
 import er.rest.ERXRestRequestNode;
 
-public class ERXBinaryPListRestWriter implements IERXRestWriter {
-	public void appendHeadersToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestContext context) {
-		response.setHeader("application/x-plist", "Content-Type");
-	}
-
+public class ERXBinaryPListRestWriter extends ERXRestWriter {
 	public void appendToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestFormat.Delegate delegate, ERXRestContext context) {
 		if (node != null) {
 			node._removeRedundantTypes();
 		}
 		appendHeadersToResponse(node, response, context);
+		response.setContentEncoding(contentEncoding());
 		Object object = node.toNSCollection(delegate);
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		ERXPropertyListSerialization.writePropertyListToStream(object, out, ERXPropertyListSerialization.PListFormat.NSPropertyListBinaryFormat_v1_0, CharEncoding.UTF_8);
 		response.appendContentData(new NSData(out.toByteArray()));
+	}
+
+	@Override
+	public String contentType() {
+		return "application/x-plist";
+	}
+
+	@Override
+	protected String contentTypeHeaderValue() {
+		return contentType();
 	}
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXJSONRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXJSONRestWriter.java
@@ -12,7 +12,7 @@ import er.rest.ERXRestUtils;
  * @property <code>er.rest.format.ERXJSONRestWriter.shouldPrettyPrint</code> Boolean property to enable pretty-printing of JSON response. Defaults to false.
  * @property <code>er.rest.format.ERXJSONRestWriter.prettyPrintIndent</code> Integer property to set the pretty print indentation space count. Defaults to <code>2</code>.
  */
-public class ERXJSONRestWriter implements IERXRestWriter {
+public class ERXJSONRestWriter extends ERXRestWriter {
 
 	// Lazily initialized static constants
 	private static class CONSTANTS {
@@ -31,10 +31,6 @@ public class ERXJSONRestWriter implements IERXRestWriter {
 		return node;
 	}
 
-	public void appendHeadersToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestContext context) {
-		response.setHeader("application/json", "Content-Type");
-	}
-
 	public void appendToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestFormat.Delegate delegate, ERXRestContext context) {
 		node = processNode(node);
 		if (node != null) {
@@ -42,6 +38,7 @@ public class ERXJSONRestWriter implements IERXRestWriter {
 		}
 		
 		appendHeadersToResponse(node, response, context);
+		response.setContentEncoding(contentEncoding());
 		Object object = node.toJavaCollection(delegate);
 		if (object == null) {
 			response.appendContentString("undefined");
@@ -55,5 +52,10 @@ public class ERXJSONRestWriter implements IERXRestWriter {
 			response.appendContentString(json);
 		}
 		response.appendContentString("\n");
+	}
+
+	@Override
+	public String contentType() {
+		return "application/json";
 	}
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXPListRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXPListRestWriter.java
@@ -5,18 +5,20 @@ import com.webobjects.foundation.NSPropertyListSerialization;
 import er.rest.ERXRestContext;
 import er.rest.ERXRestRequestNode;
 
-public class ERXPListRestWriter implements IERXRestWriter {
-	public void appendHeadersToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestContext context) {
-		response.setHeader("text/plain", "Content-Type");
-	}
-
+public class ERXPListRestWriter extends ERXRestWriter {
 	public void appendToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestFormat.Delegate delegate, ERXRestContext context) {
 		if (node != null) {
 			node._removeRedundantTypes();
 		}
 		appendHeadersToResponse(node, response, context);
+		response.setContentEncoding(contentEncoding());
 		Object object = node.toNSCollection(delegate);
 		response.appendContentString(NSPropertyListSerialization.stringFromPropertyList(object));
 		response.appendContentString("\n");
+	}
+
+	@Override
+	public String contentType() {
+		return "text/plain";
 	}
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXRestWriter.java
@@ -1,0 +1,100 @@
+package er.rest.format;
+
+import java.io.UnsupportedEncodingException;
+
+import com.webobjects.foundation.NSForwardException;
+
+import er.rest.ERXRestContext;
+import er.rest.ERXRestRequestNode;
+
+public abstract class ERXRestWriter implements IERXRestWriter {
+	/** The HTTP header key for the content type. */
+	protected static final String ContentTypeHeaderKey = "Content-Type";
+	/** The default character encoding for the REST responses. */
+	protected static String TheDefaultResponseEncoding = "UTF-8";
+	protected String contentEncoding;
+
+	public ERXRestWriter() {
+		contentEncoding = defaultEncoding();
+	}
+
+	@Override
+	public void appendHeadersToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestContext context) {
+		response.setHeader(contentTypeHeaderValue(), ContentTypeHeaderKey);
+	}
+
+	/**
+	 * The default character encoding to use for REST responses. The default value for this is UTF-8.
+	 *
+	 * @return the default character encoding
+	 */
+	public static String defaultEncoding() {
+		return TheDefaultResponseEncoding;
+	}
+
+	/**
+	 * Lets you specify the default character encoding to be used for REST responses.
+	 *
+	 * @param encoding
+	 *            the default character encoding
+	 */
+	public static void setDefaultEncoding(String encoding) {
+		if (encoding != null && !encoding.equals(TheDefaultResponseEncoding)) {
+			try {
+				"test".getBytes(encoding);
+			}
+			catch (UnsupportedEncodingException e) {
+				throw NSForwardException._runtimeExceptionForThrowable(e);
+			}
+			TheDefaultResponseEncoding = encoding;
+		}
+	}
+
+	/**
+	 * The character encoding to use for this REST response.
+	 * 
+	 * @return the content's character encoding
+	 */
+	public String contentEncoding() {
+		return contentEncoding;
+	}
+
+	/**
+	 * Lets you specify the content's character encoding to be used for this REST response.
+	 * 
+	 * @param encoding
+	 *            the content's character encoding
+	 */
+	public void setContentEncoding(String encoding) {
+		if (encoding != null && !encoding.equals(contentEncoding)) {
+			try {
+				"test".getBytes(encoding);
+			}
+			catch (UnsupportedEncodingException e) {
+				throw NSForwardException._runtimeExceptionForThrowable(e);
+			}
+
+			contentEncoding = encoding;
+		}
+	}
+
+	/**
+	 * The corresponding HTTP header content type for this REST response.
+	 *
+	 * @return content type
+	 */
+	public abstract String contentType();
+
+	/**
+	 * The value to be used for the content type HTTP header.
+	 * 
+	 * @return content type header value
+	 */
+	protected String contentTypeHeaderValue() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(contentType());
+		sb.append("; charset=");
+		sb.append(contentEncoding());
+		return sb.toString();
+	}
+}

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXWORestResponse.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXWORestResponse.java
@@ -25,4 +25,9 @@ public class ERXWORestResponse implements IERXRestResponse {
 	public void appendContentData(NSData data) {
 		_response.appendContentData(data);
 	}
+
+	@Override
+	public void setContentEncoding(String encoding) {
+		_response.setContentEncoding(encoding);
+	}
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXXmlRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXXmlRestWriter.java
@@ -16,13 +16,10 @@ import er.rest.ERXRestUtils;
  *
  * @property ERXRest.suppressTypeAttributesForSimpleTypes (default "false") If set to true, primitive types, like type = "datetime", won't be added to the output
  */
-public class ERXXmlRestWriter implements IERXRestWriter {
-	public void appendHeadersToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestContext context) {
-		response.setHeader("text/xml", "Content-Type");
-	}
-
+public class ERXXmlRestWriter extends ERXRestWriter {
 	public void appendToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestFormat.Delegate delegate, ERXRestContext context) {
 		appendHeadersToResponse(node, response, context);
+		response.setContentEncoding(contentEncoding());
 		response.appendContentString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
 		appendNodeToResponse(node, response, 0, delegate, context);
 	}
@@ -188,4 +185,8 @@ public class ERXXmlRestWriter implements IERXRestWriter {
 		}
 	}
 
+	@Override
+	public String contentType() {
+		return "text/xml";
+	}
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/IERXRestResponse.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/IERXRestResponse.java
@@ -10,4 +10,6 @@ public interface IERXRestResponse {
 	public void appendContentString(String _str);
 	
 	public void appendContentData(NSData data);
+
+	default public void setContentEncoding(String encoding) {};
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/IERXRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/IERXRestWriter.java
@@ -16,6 +16,8 @@ public interface IERXRestWriter {
 	 *            the node to render
 	 * @param response
 	 *            the response to write into
+	 * @param context
+	 *            the REST context
 	 */
 	public void appendHeadersToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestContext context);
 	
@@ -26,6 +28,10 @@ public interface IERXRestWriter {
 	 *            the node to render
 	 * @param response
 	 *            the response to write into
+	 * @param delegate
+	 *            the REST delegate
+	 * @param context
+	 *            the REST context
 	 */
 	public void appendToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestFormat.Delegate delegate, ERXRestContext context);
 }


### PR DESCRIPTION
This patch adds a default character encoding that can be overridden to ERXRestWriter classes. By this the HTTP header *Content-Type* of the response will be set accordingly making it possible for a client to detect the correct encoding. This encoding information will be passed on to the WOResponse object too so that correct handling of the response content is possible.

For Wonder6 this patch will force users to implement the ```IERXRestResponse.setContentEncoding(String)``` method in own classes as including a default interface implementation works only in Java 8.