### PR TITLE
prevent wrong SQL generation in ERXExistsQualifier

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
@@ -316,16 +316,6 @@ public class ERXExistsQualifier extends EOQualifier implements Cloneable, NSCodi
             	// (AR) Write the IN clause
                 sb.append(srcEntityForeignKey);
                 sb.append(" IN ( ");
-                
-                // (AR) Rewrite first SELECT part of subExprStr
-                EOAttribute destPK = destEntity.primaryKeyAttributes().lastObject();
-                String destEntityPrimaryKey = expression.sqlStringForAttribute(destPK);
-                int indexOfFirstPeriod = destEntityPrimaryKey.indexOf(".");
-                destEntityPrimaryKey = destEntityPrimaryKey.substring(indexOfFirstPeriod);
-                subExprStr = StringUtils.replaceOnce(
-                		subExprStr,
-                		"SELECT " + EXISTS_ALIAS + "0" + destEntityPrimaryKey + " FROM", 
-                		"SELECT " + EXISTS_ALIAS + "0" + destEntityForeignKey + " FROM");
             } else {
                 sb.append(" EXISTS ( ");
             }


### PR DESCRIPTION
As the destination attributes are already selected properly before, this string relacement is not needed anymore and even leads to invalid SQL in some cases.

Example: We have three tables: book, chapter and page. The two relationships between them are 1:n. We want to find all books which have a page with number 26.

One way to write the qualifier is:
`new ERXExistsQualifier(Page.NUMBER.is(26), Book.CHAPTERS.dot(Chapter.PAGES).key(), true)`

But this leads to the following invalid SQL:

> SELECT ... FROM book t0 WHERE t0.book_id IN
>    	( SELECT exists0.book_id FROM chapter exists0 WHERE exists0.chapter_id IN
>    		( SELECT **exists0.book_id** FROM page exists0 WHERE exists0.number = ?::int4 )  )

Proper SQL should be:

> SELECT ... FROM book t0 WHERE t0.book_id IN
>    	( SELECT exists0.book_id FROM chapter exists0 WHERE exists0.chapter_id IN
>    		( SELECT **exists0.chapter_id** FROM page exists0 WHERE exists0.number = ?::int4 )  )

I have tested this change with a few combinations of constructors and relationships. However there will be edge cases, which I have missed. So additional tests by someone else would be good.