### PR TITLE
ProcessChangesQueue.stop() shouldn't throw IllegalStateException

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinatorSynchronizer.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinatorSynchronizer.java
@@ -634,7 +634,7 @@ public class ERXObjectStoreCoordinatorSynchronizer {
 				_queueThread.interrupt();
 			}
 			else {
-				throw new IllegalStateException("Attempted to stop the " + getClass().getSimpleName() + " when it wasn't already running");
+				log.warn("Attempted to stop the " + getClass().getSimpleName() + " when it wasn't already running");
 			}
 		}
 	}


### PR DESCRIPTION
`ProcessChangesQueue.stop()` is called when `ApplicationWillTerminateNotification` is posted. If `_queueThread` is `null` or not alive, throwing an `IllegalStateException` here just prevents the application from terminating.