### PR TITLE
Prevent NPE when first array is null

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXArrayUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXArrayUtilities.java
@@ -720,7 +720,12 @@ public class ERXArrayUtilities {
             return new NSArray<>(array1);
         }
         
-        NSMutableArray<T> result = new NSMutableArray<>(array1);
+        NSMutableArray<T> result;
+        if (array1 == null) {
+        	result = new NSMutableArray<>();
+        } else {
+        	result = new NSMutableArray<>(array1);
+        }
         addObjectsFromArrayWithoutDuplicates(result, array2);
         return result;
     }


### PR DESCRIPTION
For some reason I don't understand, the new implementation introduced in #697 throws an NPE, while the previous one did not.