### PR TITLE
Fix various maven dependency issues

### DIFF
--- a/Archives/Frameworks/Validity/pom.xml
+++ b/Archives/Frameworks/Validity/pom.xml
@@ -35,8 +35,8 @@
 			<artifactId>gamma-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/Examples/Misc/ERRestRouteExample/pom.xml
+++ b/Examples/Misc/ERRestRouteExample/pom.xml
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>commons-httpclient</groupId>
 			<artifactId>commons-httpclient</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>

--- a/Frameworks/BusinessLogic/BTBusinessLogic/pom.xml
+++ b/Frameworks/BusinessLogic/BTBusinessLogic/pom.xml
@@ -51,8 +51,8 @@
 			<artifactId>JavaEOControl</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/Frameworks/BusinessLogic/ERCoreBusinessLogic/pom.xml
+++ b/Frameworks/BusinessLogic/ERCoreBusinessLogic/pom.xml
@@ -47,8 +47,8 @@
 			<artifactId>JavaFoundation</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/Frameworks/Core/ERJavaMail/pom.xml
+++ b/Frameworks/Core/ERJavaMail/pom.xml
@@ -42,7 +42,6 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>javax.mail</artifactId>
-			<version>1.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.mail</groupId>

--- a/Frameworks/Core/WOOgnl/pom.xml
+++ b/Frameworks/Core/WOOgnl/pom.xml
@@ -30,8 +30,8 @@
             <artifactId>ognl</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/Frameworks/Misc/ERQuartzScheduler/pom.xml
+++ b/Frameworks/Misc/ERQuartzScheduler/pom.xml
@@ -50,8 +50,8 @@
 		    <artifactId>quartz</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>javax.mail</groupId>
-		    <artifactId>mail</artifactId>
+		    <groupId>com.sun.mail</groupId>
+		    <artifactId>javax.mail</artifactId>
 		</dependency>
 		<dependency>
 		    <groupId>junit</groupId>

--- a/Tests/ERModernMoviesTest/pom.xml
+++ b/Tests/ERModernMoviesTest/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-firefox-driver</artifactId>
-			<version>2.45.0</version>
+			<version>2.53.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -358,8 +358,8 @@
                 <version>1.1.1</version>
             </dependency>
             <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>javax.mail</artifactId>
                 <version>1.5.5</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Updating references to javax.mail as the [groupId changed](https://java.net/projects/javamail/pages/Home) to com.sun.mail and the artifactId is now javax.mail instead of mail.

Also, ERRestRouteExample will not compile as is with httpclient 4.5.1, so I suggest to keep the dependency at 3.0.1 for now. Changing it will require some work to adapt it to the new API of 4.5.1.

With these changes, the maven build passes again.