### PR TITLE
Fix to allow for providing double value constants in both inline and WOD bindings when OGNL enabled

### DIFF
--- a/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionDeclarationParser.java
+++ b/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionDeclarationParser.java
@@ -286,8 +286,14 @@ public class WOHelperFunctionDeclarationParser {
 				association = WOHelperFunctionAssociation.associationWithValue(quotedString);
 			}
 			else if (_NSStringUtilities.isNumber(associationValue)) {
-				Integer integer = WOShared.unsignedIntNumber(Integer.parseInt(associationValue));
-				association = WOHelperFunctionAssociation.associationWithValue(integer);
+				Number number = null;
+				if (associationValue != null && associationValue.contains(".")) {
+					number = Double.valueOf(associationValue);
+				}
+				else {
+					number = WOShared.unsignedIntNumber(Integer.parseInt(associationValue));
+				}
+				association = WOHelperFunctionAssociation.associationWithValue(number);
 			}
 			else if ("true".equalsIgnoreCase(associationValue) || "yes".equalsIgnoreCase(associationValue)) {
 				association = WOConstantValueAssociation.TRUE;


### PR DESCRIPTION
Fix to allow for providing double value constants in both inline and WOD bindings (e.g. value="$1.5" or value = 1.5) when OGNL is enabled. Currently, in order to pass in a double value you have to pass in a string and then convert it to a double in your code. If you try to pass in a double, an exception is thrown. This fix mimics the functionality in a stock WO app without Wonder and OGNL.