### PR TITLE
New ERMDebuggingHelp component

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.api
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.api
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<wodefinitions>
+    <wo class="ERD2WContextInspector" wocomponentcontent="false">    <binding name="d2wContext"/>
+        <validation message="'d2wContext' is a required binding.">
+            <unbound name="d2wContext"/>
+        </validation>
+    </wo>
+</wodefinitions>

--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.wo/ERD2WContextInspector.html
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.wo/ERD2WContextInspector.html
@@ -1,0 +1,1 @@
+<pre><webobject name = "d2wContextString"></webobject></pre>

--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.wo/ERD2WContextInspector.wod
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.wo/ERD2WContextInspector.wod
@@ -1,0 +1,3 @@
+d2wContextString : WOString {
+	value = d2wContextString;
+}

--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.wo/ERD2WContextInspector.woo
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERD2WContextInspector.wo/ERD2WContextInspector.woo
@@ -1,0 +1,4 @@
+{
+	"WebObjects Release" = "WebObjects 5.0";
+	encoding = "UTF-8";
+}

--- a/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERDDebuggingHelp.wo/ERDDebuggingHelp.html
+++ b/Frameworks/Core/ERDirectToWeb/Components/Nonlocalized.lproj/ERDDebuggingHelp.wo/ERDDebuggingHelp.html
@@ -1,78 +1,78 @@
 <webobject name=Conditional1>Page Configuration:
 	<webobject name=String1></webobject>
-		<a onmouseout="this.innerHTML=this.innerHTML.replace('visibility: visible;','visibility: hidden;');" onmouseover="this.innerHTML=this.innerHTML.replace('visibility: hidden;','visibility: visible;');">
-			?
-			<span style="position:absolute;visibility: hidden;" onclick="this.style.visibility='hidden'; return false;">
-				<table bgcolor="white" border="1" onclick="this.style.visibility='hidden'; return false;">
-					<webobject name="Repetition1">
-						<tr>
-							<td>
+  <a onmouseout = "this.innerHTML=this.innerHTML.replace('visibility: visible;','visibility: hidden;');" onmouseover = "this.innerHTML=this.innerHTML.replace('visibility: hidden;','visibility: visible;');">
+    ? 
+    <span style = "position:absolute;visibility: hidden;" onclick = "this.style.visibility='hidden'; return false;">
+      <table bgcolor = "white" border = "1" onclick = "this.style.visibility='hidden'; return false;">
+        <webobject name = "Repetition1">
+          <tr>
+            <td>
 								<b>
 									<webobject name="String9"></webobject>
 								</b>
 							</td>
 							<td>
 								<webobject name="String8"></webobject>
-							</td>
-						</tr>
-					</webobject>
-				</table>
-			</span>
-		</a>
-		<br />
+            </td>
+          </tr>
+        </webobject>
+      </table>
+    </span>
+  </a>
+  <br />
 	<webobject name=Conditional3><font size=2><webobject name=Hyperlink1>HIDE property-level component
 			names</webobject></font></webobject><webobject name=Conditional2><font size=2><webobject name=Hyperlink2>SHOW
 			property-level component names</webobject></font></webobject><br>
 	<webobject name=CollapsibleComponentContent1><br>
 		<table cellspacing=0 cellpadding=0 border=0 width=600>
-			<tr>
-				<td>Task</td>
+      <tr>
+        <td>Task</td>
 				<td><webobject name=String2></webobject></td>
-			</tr>
-			<tr>
+      </tr>
+      <tr>
 				<td width=120>SubTask</td>
 				<td><webobject name=String11></webobject></td>
-			</tr>
-			<tr>
-				<td>Tab Section</td>
+      </tr>
+      <tr>
+        <td>Tab Section</td>
 				<td><webobject name=String3></webobject></td>
-			</tr>
-			<tr>
-				<td>Entity Name</td>
+      </tr>
+      <tr>
+        <td>Entity Name</td>
 				<td><webobject name=String4></webobject></td>
-			</tr>
-			<tr>
-				<td>Template Name</td>
+      </tr>
+      <tr>
+        <td>Template Name</td>
 				<td><webobject name=String12></webobject></td>
-			</tr>
-			<tr>
+      </tr>
+      <tr>
 				<td width=200>Parent Page Configuration</td>
 				<td><webobject name=String13></webobject></td>
-			</tr>
+      </tr>
 			<webobject name=Conditional4>
-				<tr>
-					<td>Page Editing Context</td>
+        <tr>
+          <td>Page Editing Context</td>
 					<td><webobject name=String5></webobject>:
 						<webobject name=Hyperlink3>Show</webobject></td>
-				</tr>
-			</webobject>
-			<tr>
-				<td>Default Editing Context</td>
+        </tr>
+      </webobject>
+      <tr>
+        <td>Default Editing Context</td>
 				<td><webobject name=String7></webobject>:
 					<webobject name=Hyperlink4>Show</webobject></td>
-			</tr>
-			<tr>
-				<td>Rule tracing</td>
+      </tr>
+      <tr>
+        <td>Rule tracing</td>
 				<td>Turn
 					<webobject name=Hyperlink5></webobject></td>
-			</tr>
+      </tr>
 			<webobject name=Form1>
-				<tr>
-					<td>D2W Key
+        <tr>
+          <td>D2W Key 
 						<webobject name=TextField1></webobject>
-						has value</td>
+            has value</td>
 					<td><tt><webobject name=String6></webobject></tt></td>
-				</tr>
-			</webobject>
-		</table>
+        </tr>
+      </webobject>
+    </table>
 	</webobject></webobject>

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDDebuggingHelp.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDDebuggingHelp.java
@@ -115,7 +115,7 @@ public class ERDDebuggingHelp extends WOComponent implements ERXDebugMarker.Debu
     
     public Object debugValueForKey() {
         if(key != null && !"".equals(key))
-            return d2wContext().valueForKeyPath(key);
+                return d2wContext().valueForKeyPath(key);
         return null;
     }
     
@@ -151,5 +151,5 @@ public class ERDDebuggingHelp extends WOComponent implements ERXDebugMarker.Debu
     	dict.removeObjectForKey("componentLevelKeys");
         return dict;
     }
- 
+    
 }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERD2WContextInspector.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERD2WContextInspector.java
@@ -1,0 +1,62 @@
+package er.directtoweb.components.misc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.webobjects.appserver.WOContext;
+import com.webobjects.appserver.WOSession;
+import com.webobjects.directtoweb.D2WContext;
+import com.webobjects.eoaccess.EOAttribute;
+import com.webobjects.eoaccess.EOEntity;
+import com.webobjects.eoaccess.EORelationship;
+
+import er.extensions.components.ERXStatelessComponent;
+
+/**
+ * Simple D2WContext inspector component, showing the bound context's local
+ * values to help debugging. Uses a shorter representation instead of toString()
+ * for WOSession, EOAttribute, EOEntity and EORelationship objects and skips the
+ * contextDictionary key.
+ * 
+ * @author fpeters
+ *
+ */
+public class ERD2WContextInspector extends ERXStatelessComponent {
+
+    private static final long serialVersionUID = 1L;
+
+    public ERD2WContextInspector(WOContext context) {
+        super(context);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    public String d2wContextString() {
+        D2WContext context = (D2WContext) valueForBinding("d2wContext");
+        StringBuilder d2wContextString = new StringBuilder();
+        List<String> keys = new ArrayList<String>(context._localValues().keySet());
+        Collections.sort(keys);
+        for (String key : keys) {
+            Object value = context.valueForKey(key);
+            // skip contextDictionary
+            if (!"contextDictionary".equals(key)) {
+                if (d2wContextString.length() > 0) {
+                    d2wContextString.append(";\n");
+                }
+                if (value instanceof WOSession) {
+                    d2wContextString.append(key + ": " + ((WOSession) value).sessionID());
+                } else if (value instanceof EOAttribute) {
+                    d2wContextString.append(key + ": " + ((EOAttribute) value).name());
+                } else if (value instanceof EOEntity) {
+                    d2wContextString.append(key + ": " + ((EOEntity) value).name());
+                } else if (value instanceof EORelationship) {
+                    d2wContextString.append(key + ": " + ((EORelationship) value).name());
+                } else {
+                    d2wContextString.append(key + ": " + value);
+                }
+            }
+        }
+        return d2wContextString.toString();
+    }
+
+}

--- a/Frameworks/D2W/ERModernDefaultSkin/WebServerResources/default_screen_stylesheet.css
+++ b/Frameworks/D2W/ERModernDefaultSkin/WebServerResources/default_screen_stylesheet.css
@@ -1479,7 +1479,28 @@ div.RtActionCell li {
 	font-weight: bold;
 }
 
+.D2WPropertyDebugInfo, .DebugHelp table, .D2WPropertyDebugInfo th, .D2WPropertyDebugInfo td {
+	font-weight: normal;
+	padding: 4px;
+	color: black;
+	background-color: #eae9eb;
+}
+
+.D2WPropertyDebugInfoToolTip {
+	z-index: 100;
+}
+
+.D2WPropertyDebugInfoToolTip span {
+	position: absolute;
+}
+
+.D2WPropertyDebugInfoToolTip:hover table {
+	display: table;
+}
+
 .D2WPropertyDebugInfo {
+	position: relative;
+	display: none;
 	z-index: 100;
 	background-color: #ddd;
 }
@@ -1488,7 +1509,6 @@ div.RtActionCell li {
 	display: none;
 }
 
-.D2WPropertyDebugInfo {}
 #ERD2WDebugFlags {
 	position: fixed;
 	bottom: 25px;
@@ -1504,3 +1524,4 @@ div.RtActionCell li {
 	opacity: 0.6;
 	-moz-opacity:0.6;
 }
+

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WPropertyName.wo/ERMD2WPropertyName.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WPropertyName.wo/ERMD2WPropertyName.html
@@ -1,15 +1,21 @@
-<webobject name=HasPropertyName>
-	<webobject name = "FieldLabel">
-			<webobject name="PropertyName" />
-			<webobject name="DisplayMandatory"><webobject name = "abbr">*</webobject></webobject>
-	</webobject>
+<webobject name = "HasPropertyName">
+  <webobject name = "FieldLabel">
+    <webobject name = "PropertyName" />
+    <webobject name = "DisplayMandatory">
+      <webobject name = "abbr">*</webobject>
+    </webobject>
+  </webobject>
 </webobject>
-<webobject name=DebuggingEnabled><a onmouseout="this.innerHTML=this.innerHTML.replace('visibility: visible;','visibility: hidden;');" onmouseover="this.innerHTML=this.innerHTML.replace('visibility: hidden;','visibility: visible;');">?<span onclick="this.style.visibility='hidden'; return false;" style="position:absolute;visibility: hidden;">
-	<table class="D2WPropertyDebugInfo" onclick="this.style.visibility='hidden'; return false;">
-		<webobject name="ContextDictionaryRepetition">
-			<tr>
-				<th><webobject name="CurrentKey" /></th>
-				<td><webobject name="CurrentValue" /></td>
-			</tr>
-		</webobject>
-	</table></span></a></webobject>
+<webobject name = "DebuggingEnabled">
+  <a class = "D2WPropertyDebugInfoToolTip">? 
+    <span>
+      <table class = "D2WPropertyDebugInfo">
+        <webobject name = "ContextDictionaryRepetition">
+          <tr>
+            <th><webobject name = "CurrentKey" /></th>
+            <td><webobject name = "CurrentValue" /></td>
+          </tr>
+        </webobject>
+      </table>
+    </span></a>
+</webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDDebuggingHelp.wo/ERMDDebuggingHelp.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDDebuggingHelp.wo/ERMDDebuggingHelp.html
@@ -1,0 +1,90 @@
+<webobject name = "ShowHelp">
+  <webobject name = "UpdateContainer">
+    <div class = "DebugHelp">
+      <webobject name = "ToggleDetails">
+        <webobject name = "IsShowDetails"><webobject name = "DoCloseIcon" /></webobject>
+        <webobject name = "IsNotShowDetails"><webobject name = "DoOpenIcon" /></webobject>
+        Page Configuration: 
+      </webobject>
+      <webobject name = "D2wContextPageConfiguration" />
+      <a class = "D2WPropertyDebugInfoToolTip">
+        ? 
+        <span>
+          <table class = "D2WPropertyDebugInfo">
+            <webobject name = "ContextDictionaryForPageAllKeysSortAscToString">
+              <tr>
+                <td> <webobject name = "CurrentKey" /> </td>
+                <td> <webobject name = "CurrentValue" /> </td>
+              </tr>
+            </webobject>
+          </table>
+        </span>
+      </a>
+      <br />
+      <br />
+      <webobject name = "IsShowDetails">
+        <table>
+          <tr>
+            <td>Task</td>
+            <td><webobject name = "D2wContextTask" /></td>
+          </tr>
+          <tr>
+            <td>SubTask</td>
+            <td><webobject name = "D2wContextSubTask" /></td>
+          </tr>
+          <tr>
+            <td>Tab Section</td>
+            <td><webobject name = "D2wContextTabKey" /></td>
+          </tr>
+          <tr>
+            <td>Entity Name</td>
+            <td><webobject name = "D2wContextEntityName" /></td>
+          </tr>
+          <tr>
+            <td>Template Name</td>
+            <td><webobject name = "D2wContextPageName" /></td>
+          </tr>
+          <tr>
+            <td>Parent Page Configuration</td>
+            <td><webobject name = "D2wContextParentPageConfiguration" /></td>
+          </tr>
+          <webobject name = "HasEditingContext">
+            <tr>
+              <td>Page Editing Context</td>
+              <td>
+                <webobject name = "EditingContext" />: 
+                <webobject name = "ShowEditingContextLink">Show</webobject>
+              </td>
+            </tr>
+          </webobject>
+          <tr>
+            <td>Default Editing Context</td>
+            <td>
+              <webobject name = "SessionDefaultEditingContext" />: 
+              <webobject name = "ShowDefaultEditingContextLink">Show</webobject>
+            </td>
+          </tr>
+          <tr>
+            <td>Rule tracing</td>
+            <td>Turn <webobject name = "ToggleRuleTracingLink" /></td>
+          </tr>
+          <webobject name = "Form1">
+            <tr>
+              <td>D2W Key 
+                <webobject name = "d2wKeyObserver"><webobject name = "TextField1" /></webobject>
+                has value</td>
+              <td>
+                <webobject name = "d2wKeyUC">
+                  <webobject name = "isKeyEmpty"><webobject name = "D2WContextInspector" /></webobject>
+                  <webobject name = "isKeyNotEmpty">
+                    <pre><webobject name = "DebugValueForKey"/></pre>
+                  </webobject>
+                </webobject>
+              </td>
+            </tr>
+          </webobject>
+        </table>
+      </webobject>
+    </div>
+  </webobject>
+</webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDDebuggingHelp.wo/ERMDDebuggingHelp.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDDebuggingHelp.wo/ERMDDebuggingHelp.wod
@@ -1,0 +1,143 @@
+UpdateContainer : AjaxUpdateContainer {
+	id = debugHelpUC;
+}
+
+ShowHelp: WOConditional {
+	condition = showHelp;
+}
+
+ToggleDetails : AjaxUpdateLink {
+	action = toggleDetails;
+	updateContainerID = debugHelpUC;
+}
+
+DoOpenIcon : WOImage {
+	filename = "RightTriangle.gif";
+	framework = "JavaWOExtensions";
+}
+
+DoCloseIcon : WOImage {
+	filename = "DownTriangle.gif";
+	framework = "JavaWOExtensions";
+}
+
+IsNotShowDetails : WOConditional {
+	condition = showDetails;
+	negate = true;
+}
+
+HasEditingContext: WOConditional {
+	condition = hasEditingContext;
+}
+
+Form1: ERXOptionalForm {
+}
+
+ShowEditingContextLink: WOHyperlink {
+	action = showEditingContext;
+	target = "_inspector";
+}
+
+ShowDefaultEditingContextLink: WOHyperlink {
+	action = showDefaultEditingContext;
+	target = "_inspector";
+}
+
+ToggleRuleTracingLink: AjaxUpdateLink {
+	action = toggleRuleTracing;
+	string = ruleTracingState;
+	updateContainerID = d2wKeyResultUC;
+}
+
+ContextDictionaryForPageAllKeysSortAscToString: WORepetition {
+	list = contextDictionaryForPage.allKeys.@sortAsc.toString;
+	item = currentKey;
+}
+
+D2wContextPageConfiguration: WOString {
+	value = ^d2wContext.pageConfiguration;
+	valueWhenEmpty = "No Page Configuration";
+}
+
+D2wContextSubTask: WOString {
+	value = ^d2wContext.subTask;
+	valueWhenEmpty = "No Sub Task";
+}
+
+D2wContextPageName: WOString {
+	value = ^d2wContext.pageName;
+	valueWhenEmpty = "Now this is very strange";
+}
+
+D2wContextParentPageConfiguration: WOString {
+	value = ^d2wContext.parentPageConfiguration;
+	valueWhenEmpty = "No Parent Configuration";
+}
+
+D2wContextTask: WOString {
+	value = ^d2wContext.task;
+}
+
+D2wContextTabKey: WOString {
+	value = ^d2wContext.tabKey;
+	valueWhenEmpty = "No Current Page Name";
+}
+
+D2wContextEntityName: WOString {
+	value = ^d2wContext.entity.name;
+}
+
+EditingContext: WOString {
+	value = editingContext;
+}
+
+DebugValueForKey: WOString {
+	value = debugValueForKey;
+	valueWhenEmpty = "No value set or empty";
+}
+
+SessionDefaultEditingContext: WOString {
+	value = session.defaultEditingContext;
+}
+
+CurrentValue: WOString {
+	value = currentValue;
+}
+
+CurrentKey: WOString {
+	value = currentKey;
+}
+
+IsShowDetails : WOConditional {
+	condition = showDetails;
+}
+
+d2wKeyObserver : AjaxObserveField {
+	updateContainerID = d2wKeyResultUC;
+	observeFieldFrequency = 1;
+}
+
+TextField1: WOText {
+	value = key;
+	rows = 3;
+	cols = 30;
+	style = "max-width:300px;";
+}
+
+d2wKeyUC : AjaxUpdateContainer {
+	id = d2wKeyResultUC;
+	style = "max-height:190px;max-width:500px;overflow:auto;";
+}
+
+isKeyEmpty : ERXNonNullConditional {
+	condition = key;
+	negate = true;
+}
+
+D2WContextInspector : ERD2WContextInspector {
+	d2wContext = d2wContext;
+}
+
+isKeyNotEmpty : ERXNonNullConditional {
+	condition = key;
+}

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDDebuggingHelp.wo/ERMDDebuggingHelp.woo
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMDDebuggingHelp.wo/ERMDDebuggingHelp.woo
@@ -1,0 +1,5 @@
+{
+    "WebObjects Release" = "WebObjects 5.0"; 
+    encoding = "UTF-8"; 
+    variables = {}; 
+}

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/ERMDDebuggingHelp.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/ERMDDebuggingHelp.java
@@ -1,0 +1,41 @@
+package er.modern.directtoweb.components;
+
+import com.webobjects.appserver.WOContext;
+
+import er.directtoweb.components.ERDDebuggingHelp;
+import com.webobjects.appserver.WOActionResults;
+
+public class ERMDDebuggingHelp extends ERDDebuggingHelp {
+
+    private static final long serialVersionUID = 1L;
+
+    public Boolean showDetails = false;
+
+    public ERMDDebuggingHelp(WOContext context) {
+        super(context);
+    }
+
+    public Object debugValueForKey() {
+        if (key != null && !"".equals(key)) {
+            try {
+                return d2wContext().valueForKeyPath(key);
+            } catch (Exception e) {
+            }
+        }
+        return null;
+    }
+
+    public String debugHelpUC() {
+        return "debugHelpUC" + d2wContext().valueForKeyPath("pageConfiguration");
+    }
+
+    public String d2wKeyResultUC() {
+        return "d2wKeyResultUC" + d2wContext().valueForKeyPath("pageConfiguration");
+    }
+
+    public WOActionResults toggleDetails() {
+        showDetails = !showDetails;
+        return null;
+    }
+
+}

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODCalendarPage.wo/ERMODCalendarPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODCalendarPage.wo/ERMODCalendarPage.wod
@@ -18,7 +18,7 @@ Header: WOSwitchComponent {
 	d2wContext = d2wContext;
 }
 
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODCompactInspectPage.wo/ERMODCompactInspectPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODCompactInspectPage.wo/ERMODCompactInspectPage.wod
@@ -1,4 +1,4 @@
-Debug: ERDDebuggingHelp {
+Debug: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODCompactListPage.wo/ERMODCompactListPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODCompactListPage.wo/ERMODCompactListPage.wod
@@ -9,7 +9,7 @@ ErrorBlock: ERMODErrorBlock {
     errorMessages = errorMessages;
 }
 
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODConfirmPage.wo/ERMODConfirmPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODConfirmPage.wo/ERMODConfirmPage.wod
@@ -4,7 +4,7 @@ BranchButton: CCSubmitLinkButton {
 	class = "Button OptionButton";
 }
 
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODMessagePage.wo/ERMODMessagePage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODMessagePage.wo/ERMODMessagePage.wod
@@ -25,7 +25,7 @@ HasNoBranchChoices: WOConditional {
 	negate = true;
 }
 
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODPickTypePage.wo/ERMODPickTypePage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODPickTypePage.wo/ERMODPickTypePage.wod
@@ -29,7 +29,7 @@ Form1: WOForm {
 	multipleSubmit = true;
 }
 
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODProgressPage.wo/ERMODProgressPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODProgressPage.wo/ERMODProgressPage.wod
@@ -6,7 +6,7 @@ ShouldShowProgressBar: WOConditional {
 	condition = shouldShowProgressBar;
 }
 
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 }
 

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODRequiredWrapper.wo/ERMODRequiredWrapper.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODRequiredWrapper.wo/ERMODRequiredWrapper.wod
@@ -1,4 +1,4 @@
-Help: ERDDebuggingHelp {
+Help: ERMDDebuggingHelp {
 	d2wContext = d2wContext;
 	condition = showHelp;
 }


### PR DESCRIPTION
Adds ERMDebuggingHelp, a modernised variant of the ERDDebuggingHelp component that uses ajax to make querying keys on the D2WContext easier. Also gets rid of some cruft and defaults to hiding the details.

When no D2W key is entered, it uses the ERD2WContextInspector component to show keys on the context in a (hopefully) sensible way. ERD2WContextInspector shows the bound context's local values, using a shorter representation instead of toString() for WOSession, EOAttribute, EOEntity and EORelationship objects and skips the contextDictionary key.