### PR TITLE
Suppress javax.naming.NameNotFoundException in servlet context 

### DIFF
--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -254,6 +254,14 @@ er.extensions.ERXComponentActionRedirector.enabled=false
 ## This is only used when the JDBCAdaptor is used in the first place
 # er.extensions.ERXJDBCAdaptor.switchReadWrite=false
 #
+
+## In servlet context, when not using JNDI to obtain the database channel, you will 
+## get annoying error messages like
+## javax.naming.NameNotFoundException: Name "comp/env/jdbc" not found in context
+## Disable the JNDI configuration to suppress these messages.
+# extensions.ERXJDBCAdaptor.ignoreJNDIConfiguration=false
+#
+
 #########################################################################
 # ERXAdaptorChannelDelegate 
 #########################################################################

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCAdaptor.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCAdaptor.java
@@ -102,6 +102,7 @@ public class ERXJDBCAdaptor extends JDBCAdaptor {
 	public static class Channel extends JDBCChannel {
 
 		public static final String COLUMN_CLASS_NAME_KEY = "er.extensions.ERXJDBCAdaptor.columnClassName";
+
 		
 		private static Class columnClass;
 
@@ -337,10 +338,28 @@ public class ERXJDBCAdaptor extends JDBCAdaptor {
 	 */
 	public static class Context extends JDBCContext {
 
+		public static final String IGNORE_JNDI_CONFIGURATION_KEY = "er.extensions.ERXJDBCAdaptor.ignoreJNDIConfiguration";
+
 		public Context(EOAdaptor eoadaptor) {
 			super(eoadaptor);
 		}
 
+		/**
+		 * In servlet context, when not using JNDI to obtain the database channel, you will get annoying error messages like
+		 * <em>javax.naming.NameNotFoundException: Name "comp/env/jdbc" not found in context</em>.
+		 * 
+		 * Set the property <code>er.extensions.ERXJDBCAdaptor.ignoreJNDIConfiguration</code> to true  in order to suppress 
+		 * this messages.
+		 * 
+		 * @throws JDBCAdaptorException
+		 */
+		@Override
+		public void setupJndiConfiguration() throws JDBCAdaptorException {
+			if(!ERXProperties.booleanForKeyWithDefault(IGNORE_JNDI_CONFIGURATION_KEY, false)) {
+				super.setupJndiConfiguration();
+			}
+		}
+		
 		private void freeConnection() {
 			if (useConnectionBroker()) {
 				if (_jdbcConnection != null) {

--- a/Frameworks/EOAdaptors/JavaERJDBCAdaptor/Sources/er/jdbcadaptor/ERJDBCContext.java
+++ b/Frameworks/EOAdaptors/JavaERJDBCAdaptor/Sources/er/jdbcadaptor/ERJDBCContext.java
@@ -1,6 +1,10 @@
 package er.jdbcadaptor;
 
+import com.webobjects.jdbcadaptor.JDBCAdaptorException;
 import com.webobjects.jdbcadaptor.JDBCContext;
+
+import er.extensions.foundation.ERXProperties;
+import er.extensions.jdbc.ERXJDBCAdaptor;
 
 /**
  * @author david
@@ -11,6 +15,22 @@ public class ERJDBCContext extends JDBCContext {
         super(adaptor);
         _connectionSupportTransaction = adaptor.supportsTransactions();
     }
+
+	/**
+	 * In servlet context, when not using JNDI to obtain the database channel, you will get annoying error messages like
+	 * <em>javax.naming.NameNotFoundException: Name "comp/env/jdbc" not found in context</em>.
+	 * 
+	 * Set the property <code>er.extensions.ERXJDBCAdaptor.ignoreJNDIConfiguration</code> to true  in order to suppress 
+	 * this messages.
+	 * 
+	 * @throws JDBCAdaptorException
+	 */
+	@Override
+	public void setupJndiConfiguration() throws JDBCAdaptorException {
+		if(!ERXProperties.booleanForKeyWithDefault(ERXJDBCAdaptor.Context.IGNORE_JNDI_CONFIGURATION_KEY, false)) {
+			super.setupJndiConfiguration();
+		}
+	}
 
     public void checkoutConnection() {
         if (_jdbcConnection == null) {


### PR DESCRIPTION
This patch will suppress the annoying javax.naming.NameNotFoundException when using properties to define the database connection.

Set 

   er.extensions.ERXJDBCAdaptor.className=er.extensions.jdbc.ERXJDBCAdaptor
   er.extensions.ERXJDBCAdaptor.ignoreJNDIConfiguration=true

to activate this feature.
