### PR TITLE
New ERMDNestingListPageRepetition

### DIFF
--- a/Frameworks/D2W/ERModernDefaultSkin/WebServerResources/default_screen_stylesheet.css
+++ b/Frameworks/D2W/ERModernDefaultSkin/WebServerResources/default_screen_stylesheet.css
@@ -570,6 +570,15 @@ ul.L2WithChildren li.Nav2Selected {
 	width: 35px;
 }
 
+/* increase clickable area */
+.ShowNestedActionCell {
+	padding: 0;
+}
+.ShowNestedActionCell a {
+	padding: 0.5em;
+	width: 18px;
+}
+
 .EmbeddedObjTable .RtActionCell,
 .EditRelationshipObjTable .RtActionCell {
 	width: 170px;
@@ -816,6 +825,12 @@ span.ErrorLabel {
 
 .OddObjRow .Button span {
 	background-color: #e6e9ef;
+}
+
+/* hide empty children row */
+.ObjRow.NestedObjRow .hidden {
+	line-height: 0px;
+	padding: 0px;
 }
 
 .ComboTHLink .Label{

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDNestingListPageRepetition.wo/ERMDNestingListPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDNestingListPageRepetition.wo/ERMDNestingListPageRepetition.html
@@ -1,0 +1,64 @@
+<webobject name = "ObjectTable">
+  <webobject name = "ObjectsRepetition">
+    <webobject name = "IsRenderTableHeader">
+  <webobject name = "ObjectTableHeaderRow">
+        <webobject name = "HasNestedRelationship"><th>&nbsp;</th></webobject>
+    <webobject name = "HasLeftActionsConditional"><th class="ActionCell LftActionCell">&nbsp;</th></webobject>
+    <webobject name = "SectionRepetition">
+      <webobject name = "ColumnLabelRepetition">
+        <webobject name = "IsNotOmitted">
+          <webobject name = "AttColumnHeader">
+            <webobject name = "TableHeaderSwitchComponent"/>
+          </webobject>
+        </webobject>
+      </webobject>
+    </webobject>
+    <webobject name = "HasRightActionsConditional"><th class="ActionCell RtActionCell">&nbsp;</th></webobject>
+  </webobject>
+    </webobject>
+    <webobject name = "ListTableRow">
+    <webobject name = "HasNestedRelationship">
+      <td class="ActionCell ShowNestedActionCell">
+		<webobject name = "HasChildren">
+			<webobject name = "ToggleNestedRelationshipEditor"><webobject name = "DoCloseIcon"/><webobject name = "DoOpenIcon"/></webobject>
+		</webobject>
+      </td>
+    </webobject>
+    <webobject name = "HasLeftActionsConditional">
+      <td class="ActionCell LftActionCell">
+        <ul class="ObjActionList LftObjActionList NestingLftObjActionList">
+          <webobject name = "LeftActions">
+            <li><webobject name = "LeftAction" /></li>
+          </webobject>
+        </ul>
+      </td>
+      </webobject>
+      <webobject name = "SectionRepetition">
+        <webobject name = "AttributeRepetition">
+          <webobject name = "IsNotOmitted"><webobject name = "AttColumnCell"><webobject name = "AttributeDisplay" /></webobject></webobject>
+        </webobject>
+      </webobject>
+      <webobject name = "HasRightActionsConditional">
+      <td class="ActionCell RtActionCell">
+        <ul class="ObjActionList RtObjActionList">
+          <webobject name = "RightActions">
+            <li><webobject name = "RightAction" /></li>
+          </webobject>
+        </ul>
+      </td>
+      </webobject>
+    </webobject>
+    <!-- optional child relationship drill-down -->
+    <webobject name = "HasNestedRelationship">
+		<webobject name = "NestedUC">
+			<webobject name = "showNestedRelationshipEditor">
+				<webobject name = "NestedRelationshipField"><webobject name = "NestedRelationshipEditor"></webobject></webobject>
+			</webobject>
+			<webobject name = "hideNestedRelationshipEditor">
+				<webobject name = "HiddenNestedRelationshipField">&nbsp;</webobject>
+			</webobject>
+	    </webobject>
+    </webobject>
+  </webobject>
+</webobject>
+<p class="ERMDebugText" style="font-size:10px;"><webobject name = "D2wContextEntityName"/>-><webobject name = "D2wContextParentPageConfiguration"/>/<webobject name = "D2wContextPageConfiguration"/>/<webobject name = "D2wContextParentProperytKey"/></p>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDNestingListPageRepetition.wo/ERMDNestingListPageRepetition.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDNestingListPageRepetition.wo/ERMDNestingListPageRepetition.wod
@@ -1,7 +1,5 @@
 AttributeDisplay: WOSwitchComponent { 
 	WOComponentName = d2wContext.componentName;
-	_componentUnroll = true;
-	_unroll = true;
 	localContext = d2wContext;
 	object = d2wContext.object;
 }
@@ -60,6 +58,42 @@ ListTableRow: WOGenericContainer {
 	class = objectRowClass;
 }
 
+HasNestedRelationship : WOConditional {
+	condition = hasNestedRelationship;
+}
+
+NestedUC : AjaxUpdateContainer {
+	id = idForNestedUpdateContainer;
+	elementName = "tr";
+	class = nestedRowClass;
+}
+
+showNestedRelationshipEditor : WOConditional {
+	condition = showNestedRelationshipEditor;
+}
+
+NestedRelationshipField : WOGenericContainer {
+	elementName = "td";
+	colspan = columnCount;
+}
+
+HiddenNestedRelationshipField : WOGenericContainer {
+	elementName = "td";
+	colspan = columnCount;
+	class = "hidden";
+}
+
+NestedRelationshipEditor : WOSwitchComponent {
+	WOComponentName = childContext.componentName;
+	localContext = childContext;
+	object = childContext.object; // VALID
+}
+
+hideNestedRelationshipEditor : WOConditional {
+	condition = showNestedRelationshipEditor;
+	negate = true;
+}
+
 TableHeaderSwitchComponent : WOSwitchComponent {
 	WOComponentName = d2wContext.tableHeaderComponentName;
 	displayGroup = displayGroup;
@@ -97,10 +131,36 @@ AttColumnHeader : WOGenericContainer {
 AttColumnCell : WOGenericContainer {
 	elementName = "td";
 	class = d2wContext.classForAttributeColumn;
+	data-label = d2wContext.displayNameForProperty;
 }
 
 HasLeftActionsConditional : WOConditional {
 	condition = hasLeftActions;
+}
+
+HasChildren : WOConditional {
+	condition = hasChildren;
+}
+
+ToggleNestedRelationshipEditor : AjaxUpdateLink {
+	action = toggleNestedRelationshipEditor;
+	updateContainerID = idForNestedUpdateContainer;
+	onComplete = toggleIconsScript;
+	style = "display:block;";
+}
+
+DoOpenIcon : WOImage {
+	filename = "RightTriangle.gif";
+	framework = "JavaWOExtensions";
+	id = idForDoOpenIcon;
+	style = initialStyleForDoOpenIcon;
+}
+
+DoCloseIcon : WOImage {
+	filename = "DownTriangle.gif";
+	framework = "JavaWOExtensions";
+	id = idForDoCloseIcon;
+	style = initialStyleForDoCloseIcon;
 }
 
 HasRightActionsConditional : WOConditional {

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDNestingListPageRepetition.wo/ERMDNestingListPageRepetition.woo
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDNestingListPageRepetition.wo/ERMDNestingListPageRepetition.woo
@@ -1,0 +1,4 @@
+{
+	"WebObjects Release" = "WebObjects 5.0";
+	encoding = "UTF-8";
+}

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDSimpleListPageRepetition.wo/ERMDSimpleListPageRepetition.html
@@ -1,18 +1,20 @@
 <webobject name = "ObjectTable">
-  <webobject name = "ObjectTableHeaderRow">
-    <webobject name = "HasLeftActionsConditional"><th class="ActionCell LftActionCell">&nbsp;</th></webobject>
-    <webobject name = "SectionRepetition">
-      <webobject name = "ColumnLabelRepetition">
-        <webobject name = "IsNotOmitted">
-          <webobject name = "AttColumnHeader">
-            <webobject name = "TableHeaderSwitchComponent"/>
+  <webobject name = "ObjectsRepetition">
+    <webobject name = "IsRenderTableHeader">
+      <webobject name = "ObjectTableHeaderRow">
+        <webobject name = "HasLeftActionsConditional"><th class="ActionCell LftActionCell">&nbsp;</th></webobject>
+        <webobject name = "SectionRepetition">
+          <webobject name = "ColumnLabelRepetition">
+            <webobject name = "IsNotOmitted">
+              <webobject name = "AttColumnHeader">
+                <webobject name = "TableHeaderSwitchComponent"/>
+              </webobject>
+            </webobject>
           </webobject>
         </webobject>
+        <webobject name = "HasRightActionsConditional"><th class="ActionCell RtActionCell">&nbsp;</th></webobject>
       </webobject>
     </webobject>
-    <webobject name = "HasRightActionsConditional"><th class="ActionCell RtActionCell">&nbsp;</th></webobject>
-  </webobject>
-  <webobject name = "ObjectsRepetition">
     <webobject name = "ListTableRow">
     <webobject name = "HasLeftActionsConditional">
       <td class="ActionCell LftActionCell">

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/ERMDBatchSizeControl.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/ERMDBatchSizeControl.java
@@ -118,23 +118,23 @@ public class ERMDBatchSizeControl extends ERDCustomComponent {
      * Defaults to the first parent update container id.
      */
 	public String updateContainerID() {
-		if (_updateContainerID == null) {
-			_updateContainerID = (String) valueForBinding(Keys.updateContainerID);
-			if (_updateContainerID == null) {
-				_updateContainerID = AjaxUpdateContainer.currentUpdateContainerID();
-			}
-		}
-		return _updateContainerID;
+        if (_updateContainerID == null) {
+            _updateContainerID = (String) valueForBinding(Keys.updateContainerID);
+            if (_updateContainerID == null) {
+                _updateContainerID = AjaxUpdateContainer.currentUpdateContainerID();
+            }
+        }
+        return _updateContainerID;
 	}
 
 	/**
 	 * Returns a unique id for this batch size control
 	 */
 	public String batchSizeFieldID() {
-		if (_batchSizeFieldID == null) {
-			_batchSizeFieldID = "BSIF" + ERXStringUtilities.safeIdentifierName(context().contextID());;
-		}
-		return _batchSizeFieldID;
+        if (_batchSizeFieldID == null) {
+            _batchSizeFieldID = updateContainerID() + "_BSIF";
+        }
+        return _batchSizeFieldID;
 	}
 	
 	public void setBatchSizeFieldID(String fieldID) {

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/repetitions/ERMDNestingListPageRepetition.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/repetitions/ERMDNestingListPageRepetition.java
@@ -1,0 +1,211 @@
+package er.modern.directtoweb.components.repetitions;
+
+import com.webobjects.appserver.WOActionResults;
+import com.webobjects.appserver.WOComponent;
+import com.webobjects.appserver.WOContext;
+import com.webobjects.directtoweb.D2WContext;
+import com.webobjects.directtoweb.ERD2WContext;
+import com.webobjects.eocontrol.EOEnterpriseObject;
+import com.webobjects.foundation.NSArray;
+import com.webobjects.foundation.NSDictionary;
+import com.webobjects.foundation.NSMutableDictionary;
+
+import er.extensions.foundation.ERXValueUtilities;
+
+/**
+ * Special list page repetition for hierarchical object structures that extends
+ * ERMDListPageRepetition. Allows recursive access to a relationship specified
+ * via the "nestedRelationship" key.
+ * 
+ * As an example, you could use this for a hierarchy of locations (think
+ * "continent > country > city > quarter"), with "containedLocations" as the
+ * nestedRelationship key. This will allow a "drill-down" access to locations.
+ * 
+ * @binding displayGroup
+ * @binding d2wContext
+ * 
+ * @d2wKey baseClassForObjectRow
+ * @d2wKey componentName
+ * @d2wKey displayNameForProperty
+ * @d2wKey extraListComponentName
+ * @d2wKey justification
+ * @d2wKey nestedRelationship
+ * @d2wKey object
+ * @d2wKey propertyIsSortable 
+ * @d2wKey showNestedRelationshipEditor
+ * @d2wKey sortCaseInsensitive
+ * @d2wKey sortKeyForList
+
+ * @author fpeters
+ */
+public class ERMDNestingListPageRepetition extends ERMDListPageRepetition {
+
+    private static final long serialVersionUID = 1L;
+
+    public interface Keys {
+
+        public static String nestedRelationship = "nestedRelationship";
+
+        public static String showNestedRelationshipEditor = "showNestedRelationshipEditor";
+
+    }
+
+    public ERMDNestingListPageRepetition(WOContext context) {
+        super(context);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public NSDictionary childRelationshipBindings() {
+        NSArray masterObjectAndRelationshipKey = new NSArray(d2wContext()
+                .valueForKeyPath("object"), d2wContext().valueForKey(
+                Keys.nestedRelationship));
+        return new NSMutableDictionary("masterObjectAndRelationshipKey",
+                masterObjectAndRelationshipKey);
+    }
+
+    public D2WContext childContext() {
+        D2WContext c = ERD2WContext.newContext(d2wContext());
+        c.setPropertyKey((String) d2wContext().valueForKey(Keys.nestedRelationship));
+        c.takeValueForKey("ERDEditRelationship", "componentName");
+        return c;
+    }
+
+    public boolean hasLeftActions() {
+        boolean hasLeftActions = leftActions() != null && leftActions().count() > 0;
+        return hasLeftActions;
+    }
+
+    public WOActionResults toggleNestedRelationshipEditor() {
+        // use globalID hash as unique key for this object
+        Boolean showNestedRelationshipEditor = (Boolean) d2wContext().valueForKeyPath(
+                Keys.showNestedRelationshipEditor + uniqueObjectID());
+        if (showNestedRelationshipEditor == null) {
+            // default to hide
+            showNestedRelationshipEditor = Boolean.FALSE;
+        }
+        d2wContext().takeValueForKeyPath(!showNestedRelationshipEditor,
+                Keys.showNestedRelationshipEditor + uniqueObjectID());
+        return null;
+    }
+
+    public Boolean hasNestedRelationship() {
+        return d2wContext().valueForKey(Keys.nestedRelationship) != null;
+    }
+
+	public boolean showNestedRelationshipEditor() {
+        // use globalID hash as unique key for this object
+		return ERXValueUtilities.booleanValue(d2wContext().valueForKeyPath(Keys.
+				showNestedRelationshipEditor + uniqueObjectID()));
+    }
+
+    /**
+     * @return the column count for the nested td's colspan
+     */
+    public int columnCount() {
+        int columnCount = displayPropertyKeyCount();
+        if (d2wContext().valueForKey(Keys.nestedRelationship) != null) {
+        	// additional column for toggle action
+        columnCount++;
+        }
+        if (hasLeftActions()) {
+            columnCount++;
+        }
+        if (hasRightActions()) {
+            columnCount++;
+        }
+        return columnCount;
+    }
+
+    /**
+     * Computes a unique ID, based on the nesting level. Depending on the object
+     * graph, a unique EOGlobalID may be insufficient as an EO might appear more
+     * than once.
+     * 
+     * @return unique ID for the nested update container
+     */
+    public String idForNestedUpdateContainer() {
+        String idForNestedUpdateContainer = (String) d2wContext().valueForKey(
+                "idForRepetitionContainer");
+        WOComponent ancestor = parent();
+        int recursionCounter = 0;
+        while (ancestor != null && ancestor.parent() != null) {
+            ancestor = ancestor.parent();
+            if (name().equals(ancestor.name())) {
+                recursionCounter++;
+            }
+        }
+        idForNestedUpdateContainer = idForNestedUpdateContainer + "_l" + recursionCounter
+                + "_" + uniqueObjectID();
+        return idForNestedUpdateContainer;
+    }
+
+    /**
+     * @return a unique ID, based on the D2WContext's object value
+     */
+    private String uniqueObjectID() {
+        EOEnterpriseObject object = (EOEnterpriseObject) d2wContext().valueForKey(
+                "object");
+        String uniqueID = String.valueOf(object.hashCode());
+        return uniqueID;
+    }
+
+    /*
+     * Overridden to remove LastObjRow class, as the nestedRowClass will always
+     * be last.
+     */
+    public String objectRowClass() {
+        String objectRowClass = super.objectRowClass();
+        objectRowClass = objectRowClass.replace("LastObjRow", "");
+        return objectRowClass;
+    }
+
+    /**
+     * Gets class list from object row class, but removes any FirstObjRow
+     * occurrence, as the nested row can never be the first row.
+     * 
+     * @return nested row class
+     */
+    public String nestedRowClass() {
+        String nestedRowClass = super.objectRowClass();
+        nestedRowClass = nestedRowClass.replace("FirstObjRow", "");
+        nestedRowClass = nestedRowClass.concat(" NestedObjRow");
+        return nestedRowClass;
+    }
+
+    public boolean hasChildren() {
+        EOEnterpriseObject object = (EOEnterpriseObject) d2wContext().valueForKey(
+                "object");
+		boolean hasChildren = ERXValueUtilities.booleanValue(object.valueForKeyPath(
+				d2wContext().valueForKey(Keys.nestedRelationship) + ".@count"));
+    	return hasChildren; 
+    }
+    
+    /*
+	 * The remainder handles the icon toggling – the same could be achieved by simply
+	 * putting the icons in a dependent update container, but that would
+	 * potentially introduce a lot of update containers.
+	 */
+
+    public String idForDoOpenIcon() {
+    	return idForNestedUpdateContainer() + "_open";
+    }
+    
+    public String idForDoCloseIcon() {
+    	return idForNestedUpdateContainer() + "_close";
+    }
+
+	public String toggleIconsScript() {
+		String toggleIconsScript = "function(){$('" + idForDoOpenIcon() + 
+				"', '" + idForDoCloseIcon() + "').invoke('toggle');}";
+		return toggleIconsScript;
+	}
+	
+	public String initialStyleForDoOpenIcon() {
+		return showNestedRelationshipEditor() ? "display:none;" : "";
+	}
+	
+	public String initialStyleForDoCloseIcon() {
+		return showNestedRelationshipEditor() ? "" : "display:none;";
+	}
+
+}

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODEditRelationshipPage.wo/ERMODEditRelationshipPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODEditRelationshipPage.wo/ERMODEditRelationshipPage.wod
@@ -115,21 +115,21 @@ InnerWrapper : WOGenericContainer {
 
 RepetitionUpdateContainer : AjaxUpdateContainer {
     elementName = "div";
-    id = d2wContext.idForRepetitionContainer;
+    id = idForRepetitionContainer;
 }
 
 ToManyListRepetition: WOSwitchComponent {
     WOComponentName = d2wContext.toManyRepetitionComponentName;
     d2wContext = localContext;
     displayGroup = relationshipDisplayGroup;
-    updateContainerID = d2wContext.idForRepetitionContainer;
+    updateContainerID = idForRepetitionContainer;
 }
 
 ToOneListRepetition: WOSwitchComponent {
     WOComponentName = d2wContext.toOneRepetitionComponentName;
     d2wContext = localContext;
     displayGroup = relationshipDisplayGroup;
-    updateContainerID = d2wContext.idForRepetitionContainer;
+    updateContainerID = idForRepetitionContainer;
 }
 
 ShowBottomBatchNavBar : WOConditional {
@@ -154,12 +154,12 @@ NavigationBar: WOSwitchComponent {
     WOComponentName = d2wContext.batchNavigationBarComponentName;
     displayGroup = relationshipDisplayGroup;
     d2wContext = d2wContext;
-    updateContainerID = d2wContext.idForRepetitionContainer;
+    updateContainerID = idForRepetitionContainer;
 }
 
 BatchSizeControl : ERMDBatchSizeControl {
   displayGroup = relationshipDisplayGroup;
-  updateContainerID = d2wContext.idForRepetitionContainer;
+  updateContainerID = idForRepetitionContainer;
   d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODEditRelationshipPage.java
@@ -635,4 +635,17 @@ public class ERMODEditRelationshipPage extends ERD2WPage implements ERMEditRelat
 		}
 	}
 
+    /**
+     * @return a unique ID for the repetition container
+     */
+    public String idForRepetitionContainer() {
+        String repetitionContainerID = (String) d2wContext().valueForKey(
+                "idForRepetitionContainer");
+        // use master object to generate globally unique ID
+        // - allows for nesting of relationship components
+        repetitionContainerID = repetitionContainerID.concat("_"
+                + masterObject().hashCode());
+        return repetitionContainerID;
+    }
+
 }


### PR DESCRIPTION
ERMDNestingListPageRepetition is a special list page repetition for hierarchical object structures that extends ERMDListPageRepetition. Allows recursive access to a relationship specified via the "nestedRelationship" key. To use it, set it via "toManyRepetitionComponentName".

As an example, you could use this for a hierarchy of locations (think "continent > country > city > quarter"), with "containedLocations" as the nestedRelationship key. This will allow a "drill-down" access to locations.

![ermdnestinglistpagerepetition](https://cloud.githubusercontent.com/assets/1228832/15862306/8dfabde4-2ccf-11e6-9ab5-e8276d3f8c6a.png)
