### PR TITLE
Make ERMODPickListPage handle batching

### DIFF
--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPickListPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPickListPage.java
@@ -28,6 +28,7 @@ import er.directtoweb.interfaces.ERDPickPageInterface;
 import er.extensions.appserver.ERXDisplayGroup;
 import er.extensions.eof.ERXEC;
 import er.extensions.eof.ERXEOControlUtilities;
+import er.extensions.foundation.ERXArrayUtilities;
 import er.extensions.foundation.ERXValueUtilities;
 
 /**
@@ -191,7 +192,7 @@ public class ERD2WPickListPage extends ERD2WListPage implements ERDPickPageInter
     }
     
     public WOComponent selectAllOnPage() {
-        NSMutableArray selectedObjects = new NSMutableArray();
+        NSMutableArray selectedObjects = selectedObjects().mutableClone();
         NSArray list = displayGroup().displayedObjects();
         for (Enumeration e = list.objectEnumerator(); e.hasMoreElements();) {
             selectedObjects.addObject(e.nextElement());
@@ -205,6 +206,13 @@ public class ERD2WPickListPage extends ERD2WListPage implements ERDPickPageInter
         setSelectedObjects(selectedObjects);
         return context().page();
     }
+    
+    public WOComponent unselectAllOnPage() {
+        NSArray selectedObjects = ERXArrayUtilities.arrayMinusArray(selectedObjects(), displayGroup().displayedObjects());
+        setSelectedObjects(selectedObjects);
+        return context().page();
+    }
+
 
     public boolean singleSelection() {
         if (_singleSelection == null) {

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODPickListPage.wo/ERMODPickListPage.html
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODPickListPage.wo/ERMODPickListPage.html
@@ -9,7 +9,16 @@
       </webobject>
       <webobject name = "RepetitionUpdateContainer">
         <webobject name = "NavBar"> <webobject name = "NavigationBar" /> </webobject>
-        <webobject name = "ListPageRepetition" />
+        <webobject name = "ShowTopBatchCount">
+          <webobject name = "TopNavBatchSize"><webobject name = "BatchSizeControl" /></webobject>
+        </webobject>
+        <webobject name = "ObservationWrapper"><webobject name = "ListPageRepetition" /></webobject>
+          <webobject name = "ShowBottomBatchNavBar">
+            <webobject name = "BottomNavBar"> <webobject name = "NavigationBar" /> </webobject>
+          </webobject>
+          <webobject name = "ShowBottomBatchCount">
+            <webobject name = "BottomNavBatchSize"><webobject name = "BatchSizeControl" /></webobject>
+          </webobject>
       </webobject>
       <webobject name = "ShowBottomActionBlock">
         <webobject name = "BottomActionBlock">

--- a/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODPickListPage.wo/ERMODPickListPage.wod
+++ b/Frameworks/D2W/ERModernLook/Components/Nonlocalized.lproj/ERMODPickListPage.wo/ERMODPickListPage.wod
@@ -49,10 +49,40 @@ HideReturnOnSelect: WOConditional {
 	negate = true;
 }
 
+ObservationWrapper : AjaxObserveField {
+	updateContainerID = idForRepetitionContainer;
+	fullSubmit = true;
+}
+
 ListPageRepetition: WOSwitchComponent {
 	WOComponentName = d2wContext.repetitionComponentName;
 	d2wContext = localContext;
 	displayGroup = displayGroup;
+}
+
+ShowBottomBatchNavBar : WOConditional {
+  condition = d2wContext.showBottomBatchNavBar;
+}
+
+BottomNavBar : WOGenericContainer {
+	elementName = "div";
+	class = d2wContext.classForBottomNavBar;
+}
+
+BottomNavBatchSize : WOGenericContainer {
+	elementName = "div";
+	class = d2wContext.classForBottomBatchSize;
+}
+
+BatchSizeControl : WOSwitchComponent {
+  WOComponentName = d2wContext.batchNavigationSizeComponentName;
+  displayGroup = displayGroup;
+  updateContainerID = idForRepetitionContainer;
+  d2wContext = d2wContext;
+}
+
+ShowBottomBatchCount : WOConditional {
+  condition = d2wContext.showBottomBatchCount;
 }
 
 NavigationBar: WOSwitchComponent {   
@@ -61,6 +91,15 @@ NavigationBar: WOSwitchComponent {
     d2wContext = d2wContext;
 	bgcolor = d2wContext.backgroundColorForTable;
 	WOComponentName = d2wContext.batchNavigationBarComponentName;
+}
+
+ShowTopBatchCount : WOConditional {
+  condition = d2wContext.showTopBatchCount;
+}
+
+TopNavBatchSize : WOGenericContainer {
+	elementName = "div";
+	class = d2wContext.classForTopBatchSize;
 }
 
 PageWrapper: WOSwitchComponent {
@@ -141,6 +180,6 @@ TopActionBlock : WOGenericContainer {
 
 RepetitionUpdateContainer : AjaxUpdateContainer {
 	elementName = "div";
-	id = d2wContext.idForRepetitionContainer;
+	id = idForRepetitionContainer;
 	class = d2wContext.classForInnerWrapper;
 }

--- a/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODPickListPage.java
+++ b/Frameworks/D2W/ERModernLook/Sources/er/modern/look/pages/ERMODPickListPage.java
@@ -1,5 +1,7 @@
 package er.modern.look.pages;
 
+import java.util.UUID;
+
 import com.webobjects.appserver.WOContext;
 
 import er.directtoweb.pages.templates.ERD2WPickListPageTemplate;
@@ -33,5 +35,23 @@ public class ERMODPickListPage extends ERD2WPickListPageTemplate {
 	public ERMODPickListPage(WOContext wocontext) {
 		super(wocontext);
 	}
+ 
+    private String _componentID;
+
+    private String componentID() {
+        if (_componentID == null)
+            _componentID = UUID.randomUUID().toString().replace("-", "_");
+        return _componentID;
+    }
+
+    /**
+     * @return a unique ID for the repetition container
+     */
+    public String idForRepetitionContainer() {
+        String repetitionContainerID = (String) d2wContext().valueForKey("idForRepetitionContainer");
+        repetitionContainerID = repetitionContainerID.concat("_" + componentID());
+        return repetitionContainerID;
+    }
+
 
 }


### PR DESCRIPTION
This also changes the behaviour of the ERD2WPickListPage in that "selectAllOnPage()" now does only add the objects on the page to the existing selection, instead of making the objects on the page the only selected objects as before.