### PR TITLE
Fix build.xml with lib versions

### DIFF
--- a/Build/build/build.xml
+++ b/Build/build/build.xml
@@ -23,11 +23,12 @@
     <property name="framework.erjars.commons.io" value="commons-io-2.6.jar" />
     <property name="framework.erjars.commons.lang" value="commons-lang-2.6.jar" />
     <property name="framework.erjars.commons.lang3" value="commons-lang3-3.7.jar" />
-    <property name="framework.erjars.fluent-hc" value="fluent-hc-4.5.3.jar" />
-    <property name="framework.erjars.httpclient" value="httpclient-4.5.3.jar" />
-    <property name="framework.erjars.httpclient-cache" value="httpclient-cache-4.5.3.jar" />
-    <property name="framework.erjars.httpcore" value="httpcore-4.4.6.jar" />
-    <property name="framework.erjars.httpmime" value="httpmime-4.5.3.jar" />
+    <property name="framework.erjars.fluent-hc" value="fluent-hc-4.5.5.jar" />
+    <property name="framework.erjars.httpclient" value="httpclient-4.5.5.jar" />
+    <property name="framework.erjars.httpclient-cache" value="httpclient-cache-4.5.5.jar" />
+    <property name="framework.erjars.httpcore" value="httpcore-4.4.9.jar" />
+    <property name="framework.erjars.httpcore-nio" value="httpcore-nio-4.4.9.jar" />
+    <property name="framework.erjars.httpmime" value="httpmime-4.5.5.jar" />
     <property name="framework.erjars.icu4j" value="icu4j-3_8_1.jar" />
     <property name="framework.erjars.joda" value="joda-time-2.9.9.jar" />
     <property name="framework.erjars.junit" value="junit-4.12.jar" />
@@ -50,6 +51,7 @@
                         <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.httpclient}" />
                         <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.httpclient-cache}" />
                         <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.httpcore}" />
+                        <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.httpcore-nio}" />
                         <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.httpmime}" />
                         <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.icu4j}" />
                         <available file="Frameworks/Core/ERJars/Libraries/${framework.erjars.joda}" />


### PR DESCRIPTION
Last update broke builds because the versions need to be mentioned in this xml. Boy, this is a fragile setup.