### PR TITLE
additional template schema for validation exceptions

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/validation/ERXValidationFactory.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/validation/ERXValidationFactory.java
@@ -532,6 +532,9 @@ public class ERXValidationFactory {
         // 2nd try everything minus the type.
         if (template == null)
             template = templateForKeyPath(entityName + "." + property, targetLanguage);
+        // 2.5th try entity plus type
+        if (template == null)
+            template = templateForKeyPath(entityName + "." + type, targetLanguage);
         // 3rd try property plus type
         if (template == null)
             template = templateForKeyPath(property + "." + type, targetLanguage);


### PR DESCRIPTION
To localize an ERXValidationException there are currently five different localization keys which are checked in a specific order:

1. Entity.Property.Type
2. Entity.Property
3. Property.Type
4. Property
5. Type

The problem is if you have an entity with several properties which should give you the same localization for a specific exception type you need either:

* many similar localization entries (using schema 1.)
* change global localization for exception type (schema 5.)

The latter one avoids many duplicate keys but often you would like to restrict that localization to a specific entity and not changing it for all entities.

This patch adds a new template key _Entity.Type_ to realize that which gives a modified order:

1. Entity.Property.Type
2. Entity.Property
3. Entity.Type
4. Property.Type
5. Property
6. Type