### PR TITLE
Make ERXPartialInitializer handle locking and class property settings correctly

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialInitializer.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/partials/ERXPartialInitializer.java
@@ -9,6 +9,7 @@ import com.webobjects.eoaccess.EOAttribute;
 import com.webobjects.eoaccess.EOEntity;
 import com.webobjects.eoaccess.EOModel;
 import com.webobjects.eoaccess.EOModelGroup;
+import com.webobjects.eoaccess.EOProperty;
 import com.webobjects.eoaccess.EORelationship;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSDictionary;
@@ -38,6 +39,7 @@ import er.extensions.foundation.ERXProperties;
  * 
  * @property er.extensions.partials.enabled
  * @author mschrag
+ * @author jtabert
  */
 public class ERXPartialInitializer {
 	private static final Logger log = LoggerFactory.getLogger(ERXModelGroup.class);
@@ -83,6 +85,7 @@ public class ERXPartialInitializer {
 		Enumeration modelsEnum = modelGroup.models().objectEnumerator();
 		while (modelsEnum.hasMoreElements()) {
 			EOModel model = (EOModel) modelsEnum.nextElement();
+			// TODO: merge userInfo from model
 			Enumeration entitiesEnum = model.entities().objectEnumerator();
 			while (entitiesEnum.hasMoreElements()) {
 				EOEntity partialExtensionEntity = (EOEntity) entitiesEnum.nextElement();
@@ -103,18 +106,33 @@ public class ERXPartialInitializer {
 								NSMutableDictionary<String, Object> attributePropertyList = new NSMutableDictionary<String, Object>();
 								partialAttribute.encodeIntoPropertyList(attributePropertyList);
 								String factoryMethodArgumentType = (String) attributePropertyList.objectForKey("factoryMethodArgumentType");
-								// OFFICIALLY THE DUMBEST DAMN THING I'VE EVER
-								// SEEN
+								// OFFICIALLY THE DUMBEST DAMN THING I'VE EVER SEEN
 								if ("EOFactoryMethodArgumentIsString".equals(factoryMethodArgumentType)) {
 									attributePropertyList.setObjectForKey("EOFactoryMethodArgumentIsNSString", "factoryMethodArgumentType");
 								}
 								EOAttribute primaryAttribute = new EOAttribute(attributePropertyList, partialEntity);
 								primaryAttribute.awakeWithPropertyList(attributePropertyList);
 								partialEntity.addAttribute(primaryAttribute);
+								// check if the attribute is a class property
+								if (!partialExtensionEntity.classPropertyNames().contains(partialAttribute.name())) {
+									EOProperty p = partialEntity.propertyNamed(partialAttribute.name());
+									if (p != null) {
+										partialEntity.classProperties().remove(p);
+										log.debug("Removing partial attribute {}.{} from {}.classProperties because it is not defined as class property.", partialExtensionEntity.name(), partialAttribute.name(), partialEntity.name());
+									}
+								}
+								// check if the attribute is used for locking
+								if (!partialExtensionEntity.attributesUsedForLocking().contains(partialAttribute)) {
+									EOAttribute a = partialEntity.attributeNamed(partialAttribute.name());
+									if (a != null) {
+										partialEntity.attributesUsedForLocking().remove(a);
+										log.debug("Removing partial attribute {}.{} from {} attributesUsedForLocking because it is not defined as locking attribute.", partialExtensionEntity.name(), partialAttribute.name(), partialEntity.name());
+									}
+								}
 							}
 							else {
-								log.debug("Skipping partial attribute {}.{} because {} already has an attribute of the same name.",
-										partialExtensionEntity.name(), partialAttribute.name(), partialEntity.name());
+								// TODO: merge userInfo from attribute
+								log.debug("Skipping partial attribute {}.{} because {} already has an attribute of the same name.", partialExtensionEntity.name(), partialAttribute.name(), partialEntity.name());
 							}
 						}
 
@@ -128,10 +146,18 @@ public class ERXPartialInitializer {
 								EORelationship primaryRelationship = new EORelationship(relationshipPropertyList, partialEntity);
 								primaryRelationship.awakeWithPropertyList(relationshipPropertyList);
 								partialEntity.addRelationship(primaryRelationship);
+								// check if the relationship is a class property
+								if (!partialExtensionEntity.classPropertyNames().contains(partialRelationship.name())) {
+									EOProperty p = partialEntity.propertyNamed(partialRelationship.name());
+									if (p != null) {
+										partialEntity.classProperties().remove(p);
+										log.debug("Removing partial relationship {}.{} from {} classProperties because it is not defined as class property.", partialExtensionEntity.name(), partialRelationship.name(), partialEntity.name());
+									}
+								}
 							}
 							else {
-								log.debug("Skipping partial relationship {}.{} because {} already has a relationship of the same name.",
-										partialExtensionEntity.name(), partialRelationship.name(), partialEntity.name());
+								// TODO: merge userInfo from relationship
+								log.debug("Skipping partial relationship {}.{} because {} already has a relationship of the same name.", partialExtensionEntity.name(), partialRelationship.name(), partialEntity.name());
 							}
 						}
 


### PR DESCRIPTION
For partial entities, fix handling of the "locking" setting on attributes and the "class property" setting on attributes and relationships.

Add reminders for missing functionality to deal with user info data.
