### PR TITLE
Make ERMD2WListFilter handle multiple search fields

### DIFF
--- a/Frameworks/D2W/ERModernDefaultSkin/WebServerResources/default_screen_stylesheet.css
+++ b/Frameworks/D2W/ERModernDefaultSkin/WebServerResources/default_screen_stylesheet.css
@@ -1456,10 +1456,12 @@ div.RtActionCell li {
 .ListFilter {
 	position: relative;
 	top: 22px;
-	width: 40%;
+	width: 55%;
 	padding: 0 50px;
 	margin: auto;
 	z-index: 100;
+    /* until flexbox can be used, we have to make do with a pseudo-table here */
+	display: table;
 }
 
 /* adapt position when used to filter relationships */
@@ -1468,32 +1470,18 @@ div.RtActionCell li {
 	padding: 4px 50px;
 }
 
-.ListFilter .ListFilterSearch  {
+.ListFilter form {
+	display: table-row;
+}
+
+.ListFilter .ListFilterSearch, .ListFilter .ListFilterChoices {
 	font-size: 16px;
-	display: inline-block;
-	width: 100%;
+	display: table-cell;
+	padding-right: 4%;
 }
 
 .ListFilter .ListFilterSearch input {
 	width: 100%;
-}
-
-/* apply lighter border and smaller font-size when used to filter relationships */
-.AttrVal .ListFilter .ListFilterSearch input {
-	border: 1px solid #aaa;
-	font-size: 11px;
-}
-
-.ListFilter .ListFilterChoices {
-	font-size: 16px;
-	margin-left: 20px;
-	display: inline-block;
-	width: 100%;
-}
-
-.ListFilter.ComboListFilter .ListFilterSearch, .ListFilter.ComboListFilter .ListFilterChoices {
-	/* input and select side-by-side, so reduce width */
-	width: 40%;
 }
 
 /* ATTACHMENT */

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WListFilter.wo/ERMD2WListFilter.html
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WListFilter.wo/ERMD2WListFilter.html
@@ -2,7 +2,14 @@
   <webobject name = "Wrapper">
     <webobject name = "form">
       <webobject name = "showSearchField">
-        <webobject name = "observeField"> <webobject name = "SearchField" /> </webobject>
+        <webobject name = "hasMultipleFields">
+          <webobject name = "fieldList">
+            <webobject name = "observeField"> <webobject name = "SearchField" /> </webobject>
+          </webobject>
+        </webobject>
+        <webobject name = "hasSingleField">
+          <webobject name = "observeField"> <webobject name = "SearchField" /> </webobject>
+        </webobject>
       </webobject>
       <webobject name = "showRestrictedChoices">
         <webobject name = "observeChoice"> <webobject name = "RestrictedChoices" /> </webobject>

--- a/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WListFilter.wo/ERMD2WListFilter.wod
+++ b/Frameworks/D2W/ERModernDirectToWeb/Components/Nonlocalized.lproj/ERMD2WListFilter.wo/ERMD2WListFilter.wod
@@ -14,7 +14,21 @@ observeField : AjaxObserveField {
 	updateContainerID = d2wContext.idForMainContainer;
 	observeFieldFrequency = 1;
 	action = search;
-	class = "ListFilterSearch";
+	class = searchFieldCssClass;
+}
+
+hasMultipleFields : WOConditional {
+	condition = hasMultipleFields;
+}
+
+fieldList : WORepetition {
+	count = searchKeyGroupCount;
+	index = searchFieldIndex;
+}
+
+hasSingleField : WOConditional {
+	condition = hasMultipleFields;
+	negate = true;
 }
 
 showSearchField : WOConditional {
@@ -24,6 +38,7 @@ showSearchField : WOConditional {
 SearchField: WOTextField {
 	value = searchValue;
 	type = "search";
+	title = localizedSearchKey;
 }
 
 showRestrictedChoices : WOConditional {

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/query/ERMD2WListFilter.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/components/query/ERMD2WListFilter.java
@@ -9,6 +9,7 @@ import com.webobjects.eocontrol.EOQualifier;
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSKeyValueCoding;
 import com.webobjects.foundation.NSMutableArray;
+import com.webobjects.foundation.NSMutableDictionary;
 
 import er.ajax.AjaxUtils;
 import er.directtoweb.components.ERDCustomQueryComponent;
@@ -20,12 +21,16 @@ import er.modern.directtoweb.delegates.ERMD2WAttributeQueryDelegate;
 import er.modern.directtoweb.delegates.ERMD2WAttributeQueryDelegate.ERMD2WQueryComponent;
 
 /**
- * Ajax-enabled ad-hoc filtering of lists. Similar to ERDAjaxSearchDisplayGroup, 
- * but enables filtering over multiple attributes and/or a pop-up list of choices.
+ * Ajax-enabled ad-hoc filtering of lists. Similar to ERDAjaxSearchDisplayGroup,
+ * but enables filtering over multiple attributes using either a single or
+ * multiple search fields and/or a pop-up list of choices.
  * 
- * Gets displayed when either or both of searchKey and restrictedChoiceKey D2W keys is not null.
+ * Gets displayed when either or both of searchKey and restrictedChoiceKey D2W
+ * keys is not null. If the search key is an array of arrays of keys, a separate
+ * search field will be rendered for each array of keys and the individual
+ * qualifiers generated for each field will be ANDed.
  * 
- * @d2wKey searchKey - either a single target key as a string or an array with multiple keys
+ * @d2wKey searchKey - either a single target key as a string, an array with multiple keys or an array of arrays with keys
  * @d2wKey restrictedChoiceKey - key path that will return a list of filter choices, note that no "object" will be available!
  * @d2wKey keyWhenRelationship - specifies the display key on the choice
  * @d2wKey noSelectionString - "no selection" string to show on the restricted choice pop-up
@@ -50,7 +55,12 @@ public class ERMD2WListFilter extends ERDCustomQueryComponent implements
     }
 
     private Object _filterChoice;
-    private String _searchValue;
+    
+    private NSMutableDictionary<String, String> _searchValues = new NSMutableDictionary<>();
+
+    private NSMutableDictionary<String, EOQualifier> _qualifiers = new NSMutableDictionary<>();
+
+    public Integer searchFieldIndex = 0;
 
     public Object filterChoiceItem;
 
@@ -73,8 +83,15 @@ public class ERMD2WListFilter extends ERDCustomQueryComponent implements
     // actions
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public WOActionResults search() {
-        EOQualifier _qualifier = ERMD2WAttributeQueryDelegate.instance
-                .buildQualifier(this);
+        // get the qualifier for the current search field
+        EOQualifier qualifier = ERMD2WAttributeQueryDelegate.instance
+                .buildQualifier(this, searchFieldIndex);
+
+        // store the qualifier for this search field
+        _qualifiers.takeValueForKey(qualifier, searchFieldIndex.toString());
+        
+        // "and" active qualifiers from all search fields
+        qualifier = ERXQ.and(_qualifiers.allValues());
         
         String filterChoicesKey = (String) d2wContext().valueForKey(Keys.restrictedChoiceTargetKey);
         if (!ERXStringUtilities.stringIsNullOrEmpty(filterChoicesKey)
@@ -85,9 +102,9 @@ public class ERMD2WListFilter extends ERDCustomQueryComponent implements
                 NSMutableArray deepChoices = new NSMutableArray(filterChoice());
                 deepChoices.addObjects(NSKeyValueCoding.Utility
                         .valueForKey(filterChoice(), recursionKey));
-                _qualifier = ERXQ.and(_qualifier, ERXQ.in(filterChoicesKey, ERXArrayUtilities.flatten(deepChoices)));
+                qualifier = ERXQ.and(qualifier, ERXQ.in(filterChoicesKey, ERXArrayUtilities.flatten(deepChoices)));
             } else {
-                _qualifier = ERXQ.and(_qualifier,
+                qualifier = ERXQ.and(qualifier,
                         ERXQ.equals(filterChoicesKey, filterChoice()));
             }
         }
@@ -95,10 +112,10 @@ public class ERMD2WListFilter extends ERDCustomQueryComponent implements
         // qualify on the data source if it's a DB data source
         if (displayGroup().dataSource() instanceof EODatabaseDataSource) {
             EODatabaseDataSource dbds = (EODatabaseDataSource) displayGroup().dataSource();
-            dbds.setAuxiliaryQualifier(_qualifier);
+            dbds.setAuxiliaryQualifier(qualifier);
             dbds.fetchSpecification().setUsesDistinct(true);
         } else {
-            displayGroup().setQualifier(_qualifier);
+            displayGroup().setQualifier(qualifier);
         }
         displayGroup().fetch();
         displayGroup().setCurrentBatchIndex(1);
@@ -109,14 +126,76 @@ public class ERMD2WListFilter extends ERDCustomQueryComponent implements
         AjaxUtils.addScriptResourceInHead(context, response, "prototype.js");
         super.appendToResponse(response, context);
     }
-
+    
+    /**
+     * @return true if multiple search fields have been defined
+     */
+    public boolean hasMultipleFields() {
+        boolean hasMultipleFields = false;
+        if (d2wContext().valueForKey("searchKey") instanceof NSArray<?>) {
+            NSArray<?> rawValue = (NSArray<?>) d2wContext().valueForKey("searchKey");
+            if (rawValue.objectAtIndex(0) instanceof NSArray<?>) {
+                hasMultipleFields = true;
+            }
+        }
+        return hasMultipleFields;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public NSArray<NSArray<String>> searchKeyGroups() {
+        NSArray<NSArray<String>> searchKeyGroups = null;
+        if ((d2wContext().valueForKey("searchKey") instanceof NSArray<?>)) {
+            NSArray<?> rawValue = (NSArray<?>) d2wContext().valueForKey("searchKey");
+            if (rawValue.objectAtIndex(0) instanceof NSArray<?>) {
+                searchKeyGroups = (NSArray<NSArray<String>>) d2wContext().valueForKey("searchKey");
+            } else {
+                NSArray<String> searchKey = (NSArray<String>) d2wContext()
+                        .valueForKey("searchKey");
+                searchKeyGroups = new NSArray<NSArray<String>>(searchKey);
+            }
+        }
+        return searchKeyGroups;
+    }
+    
+    public int searchKeyGroupCount() {
+        return searchKeyGroups().count();
+    }
+    
+    public NSArray<String> searchKey() {
+        return ERMD2WAttributeQueryDelegate.instance.searchKey(this, searchFieldIndex);
+    }
+    
+    public String localizedSearchKey() {
+        String searchKeyList = searchKey().componentsJoinedByString(",");
+        return ERXLocalizer.currentLocalizer()
+                .localizedStringForKeyWithDefault("ERMD2WListFilter.searchKey."
+                        + searchKeyList);
+    }
+    
+    /**
+     * @return a class list that allows targeting of individual search fields
+     */
+    public String searchFieldCssClass() {
+        String searchFieldCssClass = "ListFilterSearch";
+        if (hasMultipleFields()) {
+            searchFieldCssClass = searchFieldCssClass.concat(" ListFilterSearch_" + searchFieldIndex);
+        }
+        return searchFieldCssClass;
+    }
+    
     public void setSearchValue(String searchValue) {
-        _searchValue = searchValue;
+        // set the search value for the current field
+        if (searchValue == null) {
+            _searchValues.removeObjectForKey(searchFieldIndex.toString());
+        } else {
+            _searchValues.setObjectForKey(searchValue, searchFieldIndex.toString());
+        }
     }
 
     @Override
     public String searchValue() {
-        return _searchValue;
+        // retrieve the search value for the current field
+        return _searchValues.objectForKey(searchFieldIndex.toString());
     }
 
     public void setFilterChoice(Object filterChoice) {

--- a/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/delegates/ERMD2WAttributeQueryDelegate.java
+++ b/Frameworks/D2W/ERModernDirectToWeb/Sources/er/modern/directtoweb/delegates/ERMD2WAttributeQueryDelegate.java
@@ -74,6 +74,10 @@ public class ERMD2WAttributeQueryDelegate {
     }
 
     public EOQualifier buildQualifier(ERMD2WQueryComponent sender) {
+        return buildQualifier(sender, 0);
+    }
+
+    public EOQualifier buildQualifier(ERMD2WQueryComponent sender, int searchFieldIndex) {
         EOQualifier qualifier = null;
         Integer typeAheadMinimumCharacterCount = ERXValueUtilities
                 .IntegerValueWithDefault(
@@ -83,7 +87,7 @@ public class ERMD2WAttributeQueryDelegate {
                 && sender.searchValue().length() >= typeAheadMinimumCharacterCount) {
 
             NSMutableArray<EOQualifier> qualifiers = new NSMutableArray<EOQualifier>();
-            for (String anAttributeName : searchKey(sender)) {
+            for (String anAttributeName : searchKey(sender, searchFieldIndex)) {
                 EOEntity entity = null;
                 if (sender.dataSource() != null) {
                     entity = EOUtilities.entityNamed(sender.dataSource().editingContext(),
@@ -133,7 +137,7 @@ public class ERMD2WAttributeQueryDelegate {
     private static final NSSelector<?> selector = EOQualifier.QualifierOperatorCaseInsensitiveLike;
 
     @SuppressWarnings("unchecked")
-    private NSArray<String> searchKey(ERMD2WQueryComponent sender) {
+    public NSArray<String> searchKey(ERMD2WQueryComponent sender, int searchFieldIndex) {
         NSArray<String> searchKey = null;
         if (sender.d2wContext().valueForKey("searchKey") == null
                 && sender.dataSource() != null
@@ -150,8 +154,13 @@ public class ERMD2WAttributeQueryDelegate {
         } else if (sender.d2wContext().valueForKey("searchKey") instanceof String) {
             searchKey = new NSArray<String>((String) sender.d2wContext().valueForKey(
                     "searchKey"));
-        } else {
-            searchKey = (NSArray<String>) sender.d2wContext().valueForKey("searchKey");
+        } else if ((sender.d2wContext().valueForKey("searchKey") instanceof NSArray<?>)) {
+            NSArray<?> rawValue = (NSArray<?>) sender.d2wContext().valueForKey("searchKey");
+            if (rawValue.objectAtIndex(0) instanceof NSArray<?>) {
+                searchKey = (NSArray<String>) rawValue.objectAtIndex(searchFieldIndex);
+            } else {
+                searchKey = (NSArray<String>) sender.d2wContext().valueForKey("searchKey");
+            }
         }
         return searchKey;
     }


### PR DESCRIPTION
To use this, set searchKey to an array of arrays of key paths, e.g. "((dateReleased, title), (category), (roles.roleName))" to render three search fields. An ORed qualifier will be generated for each field and then ANDed to form the final qualifier.