### PR TITLE
ERXNavigation fixes

### DIFF
--- a/Frameworks/Core/ERExtensions/Components/Nonlocalized.lproj/ERXModernNavigationMenu.wo/ERXModernNavigationMenu.html
+++ b/Frameworks/Core/ERExtensions/Components/Nonlocalized.lproj/ERXModernNavigationMenu.wo/ERXModernNavigationMenu.html
@@ -1,7 +1,9 @@
 <div class="ERXNavigationMenu">
 
+<webobject name = "HasRootNavigationMenuItem">
 <ul>
 	<webobject name="RootNavigationMenuItem"></webobject>
 </ul>
-
+</webobject>
+<webobject name = "Else">No root navigation item set. You need one!</webobject>
 </div>

--- a/Frameworks/Core/ERExtensions/Components/Nonlocalized.lproj/ERXModernNavigationMenu.wo/ERXModernNavigationMenu.wod
+++ b/Frameworks/Core/ERExtensions/Components/Nonlocalized.lproj/ERXModernNavigationMenu.wo/ERXModernNavigationMenu.wod
@@ -2,3 +2,8 @@ RootNavigationMenuItem: ERXModernNavigationMenuItem {
 	navigationItem = rootNode;
 	navigationContext = navigationContext;
 }
+
+HasRootNavigationMenuItem: ERXNonNullConditional {
+	condition = rootNode;
+}
+Else : ERXElse {}

--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -210,8 +210,8 @@ er.extensions.ERXGracefulShutdown.SignalsToHandle=(TERM, INT)
 #########################################################################
 # Navigation 
 #########################################################################
-er.extensions.ERXNavigationManager.NavigationMenuFileName = NavigationMenu.plist
-er.extensions.ERXNavigationManager.localizeDisplayKeys = false
+# er.extensions.ERXNavigationManager.NavigationMenuFileName = NavigationMenu.plist
+# er.extensions.ERXNavigationManager.localizeDisplayKeys = false
 
 #########################################################################
 # Shared EO loading patching 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationManager.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationManager.java
@@ -25,6 +25,7 @@ import er.extensions.eof.ERXConstant;
 import er.extensions.foundation.ERXFileNotificationCenter;
 import er.extensions.foundation.ERXFileUtilities;
 import er.extensions.foundation.ERXPatcher;
+import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXUtilities;
 
 /** Please read "Documentation/Navigation.html" to fnd out how to use the navigation components.*/
@@ -59,7 +60,7 @@ public class ERXNavigationManager {
 
     public String navigationMenuFileName() {
         if (navigationMenuFileName == null) {
-            navigationMenuFileName = System.getProperty("er.extensions.ERXNavigationManager.NavigationMenuFileName");
+            navigationMenuFileName = ERXProperties.stringForKeyWithDefault("er.extensions.ERXNavigationManager.NavigationMenuFileName", "NavigationMenu.plist");
         }
         return navigationMenuFileName;
     }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationMenuItem.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationMenuItem.java
@@ -237,7 +237,7 @@ public class ERXNavigationMenuItem extends ERXStatelessComponent {
     public String displayName() {
     	String name = (String) resolveValue(navigationItem().displayName());
     	if(name != null) {
-    		if(ERXProperties.booleanForKey("er.extensions.ERXNavigationManager.localizeDisplayKeys")) {
+    		if(ERXProperties.booleanForKeyWithDefault("er.extensions.ERXNavigationManager.localizeDisplayKeys", false)) {
     			String localizerKey = "Nav." + name;
     			String localizedValue = ERXLocalizer.currentLocalizer().localizedStringForKey(localizerKey);
     			if(localizedValue == null) {


### PR DESCRIPTION
This pull request fixes the following problems:

1. when using the ERXNavigation inside a framework, it was not possible to overwrite the property er.extensions.ERXNavigationManager.NavigationMenuFileName in MyFramework/Resources/Properties

2. when the ERXNavigation is not configured correctly, the navigation menu throws an uncaught exception.

regards,

      René