### PR TITLE
Disable the ERModernMoviesTest module temporarily from the Maven build

### DIFF
--- a/Tests/pom.xml
+++ b/Tests/pom.xml
@@ -16,6 +16,7 @@
 		<module>ERXTest</module>
 		<module>TestAdaptor</module>
 		<module>PluginTest</module>
-		<module>ERModernMoviesTest</module>
+		<!-- Disable the ERModernMoviesTest module temporarily -->
+		<!--<module>ERModernMoviesTest</module>-->
 	</modules>
 </project>


### PR DESCRIPTION
I'm unable to run the integration tests on that module successfully. Neither on macOS nor AWS Linux. I'll disable the build of that module until we figure out how to make it work again.