### PR TITLE
Cookie-Directory fix for more than one Wonder application under the same domain

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
@@ -455,8 +455,21 @@ public  class ERXRequest extends WORequest {
         				//
         				// only parse one cookie at a time => get(0)
         				HttpCookie httpCookie = HttpCookie.parse(cookies[i]).get(0);
-        				log.debug("Cookie: '"+httpCookie.getName()+"' = '"+httpCookie.getValue()+"'");
-        				cookieDictionary.setObjectForKey(new NSArray<String>(httpCookie.getValue()), httpCookie.getName());
+        				//
+        				// Cookies with longer paths are listed before cookies with shorter paths:
+        				// see https://stackoverflow.com/a/24214538
+        				// Cookies with longer Patch are more specific than cookies with shorter path 
+        				// and should not be replaced by a less specific cookie 
+        				// If a cookie with Therfore we do not override cookies if there are already there!
+        				String cookieName  = httpCookie.getName();
+        				String cookieValue = httpCookie.getValue();
+        				log.debug("Cookie: '"+cookieName+"' = '"+cookieValue+"'");
+        				NSArray<String> cookieValueArray = cookieDictionary.get(cookieName);
+        				if ( cookieValueArray == null ){
+        					cookieValueArray = new NSArray<>();
+        				}
+        				cookieValueArray = cookieValueArray.arrayByAddingObject(cookieValue);
+        				cookieDictionary.put( cookieName, cookieValueArray );
         			} catch (Throwable t) {
         				log.warn("Unable to parse cookie '"+cookies[i]+"' : "+t.getMessage());
         			}


### PR DESCRIPTION
Fixes a problem which occurs when running more than one Wonder-Application under the same domain. Change is by my colleague Josef Burzler.

Consider the following scenario:
One of the applications (frontend) has set a "/" as path for the session cookie (via Sesson: public String domainForIDCookies(){ return "/"; }) as it uses a lot of Webserver rewrites for nice URLs.
The other application (backend) uses the default path for the session cookie (typ. /cgi-bin/...).
If a user is calling the two applications his browser will store 2 "wosid" cookies: one with Path "/" and one with Patch "/cgi-bin/..."
When sending a request to the application browsers typically put cookies with longer paths before cookies with shorter paths into the "cookie"-Header: https://stackoverflow.com/a/24214538
Unfortunately the path of the cookie is not transmitted.

In the original WORequest class the method _cookieDictionary() was implemented such that the order of the cookies was kept.
The ERXRequest class however only stores the last cookie of the header if the header of the request contains  more than one cookies with the same name (here "wosid").
If you run two applications under the same domain as described the ERXRequest always returned the "wosid"-cookie of the Applikation with the "/"-path. The application with the longer cookie patrh (here the backend) will see the wrong cookie and the user session can not be restored.

To fix this problem the method _cookieDictionary() in ERXRequest was changed such that it returns a NSDictionary which contains all the cookies of the "cookie"-Header in the very order it was recieved.
WORequest.cookieValueForKey wil take the first cookie (with the longest path) and get the most specific (and correct) session cookie.

An alternative solution would be to change the name of the session cookie  by overwriting the WOApplication.application().sessionIdKey() method.
This solution might not be practicable in situations where external services, scripts and code rely on the standrd name "wosid" of the session cookie.