### PR TITLE
Reset validation state when the cancel action is invoked

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WInspectPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WInspectPage.java
@@ -163,6 +163,7 @@ public class ERD2WInspectPage extends ERD2WPage implements InspectPageInterface,
     public WOComponent cancelAction() {
         if ((object() != null) && (object().editingContext()!=null) && shouldRevertChanges()) {
             object().editingContext().revert();
+            clearValidationFailed();
         }
         return nextPage(false);
     }


### PR DESCRIPTION
Without this change, when attempting to create a new relationship object, failing due to a validation error, cancelling and then clicking "New" once more, would still show the validation messages.