### PR TITLE
Add public host property

### DIFF
--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -509,6 +509,10 @@ er.extensions.concurrency.ERXTaskObjectStoreCoordinatorPool.maxCoordinators = 1
 # er.extensions.ERXApplication.replaceApplicationPath.pattern=/cgi-bin/WebObjects/YourApp.woa
 # er.extensions.ERXApplication.replaceApplicationPath.replace=/yourapp
 
+## If your WOHost is not your public host name, specify the public host to use for complete URL 
+## generated without a server request like background tasks that send emails.
+# er.extensions.ERXApplication.publicHost=www.yourPublicHost.com
+
 #########################################################################
 # ERXSession
 #########################################################################

--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -512,6 +512,8 @@ er.extensions.concurrency.ERXTaskObjectStoreCoordinatorPool.maxCoordinators = 1
 ## If your WOHost is not your public host name, specify the public host to use for complete URL 
 ## generated without a server request like background tasks that send emails.
 # er.extensions.ERXApplication.publicHost=www.yourPublicHost.com
+## Set to true to switch default request used in background tasks to https
+# er.extensions.ERXApplication.publicHostIsSecure=false
 
 #########################################################################
 # ERXSession

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -308,6 +308,11 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	private String _proxyBalancerCookiePath = null;
 
 	/**
+	 * The public host to use for complete url without request from a server (in background tasks)
+	 */
+	private String _publicHost;
+
+	/**
 	 * Copies the props from the command line to the static dict
 	 * propertiesFromArgv.
 	 * 
@@ -1255,6 +1260,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	        }
 	    }
 
+	    _publicHost = ERXProperties.stringForKeyWithDefault("er.extensions.ERXApplication.publicHost", host());
 	}
 
 	/**
@@ -2855,5 +2861,8 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 			context.response().addCookie(cookie);
 		}
 	}
-  
+
+	public String publicHost() {
+		return _publicHost;
+	}  
 }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -1442,7 +1442,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	}
 
 	@Override
-	public WORequest createRequest(String aMethod, String aURL, String anHTTPVersion, Map<String, ? extends List<String>> someHeaders, NSData aContent, Map<String, Object> someInfo) {
+	public ERXRequest createRequest(String aMethod, String aURL, String anHTTPVersion, Map<String, ? extends List<String>> someHeaders, NSData aContent, Map<String, Object> someInfo) {
 		// Workaround for #3428067 (Apache Server Side Include module will feed
 		// "INCLUDED" as the HTTP version, which causes a request object not to
 		// be created by an exception.

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
@@ -271,7 +271,24 @@ public  class ERXRequest extends WORequest {
     	return ERXRequest.isRequestSecure(this);
     }
     
-    @Override
+    /**
+     * Add the protocol, server and port parts of this request to a StringBuffer.
+     * @param stringbuffer 
+     * 
+     */
+	public void _completeURLPrefix(StringBuffer stringbuffer) {
+		_completeURLPrefix(stringbuffer, isSecure(), 0);
+	}
+	
+    /**
+     * Add the protocol, server and port parts to a StringBuffer to build an URL to this app.
+     * if port is set to 0, this request port will be used.
+     * @param stringbuffer 
+     * @param secure generate a https url
+     * @param port the port number to use, 0 this request port  
+     * 
+     */
+	@Override
 	public void _completeURLPrefix(StringBuffer stringbuffer, boolean secure, int port) {
     	if (_secureDisabled) {
     		secure = false;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
@@ -122,7 +122,7 @@ public  class ERXRequest extends WORequest {
 					throw new NSForwardException(new WOURLFormatException("<" + super.getClass().getName() + ">: Unable to build complete url as no server name was provided in the headers of the request."));
 			}
 			else {
-				serverName = WOApplication.application().host();
+				serverName = ERXApplication.erxApplication().publicHost();
 			}
 		}
 		return serverName;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXWOContext.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXWOContext.java
@@ -179,7 +179,12 @@ public class ERXWOContext extends ERXAjaxContext implements ERXMutableUserInfoHo
 			// look funny in the request, but still allow the context to use a relative url.
 			requestUrl = "";
 		}
-		return app.createContextForRequest(app.createRequest("GET", requestUrl, "HTTP/1.1", null, null, null));
+		WORequest dummyRequest = app.createRequest("GET", requestUrl, "HTTP/1.1", null, null, null);
+		if (ERXProperties.booleanForKeyWithDefault("er.extensions.ERXApplication.publicHostIsSecure", false)) {
+			dummyRequest.setHeader("on", "https");
+		}
+		return (ERXWOContext) app.createContextForRequest(dummyRequest);
+	}
 	}
 
 	public NSMutableDictionary mutableUserInfo() {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXWOContext.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXWOContext.java
@@ -161,8 +161,8 @@ public class ERXWOContext extends ERXAjaxContext implements ERXMutableUserInfoHo
 	 * Creates a WOContext using a dummy WORequest.
 	 * @return the new WOContext
 	 */
-	public static WOContext newContext() {
-		WOApplication app = WOApplication.application();
+	public static ERXWOContext newContext() {
+		ERXApplication app = ERXApplication.erxApplication();
 		// Try to create a URL with a relative path into the application to mimic a real request.
 		// We must create a request with a relative URL, as using an absolute URL makes the new 
 		// WOContext's URL absolute, and it is then unable to render relative paths. (Long story short.)
@@ -185,6 +185,9 @@ public class ERXWOContext extends ERXAjaxContext implements ERXMutableUserInfoHo
 		}
 		return (ERXWOContext) app.createContextForRequest(dummyRequest);
 	}
+	
+	public <T extends ERXRequest> T erxRequest() {
+		return (T) request();
 	}
 
 	public NSMutableDictionary mutableUserInfo() {


### PR DESCRIPTION
To finally fix the problem of creating email and url to the app in background tasks where the WOContext does not have an URL from the server to know the server name and the WOHost is not a suitable server to use in an URL.

To use these, simply create a context using 
ERXWOContext sessionLessContext = ERXWOContext.newContext();
sessionLessContext.generateCompleteURLs();
String url = sessionLessContext.urlWithRequestHandlerKey(...)

or create a component with ERXApplication.instantiatePage(String pageName) or ERMailUtils.instantiatePage() as both will use ERXWOContext.newContext();

Here are the 2 added properties:
```
## If your WOHost is not your public host name, specify the public host to use for complete URL 
## generated without a server request like background tasks that send emails.
# er.extensions.ERXApplication.publicHost=www.yourPublicHost.com
## Set to true to switch default request used in background tasks to https
# er.extensions.ERXApplication.publicHostIsSecure=false
```