### PR TITLE
Small patches for er.extensions.appserver.navigation

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationItem.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationItem.java
@@ -225,7 +225,7 @@ public class ERXNavigationItem implements Serializable {
 					}
 				}
 				else {
-					log.warn("For nav core object: {} and child binding: {} recieved binding object: {}", this, childrenBinding(), o);
+					log.warn("For nav core object: {} and child binding: {} received binding object: {}", this, childrenBinding(), o);
 				}
 			}
 		}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationMenuItem.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/navigation/ERXNavigationMenuItem.java
@@ -18,6 +18,7 @@ import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSMutableDictionary;
 
 import er.extensions.appserver.ERXDirectAction;
+import er.extensions.appserver.ERXRequest;
 import er.extensions.components.ERXStatelessComponent;
 import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXStringUtilities;
@@ -116,7 +117,7 @@ public class ERXNavigationMenuItem extends ERXStatelessComponent {
         	if(_linkDirectlyToDirectActions) {
         		NSMutableDictionary bindings = navigationItem().queryBindings().mutableClone();
         		bindings.setObjectForKey(context().contextID(), "__cid");
-        		url = context().directActionURLForActionNamed(navigationItem().directActionName(), bindings);
+        		url = context().directActionURLForActionNamed(navigationItem().directActionName(), bindings, ERXRequest.isRequestSecure(context().request()), false);
         	} else {
         		url = context().componentActionURL();
         	}


### PR DESCRIPTION
Mark Wardle supplied a couple of patches via the mailing list:

- Fixes a typo in `ERXNavigationItem.java`.
- Ensures that a generated URL in `ERXNavigationMenuItem.java` is secure if the current request is secure.

I don't use `ERXNavigationMenuItem.java`, so I can't really vouch for the latter patch, though it looks legit at a glance. Ideally someone that uses this package could check it out, though I imagine Mark's got the class in use and that this change works just fine.