### PR TITLE
New ERMD2WUserPresentableDescriptionHeader

### DIFF
--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WUserPresentableDescriptionHeader.wo/ERMD2WUserPresentableDescriptionHeader.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WUserPresentableDescriptionHeader.wo/ERMD2WUserPresentableDescriptionHeader.html
@@ -1,0 +1,1 @@
+<webobject name = "ShowHeading"><h1 class="PageHeader"><webobject name = "HeadingString" /></h1></webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WUserPresentableDescriptionHeader.wo/ERMD2WUserPresentableDescriptionHeader.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WUserPresentableDescriptionHeader.wo/ERMD2WUserPresentableDescriptionHeader.wod
@@ -1,0 +1,8 @@
+HeadingString : WOString {
+	value = headerString;
+	escapeHTML = d2wContext.escapeHTML;
+}
+
+ShowHeading : WOConditional {
+	condition = showHeading;
+}

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WUserPresentableDescriptionHeader.wo/ERMD2WUserPresentableDescriptionHeader.woo
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WUserPresentableDescriptionHeader.wo/ERMD2WUserPresentableDescriptionHeader.woo
@@ -1,0 +1,4 @@
+{
+	"WebObjects Release" = "WebObjects 5.0";
+	encoding = "UTF-8";
+}

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/header/ERMD2WUserPresentableDescriptionHeader.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/header/ERMD2WUserPresentableDescriptionHeader.java
@@ -1,0 +1,54 @@
+package er.modern.directtoweb.components.header;
+
+import com.webobjects.appserver.WOContext;
+import com.webobjects.eocontrol.EOEnterpriseObject;
+
+import er.extensions.foundation.ERXStringUtilities;
+import er.modern.directtoweb.components.header.ERMD2WHeader;
+import er.modern.directtoweb.components.header.ERMD2WSimpleHeader;
+
+/**
+ * Simple h1 header that defaults to displaying the
+ * displayNameForPageConfiguration and appends the object's
+ * userPresentableDescription if one is available.
+ * 
+ * @author fpeters
+ * 
+ */
+public class ERMD2WUserPresentableDescriptionHeader extends ERMD2WSimpleHeader {
+
+    private static final long serialVersionUID = 1L;
+
+    public interface Keys extends ERMD2WHeader.Keys {
+        public static String displayNameForPageConfiguration = "displayNameForPageConfiguration";
+    }
+
+    protected String _headerString;
+
+    public ERMD2WUserPresentableDescriptionHeader(WOContext context) {
+        super(context);
+    }
+
+    public String headerString() {
+        String headerString = super.headerString();
+        if (object() != null) {
+            String userPresentableDescription = (String) object().valueForKey(
+                    "userPresentableDescription");
+            if (!ERXStringUtilities.stringIsNullOrEmpty(userPresentableDescription)) {
+                // is displayNameForPageConfiguration null?
+                if (ERXStringUtilities.stringIsNullOrEmpty(headerString)) {
+                    headerString = userPresentableDescription;
+                } else {
+                    headerString = headerString + ": " + userPresentableDescription;
+                }
+            }
+        }
+        return headerString;
+    }
+
+    public EOEnterpriseObject object() {
+        EOEnterpriseObject _object = (EOEnterpriseObject) valueForBinding("object");
+        return _object;
+    }
+
+}


### PR DESCRIPTION
ERMD2WUserPresentableDescriptionHeader is a simple header component that concatenates the current object's userPresentableDescription if available.

![ermd2wuserpresentabledescriptionheader](https://cloud.githubusercontent.com/assets/1228832/15869056/f5996aa2-2cea-11e6-8a6a-56a3c2d10c58.png)
