### PR TITLE
Fix framework embedding for Maven builds

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -80,9 +80,9 @@ import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation.NSMutableSet;
 import com.webobjects.foundation.NSNotification;
 import com.webobjects.foundation.NSNotificationCenter;
+import com.webobjects.foundation.NSPathUtilities;
 import com.webobjects.foundation.NSProperties;
 import com.webobjects.foundation.NSPropertyListSerialization;
-import com.webobjects.foundation.NSRange;
 import com.webobjects.foundation.NSSelector;
 import com.webobjects.foundation.NSSet;
 import com.webobjects.foundation.NSTimestamp;
@@ -2837,5 +2837,40 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	@Override
     public String[] adaptorExtensions() {
         return myAppExtensions;
+    }
+    
+    public BuildType buildType()
+    {
+    	if(buildType == null)
+    	{
+    		buildType = BuildType.Classic;
+    		
+    		@SuppressWarnings("deprecation")
+    		File infoPlistPath = new File(NSBundle.mainBundle().bundlePath(), "Contents/Info.plist");
+    		
+    		if(infoPlistPath.exists())
+    		{
+				NSDictionary dict = (NSDictionary) NSPropertyListSerialization.propertyListWithPathURL(NSPathUtilities._URLWithPath(infoPlistPath.getAbsolutePath()));
+
+				if(dict != null)
+				{
+					String cfBundleVersion = (String) dict.objectForKey("CFBundleVersion");
+					if(cfBundleVersion.length() > 0)
+					{
+			    		buildType = BuildType.Maven;
+					}
+				}
+    		}
+    	}
+    	
+    	return buildType;
+    }
+    
+    private BuildType buildType = null;
+    
+    public static enum BuildType
+    {
+    	Classic,
+    	Maven
     }
 }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDeployedBundle.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDeployedBundle.java
@@ -16,6 +16,7 @@ import com.webobjects.foundation.NSProperties;
 import com.webobjects.foundation.NSPropertyListSerialization;
 import com.webobjects.foundation._NSStringUtilities;
 
+import er.extensions.appserver.ERXApplication.BuildType;
 import er.extensions.foundation.ERXProperties;
 
 /**
@@ -40,6 +41,7 @@ import er.extensions.foundation.ERXProperties;
  * 
  * @author mstoll
  */
+
 public class ERXDeployedBundle extends WODeployedBundle {
 
     private final NSMutableDictionary _myURLs;
@@ -53,7 +55,8 @@ public class ERXDeployedBundle extends WODeployedBundle {
      * 
      * @param nsb the given NSBundle
      */
-    public ERXDeployedBundle(NSBundle nsb)
+	@SuppressWarnings("deprecation")
+	public ERXDeployedBundle(NSBundle nsb)
     {
     	super(nsb);
 
@@ -95,25 +98,27 @@ public class ERXDeployedBundle extends WODeployedBundle {
             {
                 String aBaseURL = null;
                 if(isFramework())
-                	if(isEmbeddedFramework)
-                	{
-            			String embeddedFrameworkBaseUrl = ERXProperties.stringForKey("WOEmbeddedFrameworksBaseURL");
-            			if(embeddedFrameworkBaseUrl == null)
-            			{
-                			if(ERXProperties.booleanForKeyWithDefault("ERXDeployedBundle.MavenBuild", false))
-                			{
+                    if(isEmbeddedFramework)
+                    {
+                        String embeddedFrameworkBaseUrl = ERXProperties.stringForKey("WOEmbeddedFrameworksBaseURL");
+                        if(embeddedFrameworkBaseUrl == null)
+                        {
+                            BuildType automaticBuildType = ((ERXApplication)WOApplication.application()).buildType();
+                            
+                            if(ERXProperties.booleanForKeyWithDefault("ERXDeployedBundle.MavenBuild", automaticBuildType == BuildType.Maven))
+                            {
                                 aBaseURL = WOApplication.application().applicationBaseURL() + "/" + embeddingWrapperName + "/Contents/Frameworks";
-                			} else
-                			{
+                            } else
+                            {
                                 aBaseURL = WOApplication.application().applicationBaseURL() + "/" + embeddingWrapperName + "/Frameworks";
-                			}
-            			} else
-            			{
-            				aBaseURL = embeddedFrameworkBaseUrl;
-            			}
-                	}
-                	else
-                		aBaseURL = WOApplication.application().frameworksBaseURL();
+                            }
+                        } else
+                        {
+                            aBaseURL = embeddedFrameworkBaseUrl;
+                        }
+                    }
+                    else
+                        aBaseURL = WOApplication.application().frameworksBaseURL();
                 else
                     aBaseURL = WOApplication.application().applicationBaseURL();
                 String aWrapperName = wrapperName();
@@ -162,6 +167,7 @@ public class ERXDeployedBundle extends WODeployedBundle {
         return (WODeployedBundle)aBundle;
     }
     
+    @SuppressWarnings("deprecation")
     public static synchronized WODeployedBundle deployedBundleForFrameworkNamed(String aFrameworkName)
     {
         WODeployedBundle aBundle = null;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDeployedBundle.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXDeployedBundle.java
@@ -16,6 +16,8 @@ import com.webobjects.foundation.NSProperties;
 import com.webobjects.foundation.NSPropertyListSerialization;
 import com.webobjects.foundation._NSStringUtilities;
 
+import er.extensions.foundation.ERXProperties;
+
 /**
  * Replacement of the WODeployedBundle which adds:
  * <ul>
@@ -24,6 +26,17 @@ import com.webobjects.foundation._NSStringUtilities;
  * <li> Resource URLs for embedded Frameworks are automatically adapted to refer to the embedded Framework, 
  *      rather than to the Frameworks base URL
  * </ul>
+ * 
+ * There are two styles of webserver resource packages, with ANT builds, embedded frameworks are embedded this way
+ *    MyApp.woa/Frameworks/EmbeddedFramework.framework/...
+ * 
+ * while with Maven builds, frameworks are embedded in the WebServerResources package the same way as in the Application package:
+ *    MyApp.woa/Contents/Frameworks/EmbeddedFramework.framework/...
+ * 
+ * the property ERXDeployedBundle.MavenBuild=true activates the Url generation for the Maven build style 
+ * 
+ * 
+ * the property WOEmbeddedFrameworksBaseURL lets you override the base Url for embedded frameworks
  * 
  * @author mstoll
  */
@@ -83,9 +96,24 @@ public class ERXDeployedBundle extends WODeployedBundle {
                 String aBaseURL = null;
                 if(isFramework())
                 	if(isEmbeddedFramework)
-                        aBaseURL = WOApplication.application().applicationBaseURL() + "/" + embeddingWrapperName + "/Frameworks";
+                	{
+            			String embeddedFrameworkBaseUrl = ERXProperties.stringForKey("WOEmbeddedFrameworksBaseURL");
+            			if(embeddedFrameworkBaseUrl == null)
+            			{
+                			if(ERXProperties.booleanForKeyWithDefault("ERXDeployedBundle.MavenBuild", false))
+                			{
+                                aBaseURL = WOApplication.application().applicationBaseURL() + "/" + embeddingWrapperName + "/Contents/Frameworks";
+                			} else
+                			{
+                                aBaseURL = WOApplication.application().applicationBaseURL() + "/" + embeddingWrapperName + "/Frameworks";
+                			}
+            			} else
+            			{
+            				aBaseURL = embeddedFrameworkBaseUrl;
+            			}
+                	}
                 	else
-                    aBaseURL = WOApplication.application().frameworksBaseURL();
+                		aBaseURL = WOApplication.application().frameworksBaseURL();
                 else
                     aBaseURL = WOApplication.application().applicationBaseURL();
                 String aWrapperName = wrapperName();


### PR DESCRIPTION
This is a proposal to solve this problem:

I was unaware that using Maven for building your application, the WebServerResources bundle has a different layout (embedded framework stuff is in Contents/Frameworks rather than in Frameworks folder).

So I added an automatic detection for the build style and switches to override.

If there is a better way to solve this, let me know, I would gladly rework this