### PR TITLE
fixes arrayMinusObject if object is contained more than once

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXArrayUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXArrayUtilities.java
@@ -696,7 +696,10 @@ public class ERXArrayUtilities {
             return new NSArray<T>(array);
         }
         NSMutableArray<T> result = new NSMutableArray<>(array);
-        result.remove(object);
+        boolean removed = true;
+        while (removed) {
+        	removed = result.remove(object);
+        }
         return result.immutableClone();
     }
 

--- a/Tests/ERXTest/Sources/er/extensions/foundation/ERXArrayUtilitiesTest.java
+++ b/Tests/ERXTest/Sources/er/extensions/foundation/ERXArrayUtilitiesTest.java
@@ -728,12 +728,16 @@ public class ERXArrayUtilitiesTest extends ERXTestCase {
         assertEquals(NSArray.emptyArray(), ERXArrayUtilities.arrayMinusObject(new NSArray<>(), null));
 
         NSArray<String> array1 = new NSArray<>("red", "blue");
+        NSArray<String> array2 = new NSArray<>("red", "blue", "red");
 
         assertEquals(array1, ERXArrayUtilities.arrayMinusObject(array1, null));
 
         assertEquals(array1, ERXArrayUtilities.arrayMinusObject(array1, "something"));
         assertEquals(new NSArray<>("red"), ERXArrayUtilities.arrayMinusObject(array1, "blue"));
         assertEquals(new NSArray<>("blue"), ERXArrayUtilities.arrayMinusObject(array1, "red"));
+
+        assertEquals(2, ERXArrayUtilities.arrayMinusObject(array2, "blue").size());
+        assertEquals(new NSArray<>("blue"), ERXArrayUtilities.arrayMinusObject(array2, "red"));
     }
 
     public void testArrayByAddingObjectsFromArrayWithoutDuplicates() {


### PR DESCRIPTION
The method List.remove(Object) which replaced the previous NSMutableArray.removeObject(Object) only removes the first match from the object in contrast to *all* occurrences as removeObject does. This fix keeps the List method signature but repeats the remove until no removal happens to match the behavior of the NS-class method.