### PR TITLE
Fix critical NPE in UUID primary key generation code

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -776,7 +776,8 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 	private NSDictionary<String, Object> createUuidPrimaryKey(NSArray<EOAttribute> primaryKeyAttributes) {
 		if (primaryKeyAttributes.count() == 1) {
 			EOAttribute primaryKeyAttribute = primaryKeyAttributes.objectAtIndex(0);			
-			if (primaryKeyAttribute.prototypeName().equals(uuidPrototypeName)) {
+			String prototypeName = primaryKeyAttribute.prototypeName();
+			if (prototypeName != null && prototypeName.equals(uuidPrototypeName)) {
 				return new NSDictionary<String, Object>(UUIDUtilities.generateAsNSData(), primaryKeyAttribute.name());
 			}
 		}


### PR DESCRIPTION
Fix NPE in UUID primary key generation code when primary key isn't based on any prototype.
Currently, in that case no new objects can be inserted, so this is kind of urgent.