### PR TITLE
Small fixes

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSSet.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSSet.java
@@ -116,6 +116,9 @@ public class NSSet<E> implements Cloneable, Serializable, NSCoding, _NSFoundatio
 	}
 
 	private NSSet(E[] objects, boolean checkForNull) {
+		if (objects == null) {
+			throw new IllegalArgumentException("Objects cannot be null.");
+		}
 		initFromObjects(objects, checkForNull);
 	}
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXStyledContainer.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXStyledContainer.java
@@ -31,13 +31,11 @@ import com.webobjects.foundation.NSMutableDictionary;
 public class ERXStyledContainer extends WOGenericContainer {
 
 	NSMutableDictionary _styles;
-	WOAssociation _style;
 	WOAssociation _mimeType;
 	WOAssociation _unit;
 	
 	public ERXStyledContainer(String name, NSDictionary associations, WOElement template) {
 		super(name, associations, template);
-		_style = _associations.removeObjectForKey("style");
 		_styles = new NSMutableDictionary();
 		for (Enumeration enumerator = _associations.keyEnumerator(); enumerator.hasMoreElements();) {
 			String key = (String) enumerator.nextElement();

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXSubmitButton.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/_private/ERXSubmitButton.java
@@ -38,8 +38,6 @@ public class ERXSubmitButton extends WOInput {
 	public static final String STYLE_PREFIX = "ERXSubmitButton-";
 	private static boolean useIEFix = ERXProperties.booleanForKeyWithDefault("er.extensions.components._private.ERXSubmitButton.useIEFix", true);
 	
-    protected WOAssociation _class;
-    protected WOAssociation _id;
     protected WOAssociation _action;
     protected WOAssociation _actionClass;
     protected WOAssociation _directActionName;
@@ -95,8 +93,6 @@ public class ERXSubmitButton extends WOInput {
         _action = _associations.removeObjectForKey("action");
         _actionClass = _associations.removeObjectForKey("actionClass");
         _directActionName = _associations.removeObjectForKey("directActionName");
-        _class = (WOAssociation) nsdictionary.valueForKey("class");
-        _id = (WOAssociation) nsdictionary.valueForKey("id");
 
         if(_action != null && _action.isValueConstant())
             throw new WODynamicElementCreationException("<" + getClass().getName() + ">'action' is a constant.");

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -1125,7 +1125,7 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 			if (cd instanceof ERXEntityClassDescription) {
 				((ERXEntityClassDescription) cd).validateObjectWithUserInfo(this, value, "validateForKey." + key, key);
 			}
-			value = _validateValueForKey(value, key);
+			result = _validateValueForKey(value, key);
 		}
 		catch (ERXValidationException e) {
 			throw e;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/net/ERXTcpIp.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/net/ERXTcpIp.java
@@ -216,7 +216,7 @@ public class ERXTcpIp {
 	 * </div>
 	 */
 	public static boolean isInet4IPAddressWithinRange( long ipStart, long ip, long ipEnd ){
-		if(!isInet4IPAddressRange(ipStart) || !isInet4IPAddressRange(ip) || !isInet4IPAddressRange(ip)) return false;
+		if(!isInet4IPAddressRange(ipStart) || !isInet4IPAddressRange(ip) || !isInet4IPAddressRange(ipEnd)) return false;
 		return ((ipStart <= ip) && (ip <= ipEnd));
 	}
 


### PR DESCRIPTION
This patch contains some smaller fixes:

- passing _null_ to constructors `NSSet(NSArray)` and `NSSet(NSSet)` should throw an `IllegalArgumentException` instead of running into an NPE
- remove some association vars that are already defined in parent class
- do not throw away coerced value from `_validateValueForKey` (used by partials)
- `isInet4IPAddressWithinRange` did not check correct param