### PR TITLE
Fix ERXExistsQualifier regex pattern to match oracle expressions

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/qualifiers/ERXExistsQualifier.java
@@ -68,7 +68,7 @@ public class ERXExistsQualifier extends EOQualifier implements Cloneable, NSCodi
 	 */
 	static final Logger log = LoggerFactory.getLogger(ERXExistsQualifier.class);
 
-	private static final Pattern PATTERN = Pattern.compile("([ '\"\\(]|^)(t)([0-9])([ \\.'\"\\(]|$)");
+	private static final Pattern PATTERN = Pattern.compile("([ '\"\\(]|^)(t)([0-9])([ ,\\.'\"\\(]|$)");
 
 	public static final String EXISTS_ALIAS = "exists";
 	public static final boolean UseSQLInClause = true;


### PR DESCRIPTION
For oracle there tends to be a comma after one of the "tX" occurrences, causing the regex to not match.
