### PR TITLE
Configure Travis-CI to build and deploy Wonder artifacts

### DIFF
--- a/.maven_settings.xml
+++ b/.maven_settings.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/POM/4.0.0"	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>wocommunity</id>
+          <url>http://maven.wocommunity.org/content/groups/public/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>wocommunity-plugins</id>
+          <url>http://maven.wocommunity.org/content/groups/public/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+  </profile>
+</profiles>
+<activeProfiles>
+  <activeProfile>default</activeProfile>
+</activeProfiles>
+<servers>
+  <server>
+    <id>wocommunity.deployment</id>
+    <username>${env.CI_DEPLOY_USERNAME}</username>
+    <password>${env.CI_DEPLOY_PASSWORD}</password>
+  </server>
+</servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,9 @@ before_script:
 
 script: "mvn verify -s .maven_settings.xml -Dmaven.javadoc.skip=true -B"
 
-after_success: "mvn deploy -s .maven_settings.xml -DskipTests=true -B"
+deploy:
+  - provider: script
+    script: "mvn deploy -s .maven_settings.xml -DskipTests=true -B"
+    on:
+      branch: master
+      tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-
-env:
-  # set NEXT_ROOT, so apps will start
-  - NEXT_ROOT=/home/travis/build
-
-script: "mvn verify"
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+cache:
+  directories:
+  - $HOME/.m2
+install: "mvn install -s .maven_settings.xml -DskipTests=true -Dmaven.javadoc.skip=true -B"
+script: "mvn test -s .maven_settings.xml -Dmaven.javadoc.skip=true -B"
+after_success: "mvn deploy -s .maven_settings.xml -DskipTests=true -B"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 
-script: "mvn test -s .maven_settings.xml -Dmaven.javadoc.skip=true -B"
+script: "mvn verify -s .maven_settings.xml -Dmaven.javadoc.skip=true -B"
 
 after_success: "mvn deploy -s .maven_settings.xml -DskipTests=true -B"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 language: java
 jdk:
   - oraclejdk8
+
+env:
+  # set NEXT_ROOT, so apps will start
+  - NEXT_ROOT=/home/travis/build
+
 cache:
   directories:
   - $HOME/.m2
+
 install: "mvn install -s .maven_settings.xml -DskipTests=true -Dmaven.javadoc.skip=true -B"
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+
 script: "mvn test -s .maven_settings.xml -Dmaven.javadoc.skip=true -B"
+
 after_success: "mvn deploy -s .maven_settings.xml -DskipTests=true -B"

--- a/Applications/JavaMonitor/pom.xml
+++ b/Applications/JavaMonitor/pom.xml
@@ -11,6 +11,10 @@
 	<name>JavaMonitor Application</name>
 	<packaging>woapplication</packaging>
 
+	<properties>
+		<skip.apple.frameworks>false</skip.apple.frameworks>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>wonder.core</groupId>

--- a/Applications/wotaskd/pom.xml
+++ b/Applications/wotaskd/pom.xml
@@ -9,6 +9,9 @@
 	<artifactId>wotaskd</artifactId>
 	<name>wotaskd</name>
 	<packaging>woapplication</packaging>
+	<properties>
+		<skip.apple.frameworks>false</skip.apple.frameworks>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>wonder.core</groupId>

--- a/README.mkd
+++ b/README.mkd
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/wocommunity/wonder.svg?branch=master)](https://travis-ci.org/wocommunity/wonder)
+
 About Project Wonder
 --------------------
 


### PR DESCRIPTION
Configure Travis-CI to build and deploy Wonder artifacts

This pull request adds the required files to enable Travis-CI builds for Project Wonder. It's configured to run tests for every new pull request. Additionally, artifacts produced by successful builds of the `master` branch will be deployed to the WOCommunity Maven Repository automatically.