### PR TITLE
Non blocking database context delegates

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
@@ -7,6 +7,7 @@
 package er.extensions.eof;
 
 import java.util.Enumeration;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.log4j.Logger;
 
@@ -533,18 +534,18 @@ public class ERXDatabaseContextDelegate {
     private class ReentranceProtector {
     	public ReentranceProtector() {}
     	
-    	private NSMutableArray<EODatabaseContext> _accessing = new NSMutableArray<>();
+    	private CopyOnWriteArrayList<EODatabaseContext> _accessing = new CopyOnWriteArrayList<EODatabaseContext>();
     	
-    	public synchronized boolean canEnter(EODatabaseContext dbc) {
-    		if(_accessing.containsObject(dbc)) {
+    	public boolean canEnter(EODatabaseContext dbc) {
+    		if(_accessing.contains(dbc)) {
     			return false;
     		}
-    		_accessing.addObject(dbc);
+    		_accessing.add(dbc);
     		return true;
     	}
     	
-       	public synchronized void leave(EODatabaseContext dbc) {
-    		_accessing.removeObject(dbc);
+       	public void leave(EODatabaseContext dbc) {
+    		_accessing.remove(dbc);
     	}
     }
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXMulticastingDelegate.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXMulticastingDelegate.java
@@ -1,7 +1,8 @@
 package er.extensions.foundation;
 
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import com.webobjects.foundation.NSArray;
-import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation._NSDelegate;
 
 
@@ -49,7 +50,7 @@ import com.webobjects.foundation._NSDelegate;
  */
 public abstract class ERXMulticastingDelegate {
 
-    private NSMutableArray delegates = new NSMutableArray();
+    private CopyOnWriteArrayList delegates = new CopyOnWriteArrayList();
 
 
     /**
@@ -58,14 +59,12 @@ public abstract class ERXMulticastingDelegate {
      * @param delegate Object to add as one of the delegates called
      */
     public void addDelegate(Object delegate) {
-    	synchronized (delegates) {
         	if (hasDelegate(delegate)) {
         		throw new IllegalArgumentException("Delegate is already included");
         	}
         	
             _NSDelegate delegateObject = new _NSDelegate(getClass(), delegate);
-            delegates.addObject(delegateObject);
-        }
+            delegates.add(delegateObject);
     }
     
 
@@ -75,14 +74,13 @@ public abstract class ERXMulticastingDelegate {
      * @param delegate Object to add as one of the delegates called
      */
     public void addDelegateAtStart(Object delegate) {
-    	synchronized (delegates) {
         	if (hasDelegate(delegate)) {
         		throw new IllegalArgumentException("Delegate is already included");
         	}
         	
         	_NSDelegate delegateObject = new _NSDelegate(getClass(), delegate);
-	        delegates.insertObjectAtIndex(delegateObject, 0);
-    	}
+	        delegates.add(0, delegateObject);
+    	
     }
     
     
@@ -92,20 +90,19 @@ public abstract class ERXMulticastingDelegate {
      * @param delegate Object to remove as one of the delegates called
      */
     public void removeDelegate(Object delegate) {
-    	synchronized (delegates) {
         	if ( ! hasDelegate(delegate)) {
         		throw new IllegalArgumentException("Delegate is not present");
         	}
         	
-	        for (int i = 0; i < delegates.count(); i++) {
-	        	_NSDelegate delegateObject = (_NSDelegate)delegates.objectAtIndex(i);
+	        for (int i = 0; i < delegates.size(); i++) {
+	        	_NSDelegate delegateObject = (_NSDelegate)delegates.get(i);
 	        	if (delegateObject.delegate().equals(delegate))
 	        	{
-	        		delegates.removeObjectAtIndex(i);
+	        		delegates.remove(i);
 	        		break;
 	        	}
 	        }
-        }
+      
     }
     
 
@@ -116,16 +113,15 @@ public abstract class ERXMulticastingDelegate {
      * @return <code>true</code> if delegate is represented in delegates()
      */
     public boolean hasDelegate(Object delegate) {
-    	synchronized (delegates) {
-	        for (int i = 0; i < delegates.count(); i++) {
-	        	_NSDelegate delegateObject = (_NSDelegate)delegates.objectAtIndex(i);
+	        for (int i = 0; i < delegates.size(); i++) {
+	        	_NSDelegate delegateObject = (_NSDelegate)delegates.get(i);
 	        	if (delegateObject.delegate().equals(delegate))
 	        	{
 	        		return true;
 	        	}
 	        }
 	        return false;
-    	}
+    	
     }
     
     
@@ -137,9 +133,7 @@ public abstract class ERXMulticastingDelegate {
      * @return the delegates in the order they will be called
      */
     public NSArray delegates() {
-    	synchronized (delegates) {
-    		return delegates.immutableClone();
-    	}
+    		return new NSArray(delegates);
     }
     
 
@@ -150,15 +144,15 @@ public abstract class ERXMulticastingDelegate {
      * @param orderedDelegates array of <code>com.webobjects.foundation._NSDelegate</code> in the order in which delegates should be called
      */
     public void setDelegateOrder(NSArray orderedDelegates) {
-    	synchronized (delegates) {
 	        for (int i = 0; i < orderedDelegates.count(); i++) {
 	            if ( ! (orderedDelegates.objectAtIndex(i) instanceof _NSDelegate)) {
 	                throw new IllegalArgumentException("Object of class " + orderedDelegates.objectAtIndex(i).getClass().getName() +
 	                        " must be instanceof _NSDelegate");
 	            }
 	        }
-	        delegates = orderedDelegates.mutableClone();
-    	}
+	        delegates.clear();
+	        delegates.addAll(orderedDelegates);
+   
     }
 
 
@@ -173,14 +167,12 @@ public abstract class ERXMulticastingDelegate {
      */
     protected Object perform(String methodName, Object args[], Object defaultResult) {
         Object result = null;
-    	synchronized (delegates) {
-            for (int i = 0; (result == null || result.equals(defaultResult)) && i < delegates.count(); i++) {
-                _NSDelegate delegate = (_NSDelegate) delegates.objectAtIndex(i);
+            for (int i = 0; (result == null || result.equals(defaultResult)) && i < delegates.size(); i++) {
+                _NSDelegate delegate = (_NSDelegate) delegates.get(i);
                 if (delegate.respondsTo(methodName)) {
                     result = delegate.perform(methodName, args);
                 }
             }
-    	}
 
         return result == null ? defaultResult : result;
     }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXMulticastingDelegate.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXMulticastingDelegate.java
@@ -59,12 +59,12 @@ public abstract class ERXMulticastingDelegate {
      * @param delegate Object to add as one of the delegates called
      */
     public void addDelegate(Object delegate) {
-        	if (hasDelegate(delegate)) {
-        		throw new IllegalArgumentException("Delegate is already included");
-        	}
-        	
-            _NSDelegate delegateObject = new _NSDelegate(getClass(), delegate);
-            delegates.add(delegateObject);
+    	if (hasDelegate(delegate)) {
+    		throw new IllegalArgumentException("Delegate is already included");
+    	}
+
+    	_NSDelegate delegateObject = new _NSDelegate(getClass(), delegate);
+    	delegates.add(delegateObject);
     }
     
 
@@ -74,13 +74,12 @@ public abstract class ERXMulticastingDelegate {
      * @param delegate Object to add as one of the delegates called
      */
     public void addDelegateAtStart(Object delegate) {
-        	if (hasDelegate(delegate)) {
-        		throw new IllegalArgumentException("Delegate is already included");
-        	}
-        	
-        	_NSDelegate delegateObject = new _NSDelegate(getClass(), delegate);
-	        delegates.add(0, delegateObject);
-    	
+    	if (hasDelegate(delegate)) {
+    		throw new IllegalArgumentException("Delegate is already included");
+    	}
+
+    	_NSDelegate delegateObject = new _NSDelegate(getClass(), delegate);
+    	delegates.add(0, delegateObject);
     }
     
     
@@ -90,19 +89,18 @@ public abstract class ERXMulticastingDelegate {
      * @param delegate Object to remove as one of the delegates called
      */
     public void removeDelegate(Object delegate) {
-        	if ( ! hasDelegate(delegate)) {
-        		throw new IllegalArgumentException("Delegate is not present");
-        	}
-        	
-	        for (int i = 0; i < delegates.size(); i++) {
-	        	_NSDelegate delegateObject = (_NSDelegate)delegates.get(i);
-	        	if (delegateObject.delegate().equals(delegate))
-	        	{
-	        		delegates.remove(i);
-	        		break;
-	        	}
-	        }
-      
+    	if ( ! hasDelegate(delegate)) {
+    		throw new IllegalArgumentException("Delegate is not present");
+    	}
+
+    	for (int i = 0; i < delegates.size(); i++) {
+    		_NSDelegate delegateObject = (_NSDelegate)delegates.get(i);
+    		if (delegateObject.delegate().equals(delegate))
+    		{
+    			delegates.remove(i);
+    			break;
+    		}
+    	}
     }
     
 
@@ -113,15 +111,15 @@ public abstract class ERXMulticastingDelegate {
      * @return <code>true</code> if delegate is represented in delegates()
      */
     public boolean hasDelegate(Object delegate) {
-	        for (int i = 0; i < delegates.size(); i++) {
-	        	_NSDelegate delegateObject = (_NSDelegate)delegates.get(i);
-	        	if (delegateObject.delegate().equals(delegate))
-	        	{
-	        		return true;
-	        	}
-	        }
-	        return false;
+    	for (int i = 0; i < delegates.size(); i++) {
+    		_NSDelegate delegateObject = (_NSDelegate)delegates.get(i);
+    		if (delegateObject.delegate().equals(delegate))
+    		{
+    			return true;
+    		}
+    	}
     	
+    	return false;
     }
     
     
@@ -133,7 +131,7 @@ public abstract class ERXMulticastingDelegate {
      * @return the delegates in the order they will be called
      */
     public NSArray delegates() {
-    		return new NSArray(delegates);
+    	return new NSArray(delegates);
     }
     
 
@@ -144,15 +142,15 @@ public abstract class ERXMulticastingDelegate {
      * @param orderedDelegates array of <code>com.webobjects.foundation._NSDelegate</code> in the order in which delegates should be called
      */
     public void setDelegateOrder(NSArray orderedDelegates) {
-	        for (int i = 0; i < orderedDelegates.count(); i++) {
-	            if ( ! (orderedDelegates.objectAtIndex(i) instanceof _NSDelegate)) {
-	                throw new IllegalArgumentException("Object of class " + orderedDelegates.objectAtIndex(i).getClass().getName() +
-	                        " must be instanceof _NSDelegate");
-	            }
-	        }
-	        delegates.clear();
-	        delegates.addAll(orderedDelegates);
-   
+    	for (int i = 0; i < orderedDelegates.count(); i++) {
+    		if ( ! (orderedDelegates.objectAtIndex(i) instanceof _NSDelegate)) {
+    			throw new IllegalArgumentException("Object of class " + orderedDelegates.objectAtIndex(i).getClass().getName() +
+    					" must be instanceof _NSDelegate");
+    		}
+    	}
+    	delegates.clear();
+    	delegates.addAll(orderedDelegates);
+
     }
 
 


### PR DESCRIPTION
When using multiple EOObjectStores, ERXMulticastingDelegate will block  potential concurrent threads.  This is a performance issue when the application is under heavy load.

This patch fix this by replacing the NSMutableArray by java.util.concurrent.CopyOnWriteArrayList and removing no longer needed synchronized blocks