### PR TITLE
Avoid Maven build failures because of Javadoc generation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <configuration>
+                <failOnError>false</failOnError>
+                <additionalparam>-Xdoclint:none</additionalparam>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Up to JDK 7, the Javadoc tool was pretty lenient. With JDK 8, we are unable to get Javadoc unless our docs meet the standards of doclint. This commit disables doclint while generating Javadocs using Maven. It also tells Maven not to fail the build if something wrong happens while generating the Javadocs.

This change looks more like a workaround than a solution. And in fact, it is. The real solution to the problem requires an increased effort, including:

1. Make all Javadocs fully complaint with doclint rules.
2. Refactor the custom Wonder taglets classes into a separate module that can be compiled during the build process.