### PR TITLE
Add collectors for NSCollection types

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/stream/ERXCollectors.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/stream/ERXCollectors.java
@@ -1,0 +1,117 @@
+package er.extensions.stream;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+import com.webobjects.foundation.NSArray;
+import com.webobjects.foundation.NSDictionary;
+import com.webobjects.foundation.NSMutableArray;
+import com.webobjects.foundation.NSMutableDictionary;
+import com.webobjects.foundation.NSMutableSet;
+import com.webobjects.foundation.NSSet;
+
+/**
+ * Implementations of {@link Collector} that implement various useful reduction
+ * operations related with NSCollection classes.
+ *
+ * <p>
+ * The following are examples of using the predefined collectors to perform
+ * common mutable reduction tasks:
+ *
+ * <pre>
+ * // Accumulate names into a NSArray
+ * NSArray<String> array = people.stream().map(Person::name).collect(ERXCollectors.toNSArray());
+ *
+ * // Accumulate names into a NSSet
+ * NSSet<String> set = people.stream().map(Person::name).collect(ERXCollectors.toNSSet());
+ *
+ * // Accumulate people by name into a NSDictionary
+ * NSDictionary<String, Person> dictionary = people.stream().collect(ERXCollectors.toNSDictionary(Person::name, Function.identity()));
+ * </pre>
+ *
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ * @since 7.1
+ */
+public class ERXCollectors {
+	/**
+	 * Returns a {@code Collector} that accumulates the input elements into a new
+	 * {@code NSArray}.
+	 *
+	 * @param <T>
+	 *            the type of the input elements
+	 * @return a {@code Collector} which collects all the input elements into a
+	 *         {@code NSArray}, in encounter order
+	 */
+	public static <T> Collector<T, ?, NSArray<T>> toNSArray() {
+		return collectingAndThen(toCollection(NSMutableArray::new), NSArray::immutableClone);
+	}
+
+	/**
+	 * Returns a {@code Collector} that accumulates the input elements into a new
+	 * {@code NSSet}.
+	 *
+	 * @param <T>
+	 *            the type of the input elements
+	 * @return a {@code Collector} which collects all the input elements into a
+	 *         {@code NSSet}, in encounter order
+	 */
+	public static <T> Collector<T, ?, NSSet<T>> toNSSet() {
+		return collectingAndThen(toCollection(NSMutableSet::new), NSSet::immutableClone);
+	}
+
+	/**
+	 * Returns a {@code Collector} that accumulates the input elements grouped by
+	 * key/value into a new {@code NSDictionary}.
+	 *
+	 * @param keyMapper
+	 *            a mapping function to produce keys.
+	 * @param valueMapper
+	 *            a mapping function to produce values.
+	 * @return a {@code Collector} which collects elements into a
+	 *         {@code NSDictionary} whose keys and values are the result of applying
+	 *         mapping functions to the input elements.
+	 */
+	public static <T, K, U> Collector<T, ?, NSDictionary<K, U>> toNSDictionary(Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper) {
+		BinaryOperator<U> throwingMerger = (k, v) -> {
+			throw new IllegalStateException(String.format("Duplicate key %s", k));
+		};
+
+		return toNSDictionary(keyMapper, valueMapper, throwingMerger);
+	}
+
+	/**
+	 * Returns a {@code Collector} that accumulates the input elements grouped by
+	 * key/value into a new {@code NSDictionary}.
+	 *
+	 * @param keyMapper
+	 *            a mapping function to produce keys.
+	 * @param valueMapper
+	 *            a mapping function to produce values
+	 * @param mergeFunction
+	 *            a merge function, used to resolve collisions between values
+	 *            associated with the same key, as supplied to
+	 *            {@link Map#merge(Object, Object, BiFunction)}
+	 * @return a {@code Collector} which collects elements into a
+	 *         {@code NSDictionary} whose keys are the result of applying a key
+	 *         mapping function to the input elements, and whose values are the
+	 *         result of applying a value mapping function to all input elements
+	 *         equal to the key and combining them using the merge function
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T, K, U> Collector<T, ?, NSDictionary<K, U>> toNSDictionary(Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper, BinaryOperator<U> mergeFunction) {
+		return collectingAndThen(toMap(keyMapper, valueMapper, mergeFunction, NSMutableDictionary::new), dict -> ((NSDictionary<K, U>) dict.immutableClone()));
+	}
+
+	/**
+	 * Must not be instantiated.
+	 */
+	private ERXCollectors() {
+	}
+}

--- a/Tests/ERXTest/Sources/er/extensions/streams/ERXCollectorsTest.java
+++ b/Tests/ERXTest/Sources/er/extensions/streams/ERXCollectorsTest.java
@@ -1,0 +1,174 @@
+package er.extensions.streams;
+
+import static er.extensions.stream.ERXCollectors.toNSArray;
+import static er.extensions.stream.ERXCollectors.toNSDictionary;
+import static er.extensions.stream.ERXCollectors.toNSSet;
+import static java.util.stream.Stream.concat;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.webobjects.foundation.NSArray;
+import com.webobjects.foundation.NSDictionary;
+import com.webobjects.foundation.NSMutableArray;
+import com.webobjects.foundation.NSMutableDictionary;
+import com.webobjects.foundation.NSMutableSet;
+import com.webobjects.foundation.NSSet;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
+ */
+public class ERXCollectorsTest {
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void collectEmptyNSArrayWhenStreamReturnsNoElements() throws Exception {
+		NSArray<?> result = Stream.empty().collect(toNSArray());
+
+		assertThat(result.isEmpty(), is(true));
+	}
+
+	@Test
+	public void collectNSArrayWithOneElementWhenStreamReturnsOneElement() throws Exception {
+		NSArray<String> result = Stream.of("test").collect(toNSArray());
+
+		assertThat(result.size(), is(1));
+		assertThat(result, hasItem("test"));
+	}
+
+	@Test
+	public void collectNSArrayWithMoreThanOneElementWhenStreamReturnsTwoElements() throws Exception {
+		NSArray<String> result = Stream.of("test1", "test2").collect(toNSArray());
+
+		assertThat(result.size(), is(2));
+		assertThat(result, hasItems("test1", "test2"));
+	}
+
+	@Test
+	public void collectCombinedArrayWhenStreamCombinedWithAnotherInParallel() throws Exception {
+		NSArray<String> result = concat(Stream.of("test1").parallel(), Stream.of("test2").parallel())
+				.collect(toNSArray());
+
+		assertThat(result.size(), is(2));
+		assertThat(result, hasItems("test1", "test2"));
+	}
+
+	@Test
+	public void collectImmutableNSArrayWhenCollectingNSArray() throws Exception {
+		NSArray<String> result = Stream.of("test").collect(toNSArray());
+
+		assertThat(result, instanceOf(NSArray.class));
+		assertThat(result, not(instanceOf(NSMutableArray.class)));
+	}
+
+	@Test
+	public void collectEmptyNSDictionaryWhenStreamReturnsNoElements() throws Exception {
+		NSDictionary<?, ?> result = Stream.empty().collect(toNSDictionary(Object::toString, Function.identity()));
+
+		assertThat(result.isEmpty(), is(true));
+	}
+
+	@Test
+	public void collectNSDictionaryWhenStreamReturnsOneElement() throws Exception {
+		NSDictionary<Integer, String> result = Stream.of("test1")
+				.collect(toNSDictionary(String::length, Function.identity()));
+
+		assertThat(result.size(), is(1));
+		assertThat(result.get(5), is("test1"));
+	}
+
+	@Test
+	public void collectNSDictionaryWithMoreThanOneElementWhenStreamReturnsTwoElements() throws Exception {
+		NSDictionary<Integer, String> result = Stream.of("test1", "test12")
+				.collect(toNSDictionary(String::length, Function.identity()));
+
+		assertThat(result.size(), is(2));
+		assertThat(result.get(5), is("test1"));
+		assertThat(result.get(6), is("test12"));
+	}
+
+	@Test
+	public void collectNSDictionaryMergingElementsWhenMergingFunctionProvided() throws Exception {
+		NSDictionary<Integer, String> result = Stream.of("test1", "test2")
+				.collect(toNSDictionary(String::length, Function.identity(), (s1, s2) -> s1.concat(s2)));
+
+		assertThat(result.size(), is(1));
+		assertThat(result.get(5), is("test1test2"));
+	}
+
+	@Test
+	public void collectImmutableNSDictionaryWhenCollectingNSDictionary() throws Exception {
+		NSDictionary<Integer, String> result = Stream.of("test1")
+				.collect(toNSDictionary(String::length, Function.identity()));
+
+		assertThat(result, instanceOf(NSDictionary.class));
+		assertThat(result, not(instanceOf(NSMutableDictionary.class)));
+	}
+
+	@Test
+	public void throwExceptionWhenCollectingDictionaryAndMergeIsRequired() throws Exception {
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage(is("Duplicate key test1"));
+
+		Stream.of("test1", "test2").collect(toNSDictionary(String::length, Function.identity()));
+	}
+
+	@Test
+	public void collectEmptyNSSetWhenStreamReturnsNoElements() throws Exception {
+		NSSet<?> result = Stream.empty().collect(toNSSet());
+
+		assertThat(result.isEmpty(), is(true));
+	}
+
+	@Test
+	public void collectNSSetWithOneElementWhenStreamReturnsOneElement() throws Exception {
+		NSSet<String> result = Stream.of("test").collect(toNSSet());
+
+		assertThat(result.size(), is(1));
+		assertThat(result, hasItem("test"));
+	}
+
+	@Test
+	public void collectNSSetWithMoreThanOneElementWhenStreamReturnsTwoElements() throws Exception {
+		NSSet<String> result = Stream.of("test1", "test2").collect(toNSSet());
+
+		assertThat(result.size(), is(2));
+		assertThat(result, hasItems("test1", "test2"));
+	}
+
+	@Test
+	public void collectCombinedSetWhenStreamCombinedWithAnotherInParallel() throws Exception {
+		NSSet<String> result = concat(Stream.of("test1").parallel(), Stream.of("test2").parallel())
+				.collect(toNSSet());
+
+		assertThat(result.size(), is(2));
+		assertThat(result, hasItems("test1", "test2"));
+	}
+
+	@Test
+	public void collectImmutableNSSetWhenCollectingNSSet() throws Exception {
+		NSSet<String> result = Stream.of("test").collect(toNSSet());
+
+		assertThat(result, instanceOf(NSSet.class));
+		assertThat(result, not(instanceOf(NSMutableSet.class)));
+	}
+
+	@Test
+	public void collectNSSetWithOneElementWhenStreamReturnsTwoRepeatedElements() throws Exception {
+		NSSet<String> result = Stream.of("test1", "test1").collect(toNSSet());
+
+		assertThat(result.size(), is(1));
+		assertThat(result, hasItems("test1"));
+	}
+}


### PR DESCRIPTION
This commit adds a new class `ERXCollectors`. It includes implementations of the `Collector` interface for various useful reduction operations related with NSCollection classes.