### PR TITLE
Add possibility to disable optionalPropertiesLoader method on ERXProperties class

### DIFF
--- a/Frameworks/Core/ERExtensions/Resources/Properties
+++ b/Frameworks/Core/ERExtensions/Resources/Properties
@@ -17,6 +17,11 @@ er.extensions.ERExtensions.hasLocalization=true
 ## Retain default value
 # er.extensions.ERXProperties.RetainDefaultsEnabled = true
 
+## Enables support for custom properties file lookup. 
+## E.g., Properties.[Framework], Properties.[Framework].[Username], Properties.log4j, and so on. 
+## Disabling this option might reduce the application startup time considerably.
+# er.extensions.ERXProperties.loadOptionalProperties = true
+
 ## Allows you to specify more config files (good luck:)
 # er.extensions.ERXProperties.OptionalConfigurationFiles = (/more/files)
 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXProperties.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXProperties.java
@@ -75,6 +75,8 @@ import er.extensions.net.ERXTcpIp;
  * 
  * @property er.extensions.ERXProperties.RetainDefaultsEnabled
  * @property NSProperties.useLoadtimeAppSpecifics Default is true.
+ * @property er.extensions.ERXProperties.loadOptionalProperties Default is true. When false loads only the standard properties. 
+ * 			 This will improve application startup  time due to not looking for all files repeatedly.
  * 
  * TODO - Neither of these property names are standard. Should be camel-case and proper prefix.
  * 
@@ -1597,7 +1599,10 @@ public class ERXProperties extends Properties implements NSKeyValueCoding {
      *                     <div class="ja">プロジェクト情報 {@link ERXProperties#pathsForUserAndBundleProperties}</div>
      */
     private static void optionalPropertiesLoader(String userName, NSMutableArray<String> propertiesPaths, NSMutableArray<String> projectsInfo) {
-
+    	if(!ERXProperties.booleanForKeyWithDefault("er.extensions.ERXProperties.loadOptionalProperties", true)){
+    		return;
+    	}
+    	
     	/** Properties.log4j.<userName> -- per-Application-per-User properties */
         String logPropertiesPath;
         logPropertiesPath = ERXProperties.variantPropertiesInBundle("log4j", "app");


### PR DESCRIPTION
During a process of improving application startup time was possible to notice that the method optionalPropertiesLoader was taking a lot of time and it has not been used on the project I'm working on.

When enabled this method was called three times taking about 15 seconds each, so disabling it could save about 45 seconds at the startup.