### PR TITLE
Correct validation if values are coerced

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEntityClassDescription.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEntityClassDescription.java
@@ -156,6 +156,10 @@ import er.extensions.validation.ERXValidationFactory;
  *          }
  *          );
  * }</code></pre>
+ * If you have validation methods in your EO classes (e.g. <code>validateName(String name)</code> for attribute <i>name</i>)
+ * be aware that those are executed first and that they possibly coerce the value to validate (e.g. making a string uppercase).
+ * The validations done by this class will be executed on those potentially coerced values.
+ * <p>
  * This code is mainly a quick-and-dirty rewrite from PRValidation by Proteon.
  * <p>
  * Additionally, this class adds a concept of "Default" values that get pushed into the object at creation time.
@@ -185,7 +189,6 @@ import er.extensions.validation.ERXValidationFactory;
  * If you wish to provide your own class description subclass
  * see the documentation associated with the Factory inner class.
  */
-
 public class ERXEntityClassDescription extends EOEntityClassDescription {
 	/**
 	 * Do I need to update serialVersionUID?
@@ -919,6 +922,16 @@ public class ERXEntityClassDescription extends EOEntityClassDescription {
         return true;
     }
 
+    /**
+     * Validates a specific property of an EO by applying the rules found in the userInfo
+     * of the entity i.e. model driven validations. See class description for more info
+     * on it.
+     * 
+     * @param object the EO validation is done for
+     * @param value the value to validate
+     * @param validationTypeString the key for the validation info from userInfo
+     * @param property the property key to validate
+     */
     public void validateObjectWithUserInfo(EOEnterpriseObject object, Object value, String validationTypeString, String property) {
         if(_validationInfo != null) {
             NSArray qualifiers = (NSArray)_validationInfo.valueForKeyPath(validationTypeString);

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -1124,7 +1124,7 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 			result = super.validateValueForKey(value, key);
 			EOClassDescription cd = classDescription();
 			if (cd instanceof ERXEntityClassDescription) {
-				((ERXEntityClassDescription) cd).validateObjectWithUserInfo(this, value, "validateForKey." + key, key);
+				((ERXEntityClassDescription) cd).validateObjectWithUserInfo(this, result, "validateForKey." + key, key);
 			}
 			result = _validateValueForKey(result, key);
 		}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -1102,8 +1102,15 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 	 * validateValueForKey on the object's class description. The class
 	 * description for this object should be an
 	 * {@link ERXEntityClassDescription} or subclass. It is that class that
-	 * provides the hooks to convert model throw validation exceptions into
+	 * provides the hooks to convert model thrown validation exceptions into
 	 * {@link ERXValidationException} objects.
+	 * <p>
+	 * The order of validation processed is, if applicable:
+	 * <ol>
+	 * <li>EO class validation methods (e.g. <code>User.validateName()</code>)</li>
+	 * <li>model driven validation (see {@link ERXEntityClassDescription})</li>
+	 * <li>Partial's class validation methods</li>
+	 * </ol>
 	 * 
 	 * @param value
 	 *            to be validated for a given attribute or relationship

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialGenericRecord.java
@@ -201,7 +201,7 @@ public class ERXPartialGenericRecord extends ERXGenericRecord {
 	protected Object _validateValueForKey(Object value, String key) throws ValidationException {
 		Object result = value;
 		for (ERXPartial partial : _partials()) {
-			result = partial.validateValueForKey(value, key);
+			result = partial.validateValueForKey(result, key);
 		}
 		return result;
 	}
@@ -211,7 +211,7 @@ public class ERXPartialGenericRecord extends ERXGenericRecord {
 		Object result = super.validateTakeValueForKeyPath(value, keyPath);
 		for (ERXPartial partial : _partials()) {
 			if (partial.isPartialKeypath(keyPath)) {
-				result = partial.validateTakeValueForKeyPath(value, keyPath);
+				result = partial.validateTakeValueForKeyPath(result, keyPath);
 			}
 		}
 		return result;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialGenericRecord.java
@@ -13,15 +13,11 @@ import er.extensions.eof.ERXEntityClassDescription;
 import er.extensions.eof.ERXGenericRecord;
 
 /**
- * <p>
  * For overview information on partials, read the {@code package.html} in
  * {@code er.extensions.partials}.
- * </p>
- * 
  * <p>
  * {@code ERXPartialGenericRecord} is the base class of any entity that allows
  * itself to be extended with partials.
- * </p>
  * 
  * @author mschrag
  */


### PR DESCRIPTION
If you are coercing values in your validation methods these value changes could get lost or based on wrong values in some edge cases.
There are three main locations for key related validation:

1. EO class
2. Entity userInfo
3. Partial class

Point 3 could theoretically contain multiple partials even though this should be quite unusual. During 1. and 3. the validated value can be coerced though some of the methods did get the original value instead of the coerced one. This is inconsistent and can lead to data loss which this patch fixes.