### PR TITLE
Fix a NoSuchElementException in cleanRelationships 

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXCopyable.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXCopyable.java
@@ -468,7 +468,7 @@ public interface ERXCopyable<T extends ERXCopyable<T>> extends ERXEnterpriseObje
 				if (relatedObjects.count() > 0) {
 					entity.relationshipNamed(relationshipName);
 					ERXCopyable.copyLogger.debug("Removing objects in to-many relationship " + relationshipName);
-					for (ERXEnterpriseObject relatedObject : relatedObjects) {
+					for (ERXEnterpriseObject relatedObject : relatedObjects.immutableClone()) {
 						destination.removeObjectFromBothSidesOfRelationshipWithKey(relatedObject, relationshipName);
 						if (relatedObject.isNewObject()) {
 							editingContext.deleteObject(relatedObject);


### PR DESCRIPTION
caused by the use of an iterator on the relationship mutable array that is modified.