### PR TITLE
YUI.framework fix

### DIFF
--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIBlock.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIBlock.java
@@ -4,7 +4,7 @@ import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOElement;
 import com.webobjects.foundation.NSDictionary;
 
-import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 
 /**
  * Generates a YUI class = "yui-b" div.
@@ -21,7 +21,7 @@ public class YUIBlock extends YUIDivContainer {
 
   @Override
   protected String divID(WOContext context) {
-    return AjaxUtils.stringValueForBinding("id", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("id", associations(), context.component());
   }
 
   @Override
@@ -31,7 +31,7 @@ public class YUIBlock extends YUIDivContainer {
 
   @Override
   protected String divStyle(WOContext context) {
-    return AjaxUtils.stringValueForBinding("style", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("style", associations(), context.component());
   }
 
 }

--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIBody.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIBody.java
@@ -4,7 +4,7 @@ import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOElement;
 import com.webobjects.foundation.NSDictionary;
 
-import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 
 /**
  * Generates a YUI class = "bd" div.
@@ -20,7 +20,7 @@ public class YUIBody extends YUIDivContainer {
   }
 
   protected String divID(WOContext context) {
-    return AjaxUtils.stringValueForBinding("id", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("id", associations(), context.component());
   }
 
   protected String divClass(WOContext context) {
@@ -28,6 +28,6 @@ public class YUIBody extends YUIDivContainer {
   }
 
   protected String divStyle(WOContext context) {
-    return AjaxUtils.stringValueForBinding("style", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("style", associations(), context.component());
   }
 }

--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIFooter.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIFooter.java
@@ -4,7 +4,7 @@ import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOElement;
 import com.webobjects.foundation.NSDictionary;
 
-import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 
 /**
  * Generates a YUI class = "ft" div.
@@ -20,7 +20,7 @@ public class YUIFooter extends YUIDivContainer {
   }
 
   protected String divID(WOContext context) {
-    return AjaxUtils.stringValueForBinding("id", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("id", associations(), context.component());
   }
 
   protected String divClass(WOContext context) {
@@ -28,6 +28,6 @@ public class YUIFooter extends YUIDivContainer {
   }
 
   protected String divStyle(WOContext context) {
-    return AjaxUtils.stringValueForBinding("style", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("style", associations(), context.component());
   }
 }

--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIHeader.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIHeader.java
@@ -4,7 +4,7 @@ import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOElement;
 import com.webobjects.foundation.NSDictionary;
 
-import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 
 /**
  * Generates a YUI class = "hd" div.
@@ -20,7 +20,7 @@ public class YUIHeader extends YUIDivContainer {
   }
 
   protected String divID(WOContext context) {
-    return AjaxUtils.stringValueForBinding("id", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("id", associations(), context.component());
   }
 
   protected String divClass(WOContext context) {
@@ -28,6 +28,6 @@ public class YUIHeader extends YUIDivContainer {
   }
 
   protected String divStyle(WOContext context) {
-    return AjaxUtils.stringValueForBinding("style", associations(), context.component());
+    return ERXComponentUtilities.stringValueForBinding("style", associations(), context.component());
   }
 }

--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIPanel.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIPanel.java
@@ -11,6 +11,7 @@ import com.webobjects.foundation.NSMutableDictionary;
 import er.ajax.AjaxOption;
 import er.ajax.AjaxOptions;
 import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 
 /**
  * Generates a YUI panel (@see http://developer.yahoo.com/yui/container/panel/).
@@ -55,7 +56,7 @@ public class YUIPanel extends YUIDivContainer {
   }
 
   protected String divStyle(WOContext context) {
-    String style = AjaxUtils.stringValueForBinding("style", associations(), context.component());
+    String style = ERXComponentUtilities.stringValueForBinding("style", associations(), context.component());
     StringBuffer styleBuffer = new StringBuffer();
     styleBuffer.append("visibility: hidden; ");
     if (style != null) {

--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIShowPanelLink.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIShowPanelLink.java
@@ -6,7 +6,7 @@ import com.webobjects.appserver.WOResponse;
 import com.webobjects.appserver._private.WODynamicGroup;
 import com.webobjects.foundation.NSDictionary;
 
-import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 
 /**
  * YUIShowPanelLink generates either an hyperlink or an input button that 
@@ -28,9 +28,9 @@ public class YUIShowPanelLink extends WODynamicGroup {
   }
 
   public void appendToResponse(WOResponse response, WOContext context) {
-    String id = AjaxUtils.stringValueForBinding("panelID", _associations, context.component());
+    String id = ERXComponentUtilities.stringValueForBinding("panelID", _associations, context.component());
     String varName = YUIUtils.varName(id, _associations, context);
-    String type = AjaxUtils.stringValueForBinding("type", _associations, context.component());
+    String type = ERXComponentUtilities.stringValueForBinding("type", _associations, context.component());
     String showScript = varName + ".render();" + varName + ".show();return false;";
     if ("button".equals(type)) {
       response.appendContentString("<input");

--- a/Archives/Frameworks/YUI/Sources/er/yui/YUIUtils.java
+++ b/Archives/Frameworks/YUI/Sources/er/yui/YUIUtils.java
@@ -6,6 +6,7 @@ import com.webobjects.appserver.WOResponse;
 import com.webobjects.foundation.NSDictionary;
 
 import er.ajax.AjaxUtils;
+import er.extensions.components.ERXComponentUtilities;
 import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXStringUtilities;
 
@@ -59,7 +60,7 @@ public class YUIUtils {
   }
 
   public static String id(String idBindingName, NSDictionary associations, WOContext context) {
-    String id = AjaxUtils.stringValueForBinding(idBindingName, associations, context.component());
+    String id = ERXComponentUtilities.stringValueForBinding(idBindingName, associations, context.component());
     if (id == null) {
       id = ERXStringUtilities.safeIdentifierName(context.elementID());
     }
@@ -67,7 +68,7 @@ public class YUIUtils {
   }
 
   public static String varName(String name, NSDictionary associations, WOContext context) {
-    String namespace = AjaxUtils.stringValueForBinding("namespace", associations, context.component());
+    String namespace = ERXComponentUtilities.stringValueForBinding("namespace", associations, context.component());
     return YUIUtils.varName(name, namespace);
   }
 
@@ -80,7 +81,7 @@ public class YUIUtils {
   }
 
   public static void appendAttributeValue(WOResponse response, WOContext context, NSDictionary associations, String name) {
-    String value = AjaxUtils.stringValueForBinding(name, associations, context.component());
+    String value = ERXComponentUtilities.stringValueForBinding(name, associations, context.component());
     YUIUtils.appendAttributeValue(response, context, name, value);
   }
 


### PR DESCRIPTION
Although it's gathering dust in the `Archive` directory, we still have an ancient app dependent on `YUI.framework`. (It seemed easier to fix the framework than extricate it from the app.) Several classes were calling the now non-existent `AjaxUtils.stringValueForBinding()`, so here we just substitute the alternative `ERXComponentUtilities.stringValueForBinding()`.