### PR TITLE
The tests where using a constant now reference in the system time zone.

### DIFF
--- a/Tests/ERXTest/Sources/er/chronic/ParserTest.java
+++ b/Tests/ERXTest/Sources/er/chronic/ParserTest.java
@@ -17,8 +17,6 @@ import er.chronic.utils.Time;
 
 public class ParserTest extends TestCase {
 
-	public static final Calendar TIME_2006_08_16_14_00_00 = Time.construct(2006, 8, 16, 14, 0, 0, 0);
-
 	static final NSArray<String> tzIDs;
 
 	static {
@@ -83,7 +81,7 @@ public class ParserTest extends TestCase {
 		protected void setUp() throws Exception {
 			super.setUp();
 			TimeZone.setDefault(TimeZone.getTimeZone(tzID));
-			_time_2006_08_16_14_00_00 = TIME_2006_08_16_14_00_00;
+			_time_2006_08_16_14_00_00 = Time.construct(2006, 8, 16, 14, 0, 0, 0);
 		}
 
 		protected void assertEquals(Calendar ec, Span span) {
@@ -99,7 +97,7 @@ public class ParserTest extends TestCase {
 		}
 
 		public Span parse_now(String string, Options options) {
-			options.setNow(TIME_2006_08_16_14_00_00);
+			options.setNow(_time_2006_08_16_14_00_00);
 			options.setCompatibilityMode(true);
 			//options.setDebug(true);
 			return Chronic.parse(string, options);


### PR DESCRIPTION
and doing comparison with expected results in tested timezone. This ensure the now used is in the tested time zone.