### PR TITLE
Added accept attribute to AjaxFlexibleFileUpload

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.api
+++ b/Frameworks/Ajax/Ajax/Components/AjaxFlexibleFileUpload.api
@@ -35,5 +35,6 @@
     <binding name="mimeType"/>
     <binding name="clearedFunction"/>
         <binding name="clearedAction"/>
+    <binding name="accept"/>
     </wo>
 </wodefinitions>

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlexibleFileUpload.java
@@ -24,6 +24,7 @@ import er.extensions.localization.ERXLocalizer;
  * this component to be used in or out of a form. The component is fully styleable (including the upload button) and
  * supports upload progress and canceling.
  * 
+ * @binding accept the attribute specifies the types of files that the server accepts (that can be submitted through a file upload) 
  * @binding cancelLabel the label for for the cancel button (defaults to "Cancel")
  * @binding startingText the text to display when the progress is starting (defaults "Upload Starting...");
  * @binding selectFileLabel the label for the select file button (defaults to "Select File...")
@@ -219,6 +220,9 @@ public class AjaxFlexibleFileUpload extends AjaxFileUpload {
     	NSMutableArray<String> _options = new NSMutableArray<>("action:'" + uploadUrl() + "'");
     	
     	// add options
+    	if (canGetValueForBinding("accept")) {
+    		_options.addObject("accept:'"+ valueForBinding("accept") +"'");
+    	}
     	_options.addObject("data:{" + ajaxUploadData() + "}");
     	_options.addObject("name:'" + uploadName() + "'");
     	_options.add("iframeId:'"+ iframeId() +"'");

--- a/Frameworks/Ajax/Ajax/WebServerResources/ajaxupload.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/ajaxupload.js
@@ -220,6 +220,8 @@
         this._settings = {
             // Location of the server-side upload script
             action: 'upload.php',
+            // accept attribute e.g. '.docx,.pdf'
+            accept: '',
             // File upload name
             name: 'userfile',
             // Select & upload multiple files at once FF3.6+, Chrome 4+
@@ -343,6 +345,7 @@
             var input = document.createElement("input");
             input.setAttribute('type', 'file');
             input.setAttribute('name', this._settings.name);
+            input.setAttribute('accept', this._settings.accept);
             if(this._settings.multiple) input.setAttribute('multiple', 'multiple');
             
             addStyles(input, {


### PR DESCRIPTION
The accept attribute specifies the types of files that the server accepts (that can be submitted through a file upload).
