### PR TITLE
Adds proxy binding for AjaxProxy component

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.wo/AjaxFlexibleFileUpload.wod
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.wo/AjaxFlexibleFileUpload.wod
@@ -1,6 +1,7 @@
 AjaxProxy : AjaxProxy {
   name = ajaxProxyName;
   proxyName = "wopage";
+  proxy = proxy;
 }
 
 SelectFileButtonWrapper : WOGenericContainer {

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
@@ -100,7 +100,46 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
 		public static final String clearUploadProgressOnSuccess = "clearUploadProgressOnSuccess";
 		public static final String onClickBefore = "onClickBefore";
 	}
-	
+
+	/**
+	 * Wrapper class to expose only the methods we need to {@link AjaxProxy}.
+	 * 
+	 * @author paulh
+	 * @see <a href="https://github.com/wocommunity/wonder/issues/768">#768</a>
+	 */
+	public final class Proxy {
+		/**
+		 * Wrapper for {@link AjaxFlexibleFileUpload#uploadState()}.
+		 * 
+		 * @return see {@link AjaxFlexibleFileUpload#uploadState()}
+		 */
+		public NSDictionary<String, ?> uploadState() {
+			return AjaxFlexibleFileUpload.this.uploadState();
+		}
+
+		/**
+		 * Wrapper for {@link AjaxFlexibleFileUpload#cancelUpload()}.
+		 */
+		public void cancelUpload() {
+			AjaxFlexibleFileUpload.this.cancelUpload();
+			return;
+		}
+
+		/**
+		 * Wrapper for {@link AjaxFlexibleFileUpload#uploadState()}.
+		 * 
+		 * @return see {@link AjaxFlexibleFileUpload#uploadState()}
+		 */
+		public WOActionResults clearFileResults() {
+			return AjaxFlexibleFileUpload.this.clearFileResults();
+		}
+	}
+
+	/**
+	 * Proxy used for method access by {@link AjaxProxy}
+	 */
+	public final Proxy proxy = new Proxy();
+
 	private String _refreshTime;
 	private String _clearLabel;
 	private String _cancelLabel;


### PR DESCRIPTION
Adds a single-purpose `Proxy` object as an inner class of `AjaxFlexibleFileUpload` which simply wraps the methods that we need to call from the client. Fixes the security issue described in #768.