### PR TITLE
Add uuid support

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOControlUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOControlUtilities.java
@@ -60,6 +60,7 @@ import er.extensions.eof.ERXEOAccessUtilities.DatabaseContextOperation;
 import er.extensions.foundation.ERXArrayUtilities;
 import er.extensions.foundation.ERXDictionaryUtilities;
 import er.extensions.foundation.ERXKeyValueCodingUtilities;
+import er.extensions.foundation.ERXStringUtilities;
 import er.extensions.jdbc.ERXSQLHelper;
 import er.extensions.validation.ERXValidationException;
 import er.extensions.validation.ERXValidationFactory;
@@ -1307,6 +1308,10 @@ public class ERXEOControlUtilities {
             return null;
         if(pk instanceof String || pk instanceof Number) {
             return pk.toString();
+        }
+        if (pk instanceof NSData) {
+        	byte[] pkBytes = ((NSData)pk)._bytesNoCopy();
+			return ERXStringUtilities.byteArrayToHexString(pkBytes);
         }
         return NSPropertyListSerialization.stringFromPropertyList(pk);
     }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOControlUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOControlUtilities.java
@@ -61,6 +61,7 @@ import er.extensions.foundation.ERXArrayUtilities;
 import er.extensions.foundation.ERXDictionaryUtilities;
 import er.extensions.foundation.ERXKeyValueCodingUtilities;
 import er.extensions.foundation.ERXStringUtilities;
+import er.extensions.foundation.UUIDUtilities;
 import er.extensions.jdbc.ERXSQLHelper;
 import er.extensions.validation.ERXValidationException;
 import er.extensions.validation.ERXValidationFactory;
@@ -1311,7 +1312,10 @@ public class ERXEOControlUtilities {
         }
         if (pk instanceof NSData) {
         	byte[] pkBytes = ((NSData)pk)._bytesNoCopy();
-			return ERXStringUtilities.byteArrayToHexString(pkBytes);
+        	if (pkBytes.length == 16) {
+        		return UUIDUtilities.encodeAsPrettyString(pkBytes);
+        	}
+        	return ERXStringUtilities.byteArrayToHexString(pkBytes);
         }
         return NSPropertyListSerialization.stringFromPropertyList(pk);
     }
@@ -1346,6 +1350,9 @@ public class ERXEOControlUtilities {
                     if(attribute.adaptorValueType() == EOAttribute.AdaptorDateType && !(value instanceof NSTimestamp)) {
                         value = new NSTimestampFormatter("%Y-%m-%d %H:%M:%S %Z").parseObject((String)value);
                     }
+                    if(attribute.adaptorValueType() == EOAttribute.AdaptorBytesType && attribute.width() == 16 && !(value instanceof NSData)) {
+                    	value = UUIDUtilities.decodeStringAsNSData((String)value);
+                    }
                     value = attribute.validateValue(value);
                     pk.setObjectForKey(value, attribute.name());
                     if(pks.count() == 1) {
@@ -1362,6 +1369,9 @@ public class ERXEOControlUtilities {
             	}
                 EOAttribute attribute = pks.objectAtIndex(0);
                 Object value = rawValue;
+                if(attribute.adaptorValueType() == EOAttribute.AdaptorBytesType && attribute.width() == 16 && !(value instanceof NSData)) {
+                	value = UUIDUtilities.decodeStringAsNSData((String)value);
+                }
                 value = attribute.validateValue(value);
                 pk.setObjectForKey(value, attribute.name());
             }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -39,6 +39,7 @@ import er.extensions.foundation.ERXArrayUtilities;
 import er.extensions.foundation.ERXDictionaryUtilities;
 import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXUtilities;
+import er.extensions.foundation.UUIDUtilities;
 import er.extensions.localization.ERXLocalizer;
 import er.extensions.validation.ERXValidationException;
 import er.extensions.validation.ERXValidationFactory;
@@ -88,6 +89,8 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 
 	/** holds all subclass related Logger's */
 	private static final NSMutableDictionary<Class, Logger> classLogs = new NSMutableDictionary<Class, Logger>();
+
+	private static final Object uuidPrototypeName = "uuid";
 
 	public static boolean shouldTrimSpaces() {
 		return ERXProperties.booleanForKeyWithDefault("er.extensions.ERXGenericRecord.shouldTrimSpaces", false);
@@ -749,12 +752,35 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 						_primaryKeyDictionary = compositePrimaryKey;
 					}
 					else {
-						_primaryKeyDictionary = ERXEOControlUtilities.newPrimaryKeyDictionaryForObject(this);
+						_primaryKeyDictionary = createUuidPrimaryKey(primaryKeyAttributes);
+						if (_primaryKeyDictionary == null) {
+							_primaryKeyDictionary = ERXEOControlUtilities.newPrimaryKeyDictionaryForObject(this);
+						}
 					}
 				}
 			}
+			else { // inTransaction
+				EOEntity entity = entity();
+				NSArray<EOAttribute> primaryKeyAttributes = entity.primaryKeyAttributes();
+				_primaryKeyDictionary = createUuidPrimaryKey(primaryKeyAttributes);
+			}
 		}
 		return _primaryKeyDictionary;
+	}
+
+	/**
+	 * Create a primary key if the entity primary key is an attribute with uuid prototype.
+	 * @param primaryKeyAttributes
+	 * @return the primary key dictionary or null if the primary key is not a uuid.
+	 */
+	private NSDictionary<String, Object> createUuidPrimaryKey(NSArray<EOAttribute> primaryKeyAttributes) {
+		if (primaryKeyAttributes.count() == 1) {
+			EOAttribute primaryKeyAttribute = primaryKeyAttributes.objectAtIndex(0);			
+			if (primaryKeyAttribute.prototypeName().equals(uuidPrototypeName)) {
+				return new NSDictionary<String, Object>(UUIDUtilities.generateAsNSData(), primaryKeyAttribute.name());
+			}
+		}
+		return null;
 	}
 	
 	/**

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/UUIDUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/UUIDUtilities.java
@@ -1,0 +1,124 @@
+package er.extensions.foundation;
+
+import java.security.SecureRandom;
+
+import com.webobjects.foundation.NSData;
+
+/**
+ * Helper functions for UUID
+ *
+ */
+public class UUIDUtilities  {
+	private static final String validHexCharacters = "ABCDEF0123456789abcdef";
+	static final SecureRandom randomGenerator = new SecureRandom();
+	
+	
+	/**
+	 * Generate a type 4 UUID from a secure random source like the java UUID class.
+	 * @return a new UUID in a NSData
+	 */
+    public static NSData generateAsNSData() {
+		return new NSData(generateAsByteArray());
+	}
+
+	/**
+	 * Generate a type 4 UUID from a secure random source like the java UUID class.
+	 * @return a new UUID in a byte[]
+	 */
+    private static byte[] generateAsByteArray() {
+		byte[] value = new byte[16];
+		randomGenerator.nextBytes(value);
+		return value;
+	}
+
+    /**
+     * Decode a string representing a UUID in hex. 
+     * All non hex char are filtered before the decoding, any formats are accepted.
+     * @param uuid the string representing a UUID
+     * @return the decoded UUID in a NSData
+     */
+	static public NSData decodeStringAsNSData(String uuid) {
+		return new NSData(decodeStringAsByteArray(uuid));
+	}
+		
+    /**
+     * Decode a string representing a UUID in hex. 
+     * All non hex char are filtered before the decoding, any formats are accepted.
+     * @param uuid the string representing a UUID
+     * @return the decoded UUID in a byte[]
+     */
+	static public byte[] decodeStringAsByteArray(String uuid) {
+		if (uuid == null) {
+			throw new IllegalArgumentException("Null is not a valid UUID value.");
+		}
+		String cleannedUuid = ERXStringUtilities.removeExceptCharacters(uuid, validHexCharacters);
+		if (cleannedUuid.length() != 16) {
+			throw new IllegalArgumentException("\""+uuid+"\" is not a valid hex string representing a byte[16].");
+		}
+		
+		try {
+			return ERXStringUtilities.hexStringToByteArray(cleannedUuid);
+		}
+		catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("\""+uuid+"\" is not a valid hex string representing a byte[16].", e);
+		}
+	}
+		
+	/**
+	 * Encode a UUID in a String using the usual format 12345678-1234-1234-1234-123456789ABC 
+	 * @param uuid a NSData containing a UUID
+	 * @return the encoded UUID
+	 */
+	static public String encodeAsPrettyString(NSData uuid) {
+		return encodeAsPrettyString(uuid.bytes());
+	}
+
+	/**
+	 * Encode a UUID in a String using the usual format 12345678-1234-1234-1234-123456789ABC 
+	 * @param uuid a byte[] containing a UUID
+	 * @return the encoded UUID
+	 */
+	static public String encodeAsPrettyString(byte[] uuid) {		
+		String rawString = encodeAsString(uuid);
+		
+		StringBuilder formattedString = new StringBuilder();
+		formattedString.append(rawString.substring(0, 8));
+		formattedString.append("-");
+		formattedString.append(rawString.substring(8, 12));
+		formattedString.append("-");
+		formattedString.append(rawString.substring(12, 16));
+		formattedString.append("-");
+		formattedString.append(rawString.substring(16, 20));
+		formattedString.append("-");
+		formattedString.append(rawString.substring(20, 24));
+		formattedString.append("-");
+		formattedString.append(rawString.substring(24, 32));
+		return formattedString.toString();
+	}
+	
+	/**
+	 * Encode a UUID in a String in hex 
+	 * @param uuid a NSData containing a UUID
+	 * @return the encoded UUID
+	 */
+	static public String encodeAsString(NSData uuid) {
+		return encodeAsString(uuid.bytes());
+	}
+	
+	/**
+	 * Encode a UUID in a String in hex 
+	 * @param uuid a byte[] containing a UUID
+	 * @return the encoded UUID
+	 */
+	static public String encodeAsString(byte[] uuid) {
+		if (uuid == null) {
+			throw new IllegalArgumentException("Null is not a valid UUID value.");
+		}
+		
+		String rawString = ERXStringUtilities.byteArrayToHexString(uuid);
+		if (uuid.length != 16) {
+			throw new IllegalArgumentException("\""+rawString+"\" is not a byte[16].");
+		}
+		return rawString;
+	}
+}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/UUIDUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/UUIDUtilities.java
@@ -11,7 +11,10 @@ import com.webobjects.foundation.NSData;
 public class UUIDUtilities  {
 	private static final String validHexCharacters = "ABCDEF0123456789abcdef";
 	static final SecureRandom randomGenerator = new SecureRandom();
-	
+
+    public final static int typeByteOffset = 6;
+    public final static int variationByteOffset = 8;
+
 	
 	/**
 	 * Generate a type 4 UUID from a secure random source like the java UUID class.
@@ -28,6 +31,12 @@ public class UUIDUtilities  {
     private static byte[] generateAsByteArray() {
 		byte[] value = new byte[16];
 		randomGenerator.nextBytes(value);
+		
+		value[typeByteOffset] &= 0xF; // Clear the type part of the byte
+		value[typeByteOffset] |= 0x40; // Set the type part of the byte to random
+		value[variationByteOffset] &= 0x3F; // Clear the variant part of the byte
+		value[variationByteOffset] |= 0x80; // set to IETF variant
+		
 		return value;
 	}
 
@@ -52,7 +61,7 @@ public class UUIDUtilities  {
 			throw new IllegalArgumentException("Null is not a valid UUID value.");
 		}
 		String cleannedUuid = ERXStringUtilities.removeExceptCharacters(uuid, validHexCharacters);
-		if (cleannedUuid.length() != 16) {
+		if (cleannedUuid.length() != 32) {
 			throw new IllegalArgumentException("\""+uuid+"\" is not a valid hex string representing a byte[16].");
 		}
 		
@@ -90,9 +99,7 @@ public class UUIDUtilities  {
 		formattedString.append("-");
 		formattedString.append(rawString.substring(16, 20));
 		formattedString.append("-");
-		formattedString.append(rawString.substring(20, 24));
-		formattedString.append("-");
-		formattedString.append(rawString.substring(24, 32));
+		formattedString.append(rawString.substring(20, 32));
 		return formattedString.toString();
 	}
 	

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2194,6 +2194,9 @@ public class ERXSQLHelper {
 			if (jdbcType == Types.BOOLEAN) {
 				externalType = "boolean";
 			}
+			else if (jdbcType == Types.BINARY) {
+				externalType = "byte";
+			}
 			else {
 				externalType = super.externalTypeForJDBCType(adaptor, jdbcType);
 			}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationTable.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/migration/ERXMigrationTable.java
@@ -907,7 +907,19 @@ public class ERXMigrationTable {
 	public ERXMigrationColumn newIpAddressColumn(String name, boolean allowsNull, String defaultValue) throws SQLException {
 		return newColumn(name, CustomTypes.INET, 39, 0, 0, allowsNull, null, defaultValue);
 	}
-	
+
+	/**
+	 * Returns a new UUID column.  See newColumn(..) for the full docs.
+	 * 
+	 * @param name the name of the column
+	 * @param allowsNull if true, the column will allow null values
+	 * @return the new ERXMigrationColumn
+	 * @throws SQLException if the column cannot be created 
+	 */
+	public ERXMigrationColumn newUuidColumn(String name, boolean allowsNull) throws SQLException {
+		return newColumn(name, Types.BINARY, 16, 0, 0, allowsNull, null);
+	}
+
 	/**
 	 * Callback method for ERXMigrationColumn to notify the table that
 	 * it has been deleted.

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFrontBasePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCFrontBasePrototypes.plist
@@ -361,6 +361,13 @@
             valueClassName = NSString; 
             valueType = c; 
             width = 10000000; 
+        }, 
+        {
+            columnName = uuid; 
+            externalType = BYTE; 
+            name = uuid; 
+            valueClassName = NSData; 
+            width = 16; 
         }
     ); 
     attributesUsedForLocking = (boolean, id); 
@@ -431,6 +438,7 @@
             osType, 
             shortString, 
             type, 
+            uuid, 
             varchar10, 
             varchar100, 
             varchar1000, 
@@ -443,7 +451,7 @@
     }; 
     isAbstractEntity = Y; 
     name = EOJDBCFrontBasePrototypes; 
-    primaryKeyAttributes = (eofKey, id); 
+    primaryKeyAttributes = (eofKey, id, uuid); 
     userInfo = {
         exampleConnectionDictionary = {URL = "jdbc:FrontBase://127.0.0.1/DatabaseName"; }; 
     }; 

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCMySQLPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCMySQLPrototypes.plist
@@ -353,6 +353,13 @@
             name = varcharLarge; 
             valueClassName = NSString; 
             valueType = c; 
+        }, 
+        {
+            columnName = uuid; 
+            externalType = BINARY; 
+            name = uuid; 
+            valueClassName = NSData; 
+            width = 16; 
         }
     ); 
     attributesUsedForLocking = (
@@ -456,5 +463,5 @@
     }; 
     isAbstractEntity = Y; 
     name = EOJDBCMySQLPrototypes; 
-    primaryKeyAttributes = (id); 
+    primaryKeyAttributes = (id, uuid); 
 }

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCOraclePrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCOraclePrototypes.plist
@@ -344,6 +344,13 @@
             externalType = CLOB; 
             name = varcharLarge; 
             valueClassName = NSString; 
+        }, 
+        {
+            columnName = uuid; 
+            externalType = RAW; 
+            name = uuid; 
+            valueClassName = NSData; 
+            width = 16; 
         }
     ); 
     attributesUsedForLocking = (
@@ -441,5 +448,5 @@
     }; 
     isAbstractEntity = Y; 
     name = EOJDBCOraclePrototypes; 
-    primaryKeyAttributes = (eofKey, id); 
+    primaryKeyAttributes = (eofKey, id, uuid); 
 }

--- a/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCPostgresqlPrototypes.plist
+++ b/Frameworks/Core/ERPrototypes/Resources/erprototypes.eomodeld/EOJDBCPostgresqlPrototypes.plist
@@ -359,6 +359,13 @@
             valueClassName = NSString; 
             valueType = S; 
             width = 10000000; 
+        }, 
+        {
+            columnName = uuid; 
+            externalType = bytea; 
+            name = uuid; 
+            valueClassName = NSData; 
+            width = 16; 
         }
     ); 
     attributesUsedForLocking = (boolean, id, jodaDateTime); 
@@ -441,5 +448,5 @@
     }; 
     isAbstractEntity = Y; 
     name = EOJDBCPostgresqlPrototypes; 
-    primaryKeyAttributes = (eofKey, id); 
+    primaryKeyAttributes = (eofKey, id, uuid); 
 }

--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXEORestDelegate.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXEORestDelegate.java
@@ -29,10 +29,10 @@ public class ERXEORestDelegate extends ERXAbstractRestDelegate {
 		boolean numericPKs = false;
 		if (classDescription instanceof EOEntityClassDescription) {
 			EOEntity entity = ((EOEntityClassDescription)classDescription).entity();
-			NSArray primaryKeyAttributes = entity.primaryKeyAttributes();
+			NSArray<EOAttribute> primaryKeyAttributes = entity.primaryKeyAttributes();
 			if (primaryKeyAttributes.count() == 1) {
-				EOAttribute primaryKeyAttribute = (EOAttribute) primaryKeyAttributes.objectAtIndex(0);
-				Class primaryKeyClass = _NSUtilities.classWithName(primaryKeyAttribute.className());
+				EOAttribute primaryKeyAttribute = primaryKeyAttributes.objectAtIndex(0);
+				Class<?> primaryKeyClass = _NSUtilities.classWithName(primaryKeyAttribute.className());
 				numericPKs = primaryKeyClass != null && Number.class.isAssignableFrom(primaryKeyClass);
 			}
 		}

--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXEORestDelegate.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXEORestDelegate.java
@@ -13,6 +13,7 @@ import com.webobjects.foundation.NSData;
 import com.webobjects.foundation._NSUtilities;
 
 import er.extensions.eof.ERXEOControlUtilities;
+import er.extensions.foundation.UUIDUtilities;
 
 /**
  * EODelegate is an implementation of the ERXRestRequestNode.Delegate interface that understands EOF.
@@ -81,20 +82,23 @@ public class ERXEORestDelegate extends ERXAbstractRestDelegate {
 				pkValue = ERXEOControlUtilities.primaryKeyObjectForObject(eo);
 			}
 		}
+		if (pkValue instanceof NSData) {
+			NSData pkData = (NSData) pkValue;
+			if (pkData.length() == 16) {
+				pkValue = UUIDUtilities.encodeAsPrettyString(pkData);
+			}
+		}
 
 		return pkValue;
 	}
 
 	public Object objectOfEntityWithID(EOClassDescription entity, Object id, ERXRestContext context) {
-		EOEntity eoEntity = ((EOEntityClassDescription) entity).entity();
 		String strPKValue = String.valueOf(id);
-		Object pkValue = eoEntity.primaryKeyAttributes().objectAtIndex(0).validateValue(strPKValue);
 		EOEditingContext editingContext = context.editingContext();
 		if (editingContext == null) {
 			throw new IllegalArgumentException("There was no editing context attached to this rest context.");
 		}
 		editingContext.lock();
-		Object obj;
 		try {
 			EOGlobalID gid = ERXEOControlUtilities.globalIDForString(editingContext, entity.entityName(), strPKValue);
 			return editingContext.faultForGlobalID(gid, editingContext);


### PR DESCRIPTION
Add support for auto generated UUID type 4 (random) as primary key.
Add a uuid prototype for FrontBase, MySQL and PostgreSQL. I do not have instance of other type of database to test them.
Add support for UUID primary key in ERRest.
