### PR TITLE
Fix handling of owned relationships in ERModern

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/buttons/ERMDDeleteButton.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/buttons/ERMDDeleteButton.java
@@ -11,6 +11,8 @@ import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.ConfirmPageInterface;
 import com.webobjects.directtoweb.D2W;
 import com.webobjects.directtoweb.D2WPage;
+import com.webobjects.eocontrol.EOClassDescription;
+import com.webobjects.eocontrol.EODataSource;
 import com.webobjects.eocontrol.EODetailDataSource;
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
@@ -45,7 +47,9 @@ import er.extensions.localization.ERXLocalizer;
  */
 public class ERMDDeleteButton extends ERMDActionButton {
 	
-	@SuppressWarnings("unused")
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("unused")
 	private static final Logger log = Logger.getLogger(ERMDDeleteButton.class);
 	
 	public final static String DisplayGroupObjectDeleted = "DisplayGroupObjectDeleted";
@@ -113,12 +117,32 @@ public class ERMDDeleteButton extends ERMDActionButton {
      * in-line confirmation dialog. Calls saveChanges on the parent ec if the finalCommit flag is true.
      */
     public WOActionResults deleteObjectWithFinalCommit(boolean finalCommit) {
-    	dataSource().deleteObject(object());
     	EOEnterpriseObject obj = (EOEnterpriseObject)d2wContext().valueForKey(Keys.objectPendingDeletion);
-    	obj.editingContext().deleteObject(obj);
-
+        EODataSource ds = dataSource();
+        
+        // check whether the relationship is marked "owns destination"
+        boolean isOwnsDestination = false;
+        if (ds != null && ds instanceof EODetailDataSource) {
+            EODetailDataSource dds = (EODetailDataSource) ds;
+            EOClassDescription masterClassDescription = dds.masterClassDescription();
+            isOwnsDestination = masterClassDescription
+                    .ownsDestinationObjectsForRelationshipKey(dds.detailKey());
+        }
+        
     	try {
-	    	obj.editingContext().saveChanges();
+    	    // with EODetailDatasource, calling deleteObject
+    	    // will only remove the object from the relationship
+    	    ds.deleteObject(object());
+
+    	    // for "owns destination" relationships, the following would
+    	    // fail as the object will already be marked as deleted in the
+    	    // parent EC
+            if (!isOwnsDestination) {
+                // actually delete the object in the nested EC
+                obj.editingContext().deleteObject(obj);
+                obj.editingContext().saveChanges();
+            } 
+	    	
 	    	if (displayGroup() != null && displayGroup().displayedObjects().count() == 0) {
 	    		displayGroup().displayPreviousBatch();
 	    	}

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/buttons/ERMDRemoveRelatedButton.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/buttons/ERMDRemoveRelatedButton.java
@@ -195,12 +195,10 @@ public class ERMDRemoveRelatedButton extends ERMDDeleteButton {
     			EORelationship relationship = masterEntity.relationshipNamed(dds.detailKey());
     			EORelationship reverseRelationship = relationship.inverseRelationship();
     			if(isRemoveable && !relationship.ownsDestination()) {
-                    if (!relationship.ownsDestination()) {
-                        if (reverseRelationship == null) {
-                            _showRemoveButton = Boolean.TRUE;
-                        } else {
-                            _showRemoveButton = !reverseRelationship.isMandatory();
-                        }
+                    if (reverseRelationship == null) {
+                        _showRemoveButton = Boolean.TRUE;
+                    } else {
+                        _showRemoveButton = !reverseRelationship.isMandatory();
                     }
     			} else {
     				_showRemoveButton = Boolean.FALSE;

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/buttons/ERMDRemoveRelatedButton.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/buttons/ERMDRemoveRelatedButton.java
@@ -36,7 +36,9 @@ import er.extensions.foundation.ERXValueUtilities;
  */
 public class ERMDRemoveRelatedButton extends ERMDDeleteButton {
 	
-	@SuppressWarnings("unused")
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("unused")
 	private static final Logger log = Logger.getLogger(ERMDRemoveRelatedButton.class);
 	
 	public interface Keys extends ERMDActionButton.Keys {
@@ -176,10 +178,11 @@ public class ERMDRemoveRelatedButton extends ERMDDeleteButton {
 	}
     
     /**
-     * Boolean used to hide/show the confirmation dialog's remove button. 
+     * Boolean used to hide/show the confirmation dialog's remove button.
      * 
-     * The remove button show only be displayed if the reverse relationship for the related eo is not
-     * mandatory and isEntityRemoveable returns true.
+     * The remove button should only be displayed if the relationship is not
+     * owned, the reverse relationship for the related EO not mandatory and
+     * isEntityRemoveable returns true.
      */
     public Boolean showRemoveButton() {
     	if (_showRemoveButton == null) {
@@ -191,12 +194,14 @@ public class ERMDRemoveRelatedButton extends ERMDDeleteButton {
     			EOEntity masterEntity = ERXEOAccessUtilities.entityForEo(masterObj);
     			EORelationship relationship = masterEntity.relationshipNamed(dds.detailKey());
     			EORelationship reverseRelationship = relationship.inverseRelationship();
-    			if(isRemoveable) {
-    				if(reverseRelationship == null) {
-    					_showRemoveButton = Boolean.TRUE;
-    				} else {
-    					_showRemoveButton = !reverseRelationship.isMandatory();
-    				}
+    			if(isRemoveable && !relationship.ownsDestination()) {
+                    if (!relationship.ownsDestination()) {
+                        if (reverseRelationship == null) {
+                            _showRemoveButton = Boolean.TRUE;
+                        } else {
+                            _showRemoveButton = !reverseRelationship.isMandatory();
+                        }
+                    }
     			} else {
     				_showRemoveButton = Boolean.FALSE;
     			}

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODEditRelationshipPage.wo/ERMODEditRelationshipPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODEditRelationshipPage.wo/ERMODEditRelationshipPage.wod
@@ -219,5 +219,5 @@ ListNotEmpty: WOConditional {
 }
 
 ShowFind: WOConditional {
-	condition = d2wContext.shouldShowQueryRelatedButton;
+	condition = shouldShowQueryRelatedButton;
 }

--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
@@ -80,6 +80,7 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 		public static String displayPropertyKeys = "displayPropertyKeys";
 		public static String subTask = "subTask";
 		public static String isEntityCreatable = "isEntityCreatable";
+        public static String shouldShowQueryRelatedButton = "shouldShowQueryRelatedButton";
 		
 	}
 	
@@ -350,17 +351,17 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
      * @see er.directtoweb.pages.ERD2WPage#settings()
      */
     @Override
-    public NSDictionary settings() {
+    public NSDictionary<String,Object> settings() {
         String pc = d2wContext().dynamicPage();
         if (pc != null) {
             if (d2wContext().valueForKey("currentRelationship") != null) {
                 // set parentRelationship key to allow subcomponents to
                 // reference the correct ID (wonder-140)
-                return new NSDictionary(new Object[] { pc,
-                        d2wContext().valueForKey("currentRelationship") }, new Object[] {
+                return new NSDictionary<String,Object>(new Object[] { pc,
+                        d2wContext().valueForKey("currentRelationship") }, new String[] {
                         "parentPageConfiguration", "parentRelationship" });
             } else {
-                return new NSDictionary(pc, "parentPageConfiguration");
+                return new NSDictionary<String,Object>(pc, "parentPageConfiguration");
             }
         }
         return null;
@@ -557,6 +558,24 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 		return ERXValueUtilities.booleanValue(d2wContext().valueForKey(Keys.isEntityCreatable)) && !isEntityReadOnly();
 	}
 	
+    public boolean shouldShowQueryRelatedButton() {
+        boolean shouldShowQueryRelatedButton = ERXValueUtilities
+                .booleanValue(d2wContext().valueForKey(Keys.shouldShowQueryRelatedButton));
+        if (isRelationshipOwned()) {
+            // if the relationship is owned, search makes no sense
+            shouldShowQueryRelatedButton = false;
+        }
+        return shouldShowQueryRelatedButton;
+    }
+
+    public boolean isRelationshipOwned() {
+        boolean isRelationshipOwned = false;
+        if (masterObject().allPropertyKeys().contains(relationshipKey())) {
+            isRelationshipOwned = masterObject().classDescription().ownsDestinationObjectsForRelationshipKey(relationshipKey());
+        }
+        return isRelationshipOwned;
+    }
+
 	private void writeObject(ObjectOutputStream out) throws IOException {
 		out.writeObject(_masterObject);
 		out.writeObject(_objectToAddToRelationship);


### PR DESCRIPTION
This fixes an issue with deletion of an owned relationships, which would cause an NPE in EOEditingContext.
Also, the "query related" and "remove related" buttons will never be shown for owned relationships.