### PR TITLE
Add ERXRest.includeNullValues property to show/hide null values on Rest responses

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
@@ -28,6 +28,7 @@ import er.extensions.appserver.ERXResponse;
 import er.extensions.eof.ERXKey;
 import er.extensions.eof.ERXKeyFilter;
 import er.extensions.foundation.ERXArrayUtilities;
+import er.extensions.foundation.ERXProperties;
 import er.rest.format.ERXRestFormat;
 import er.rest.format.ERXWORestResponse;
 import er.rest.format.IERXRestWriter;
@@ -37,6 +38,8 @@ import er.rest.format.IERXRestWriter;
  * etc), we needed a document model that is more abstract than just an org.w3c.dom. Or, rather, one that isn't obnoxious
  * to use.
  * 
+ * @property <code>ERXRest.includeNullValues</code> Boolean property to enable null values in return. Defaults
+ *           to true.
  * @author mschrag
  */
 public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdditions {
@@ -203,9 +206,9 @@ public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdd
 					// MS: name has to be after toJavaCollection, because the naming delegate could rename it ... little
 					// sketchy, i know
 					String name = child.name();
-					// if (value != null) {
-					dict.put(name, value);
-					// }
+					if (value != null || ERXProperties.booleanForKeyWithDefault("ERXRest.includeNullValues", true)) {
+						dict.put(name, value);
+					}
 				}
 				if (dict.isEmpty()) {
 					result = null;
@@ -276,9 +279,9 @@ public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdd
 				for (ERXRestRequestNode child : _children) {
 					String name = child.name();
 					Object value = child.toNSCollection(delegate, associatedObjects);
-					// if (value != null) {
-					dict.put(name, value);
-					// }
+					if (value != NSKeyValueCoding.NullValue || ERXProperties.booleanForKeyWithDefault("ERXRest.includeNullValues", true) == true) {
+						dict.put(name, value);
+					}
 				}
 				if (dict.isEmpty()) {
 					result = NSKeyValueCoding.NullValue;

--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestRequestNode.java
@@ -279,7 +279,7 @@ public class ERXRestRequestNode implements NSKeyValueCoding, NSKeyValueCodingAdd
 				for (ERXRestRequestNode child : _children) {
 					String name = child.name();
 					Object value = child.toNSCollection(delegate, associatedObjects);
-					if (value != NSKeyValueCoding.NullValue || ERXProperties.booleanForKeyWithDefault("ERXRest.includeNullValues", true) == true) {
+					if (value != NSKeyValueCoding.NullValue || ERXProperties.booleanForKeyWithDefault("ERXRest.includeNullValues", true)) {
 						dict.put(name, value);
 					}
 				}

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXXmlRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXXmlRestWriter.java
@@ -15,7 +15,7 @@ import er.rest.ERXRestUtils;
 /**
  *
  * @property ERXRest.suppressTypeAttributesForSimpleTypes (default "false") If set to true, primitive types, like type = "datetime", won't be added to the output
- * @property <code>er.rest.ERXRest.includeNullValues</code> Boolean property to enable null values in return. Defaults
+ * @property <code>ERXRest.includeNullValues</code> Boolean property to enable null values in return. Defaults
  *           to true.
  */
 public class ERXXmlRestWriter extends ERXRestWriter {

--- a/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXXmlRestWriter.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/format/ERXXmlRestWriter.java
@@ -15,6 +15,8 @@ import er.rest.ERXRestUtils;
 /**
  *
  * @property ERXRest.suppressTypeAttributesForSimpleTypes (default "false") If set to true, primitive types, like type = "datetime", won't be added to the output
+ * @property <code>er.rest.ERXRest.includeNullValues</code> Boolean property to enable null values in return. Defaults
+ *           to true.
  */
 public class ERXXmlRestWriter extends ERXRestWriter {
 	public void appendToResponse(ERXRestRequestNode node, IERXRestResponse response, ERXRestFormat.Delegate delegate, ERXRestContext context) {
@@ -47,16 +49,18 @@ public class ERXXmlRestWriter extends ERXRestWriter {
 		String name = node.name();
 		Object value = node.value();
 		String formattedValue = coerceValueToString(value, context);
+
 		if (formattedValue == null) {
-			indent(response, indent);
-			response.appendContentString("<");
-			response.appendContentString(name);
-			appendAttributesToResponse(node, response, context);
-			appendTypeToResponse(value, response);
-			response.appendContentString("/>");
-			response.appendContentString("\n");
-		}
-		else {
+			if(ERXProperties.booleanForKeyWithDefault("ERXRest.includeNullValues", true)) {
+				indent(response, indent);
+				response.appendContentString("<");
+				response.appendContentString(name);
+				appendAttributesToResponse(node, response, context);
+				appendTypeToResponse(value, response);
+				response.appendContentString("/>");
+				response.appendContentString("\n");
+			}
+		} else {
 			indent(response, indent);
 			response.appendContentString("<");
 			response.appendContentString(name);


### PR DESCRIPTION
Using the boolean ERXRest.includeNullValues it`s either possible to return null values or simply not showing them, use Properties file to set it. Supported formats are json, xml and plist formats.