### PR TITLE
Add support for X-HTTP-Method-Override header on REST requests

### DIFF
--- a/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteRequestHandler.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/routes/ERXRouteRequestHandler.java
@@ -125,6 +125,11 @@ import er.rest.routes.jsr311.Paths;
  */
 public class ERXRouteRequestHandler extends WODirectActionRequestHandler {
 	/**
+	 * Header used to override the method of a request. Useful when client code can use only GET and POST methods.
+	 */
+	private static final String X_HTTP_METHOD_OVERRIDE_HEADER_KEY = "x-http-method-override";
+
+	/**
 	 * A NameFormat that behaves like Rails -- plural entities, plural routes, lowercase underscore names
 	 * (names_like_this).
 	 */
@@ -823,8 +828,9 @@ public class ERXRouteRequestHandler extends WODirectActionRequestHandler {
 
 		try {
 			String path = request._uriDecomposed().requestHandlerPath();
+			String method = request.headerForKey(X_HTTP_METHOD_OVERRIDE_HEADER_KEY, request.method());
 
-			ERXRoute matchingRoute = setupRequestWithRouteForMethodAndPath(request, request.method(), path);
+			ERXRoute matchingRoute = setupRequestWithRouteForMethodAndPath(request, method, path);
 			if (matchingRoute != null) {
 				@SuppressWarnings("unchecked")
 				NSDictionary<ERXRoute.Key, String> keys = (NSDictionary<ERXRoute.Key, String>) request.userInfo().objectForKey(ERXRouteRequestHandler.KeysKey);


### PR DESCRIPTION
Sometimes a client cannot consume REST services using methods like PUT, DELETE or PATCH, due to browser limitation or firewall rules. Some frameworks provide a workaround using the X-HTTP-Method-Override header to override the method of a request. No change to the route configuration is necessary. The client of the API just informs the override header, and the ERRest library maps routes as expected. Keeping a RESTful API on the server side is the main benefit of that approach. No need for alternate / unRESTfull routes creation.

Scott Hanselman talked in more detail about that in [a blog post](http://www.hanselman.com/blog/HTTPPUTOrDELETENotAllowedUseXHTTPMethodOverrideForYourRESTServiceWithASPNETWebAPI.aspx).