### PR TITLE
Correctly handle removal of last related object in displayed batch

### DIFF
--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
@@ -226,6 +226,10 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 			EOEnterpriseObject obj = (EOEnterpriseObject)userInfo.valueForKey("object");
 			if (relationshipKey() != null && relationshipKey().equals(key) && ERXEOControlUtilities.eoEquals(masterObject(), obj)) {
 				relationshipDisplayGroup().fetch();
+				// when the last object of the last batch gets removed, select the new last batch
+				if (relationshipDisplayGroup().currentBatchIndex() > relationshipDisplayGroup().batchCount()) {
+				    relationshipDisplayGroup().setCurrentBatchIndex(relationshipDisplayGroup().batchCount());
+				}
 			}
 		}
         if (notif.userInfo().valueForKey("ajaxNotificationCenterId") == null) {


### PR DESCRIPTION
In ERMODEditRelationshipPage, when the last batch of related objects is being displayed and the sole object in that batch is removed, set the new last batch as the DG's current batch.