### PR TITLE
make SameSite setting for cookies configurable

### DIFF
--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -514,6 +514,12 @@ er.extensions.concurrency.ERXTaskObjectStoreCoordinatorPool.maxCoordinators = 1
 #
 # er.extensions.ERXSession.useSecureSessionCookies=false
 
+# If you want to set the SameSite policy for session and instance cookies
+# you can set this property to one of the following values:
+# LAX, NORMAL, STRICT
+#
+# er.extensions.ERXSession.cookies.SameSite=STRICT
+
 #########################################################################
 # ERXJDBCConnectionBroker 
 #########################################################################

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXSession.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXSession.java
@@ -21,6 +21,7 @@ import com.webobjects.appserver.WOCookie;
 import com.webobjects.appserver.WORequest;
 import com.webobjects.appserver.WOResponse;
 import com.webobjects.appserver.WOSession;
+import com.webobjects.appserver.WOCookie.SameSite;
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSKeyValueCodingAdditions;
@@ -71,6 +72,9 @@ public class ERXSession extends ERXAjaxSession implements Serializable {
   /** cookie name that if set it means that the user has cookies enabled */
   // FIXME: This should be configurable
   public static final String JAVASCRIPT_ENABLED_COOKIE_NAME = "js";
+
+  /** the SameSite to set for session and instance cookies */
+  private static SameSite _sameSite = ERXProperties.enumValueForKey(SameSite.class, "er.extensions.ERXSession.cookies.SameSite");
 
   /** holds a reference to the current localizer used for this session */
   transient private ERXLocalizer _localizer;
@@ -741,17 +745,30 @@ public class ERXSession extends ERXAjaxSession implements Serializable {
       return ERXProperties.booleanForKeyWithDefault("er.extensions.ERXSession.useHttpOnlySessionCookies", false);
   }
 
-  protected void _convertSessionCookiesToSecure(WOResponse response) {
-	    if (storesIDsInCookies() && !ERXRequest._isSecureDisabled()) {
+  protected void _setCookieSameSite(WOResponse response) {
+		if (storesIDsInCookies() && _sameSite != null) {
 			for (WOCookie cookie : response.cookies()) {
 				String sessionIdKey = application().sessionIdKey();
 				String instanceIdKey = application().instanceIdKey();
 				String cookieName = cookie.name();
 				if (sessionIdKey.equals(cookieName) || instanceIdKey.equals(cookieName)) {
-					 cookie.setIsSecure(true);
+					 cookie.setSameSite(_sameSite);
 				}
 			}
 		}
+  }
+
+  protected void _convertSessionCookiesToSecure(WOResponse response) {
+	  if (storesIDsInCookies() && !ERXRequest._isSecureDisabled()) {
+		  for (WOCookie cookie : response.cookies()) {
+			  String sessionIdKey = application().sessionIdKey();
+			  String instanceIdKey = application().instanceIdKey();
+			  String cookieName = cookie.name();
+			  if (sessionIdKey.equals(cookieName) || instanceIdKey.equals(cookieName)) {
+				  cookie.setIsSecure(true);
+			  }
+		  }
+	  }
   }
   
   protected void _convertSessionCookiesToHttpOnly(final WOResponse response) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXSession.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXSession.java
@@ -792,7 +792,8 @@ public class ERXSession extends ERXAjaxSession implements Serializable {
 		}
         if (useHttpOnlySessionCookies()) {
             _convertSessionCookiesToHttpOnly(response);
-        }		
+        }
+        _setCookieSameSite(response);
 	}
   
   @Override

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXProperties.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXProperties.java
@@ -1110,7 +1110,46 @@ public class ERXProperties extends Properties implements NSKeyValueCoding {
     	}
     	return array;
     }
-    
+
+    /**
+     * Returns an enum value for a given enum class and system property. If the property is not
+     * set or matches no enum constant, <code>null</code> will be returned. The search for the
+     * enum value is case insensitive, i.e. a property value "foo" will match the enum constant
+     * <code>FOO</code>.
+     * 
+     * @param enumClass the enum class
+     * @param key the property key
+     * @return the enum value
+     */
+    public static <T extends Enum> T enumValueForKey(Class<T> enumClass, String key) {
+    	return enumValueForKeyWithDefault(enumClass, key, null);
+    }
+
+    /**
+     * Returns an enum value for a given enum class and system property. If the property is not
+     * set or matches no enum constant, the specified default value will be returned. The
+     * search for the enum value is case insensitive, i.e. a property value "foo" will match
+     * the enum constant <code>FOO</code>.
+     * 
+     * @param enumClass the enum class
+     * @param key the property key
+     * @param defaultValue the default value
+     * @return the enum value
+     */
+    public static <T extends Enum> T enumValueForKeyWithDefault(Class<T> enumClass, String key, T defaultValue) {
+    	T result = defaultValue;
+    	String stringValue = stringForKey(key);
+    	if (stringValue != null) {
+    		for (T enumValue : enumClass.getEnumConstants()) {
+    			if (enumValue.name().equalsIgnoreCase(stringValue)) {
+    				result = enumValue;
+    				break;
+    			}
+    		}
+    	}
+    	return result;
+    }
+
     /**
      * <div class="en">
      * Sets an array in the System properties for


### PR DESCRIPTION
By property *er.extensions.ERXSession.cookies.SameSite* you can define if and which SameSite setting should be used for your session and instance cookies.