### PR TITLE
Add properties to ERXDatabase and ERXDatabaseContext for customization and tuning

### DIFF
--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -291,6 +291,17 @@ er.extensions.ERXComponentActionRedirector.enabled=false
 # Set to true to have this delegate order the operations (e.g. or MS SQL Server)
 com.webobjects.eoaccess.ERXEntityDependencyOrderingDelegate.active = false
 
+## Defines the DB class to use together with ERXDatabaseContext
+er.extensions.ERXDatabase.className = er.extensions.eof.ERXDatabase
+
+## Define the HashMap initialization parameters to use for the HashMap that ERXDatabase
+## uses for the snapshot cache. Usually the load factor is fine, but the capacity
+## could use increasing for applications handling many objects. You can use
+## ERXDatabase.snapshotCacheSize() to get the actual map size at runtime to
+## determine how to tune this.
+# er.extensions.ERXDatabase.snapshotCacheMapInitialCapacity = 1048576
+# er.extensions.ERXDatabase.snapshotCacheMapInitialLoadFactor = 0.75
+
 #########################################################################
 # ERXDatabaseContextDelegate 
 #########################################################################

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContext.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContext.java
@@ -1,5 +1,7 @@
 package er.extensions.eof;
 
+import java.lang.reflect.InvocationTargetException;
+
 import com.webobjects.eoaccess.EOAttribute;
 import com.webobjects.eoaccess.EODatabase;
 import com.webobjects.eoaccess.EODatabaseContext;
@@ -12,14 +14,21 @@ import com.webobjects.eocontrol.EOGlobalID;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSKeyValueCoding;
+import com.webobjects.foundation.NSLog;
 
 public class ERXDatabaseContext extends EODatabaseContext {
 	private static ThreadLocal _fetching = new ThreadLocal();
-
-	public ERXDatabaseContext(EODatabase database) {
-		super(new ERXDatabase(database));
+	protected static Class<? extends ERXDatabase> _dbClass = null;
+	
+	public ERXDatabaseContext( EODatabase database ) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+		super( _dbClass != null ? _dbClass.getConstructor( EODatabase.class ).newInstance( database ) : new ERXDatabase( database ) );
 	}
 
+	public static void setDatabaseContextClass( Class<? extends ERXDatabase> cls ) {
+		NSLog.out.appendln( "Setting ERXDatabase subclass to " + cls.getName() );
+		_dbClass = cls;
+	}
+	
 	public static boolean isFetching() {
 		Boolean fetching = (Boolean) _fetching.get();
 		// System.out.println("ERXDatabaseContext.isFetching: " +


### PR DESCRIPTION
**Add properties to ERXDatabase to define initial snapshot cache HashMap parameters**

Large HashMaps perform best when they are created with suitable initial capacity and load factor parameters. This patch adds the possibility to supply those via properties, and also sets a reasonable default while there wasn't one before. This eliminates application pauses when the snapshot cache hits a certain size, causing the HashMap to reorganize.

**Add the possibility to use a customer ERXDatabase subclass with ERXDatabaseContext**

To enable programmers to use custom behaviour or extensions (like the one in 1.) on ERXDatabase subclasses, this adds a property that can be used to define which subclass to use.