### PR TITLE
Get rid of the ~4.3 GB file size limit of WOAdaptor

### DIFF
--- a/Utilities/Adaptors/Adaptor/config.h
+++ b/Utilities/Adaptors/Adaptor/config.h
@@ -57,7 +57,7 @@ typedef int  intptr_t;
 #define CURRENT_WOF_VERSION_MAJOR	4
 #define CURRENT_WOF_VERSION_MINOR	6
 
-#define ADAPTOR_VERSION			"4.6.3"
+#define ADAPTOR_VERSION			"4.6.4"
 
 /* Used to turn the value of a macro into a string literal */
 #define _Str(x) #x

--- a/Utilities/Adaptors/Adaptor/request.c
+++ b/Utilities/Adaptors/Adaptor/request.c
@@ -70,7 +70,7 @@ void req_free(HTTPRequest *req)
    WOFREE(req);
 }
 
-void req_allocateContent(HTTPRequest *req, unsigned content_length, int allowStreaming)
+void req_allocateContent(HTTPRequest *req, unsigned long content_length, int allowStreaming)
 {
    if (req) {
       req->content_buffer_size = content_length;

--- a/Utilities/Adaptors/Adaptor/request.h
+++ b/Utilities/Adaptors/Adaptor/request.h
@@ -53,7 +53,7 @@ typedef struct _HTTPRequest {
 	void *api_handle;			/* api specific pointer */
 	unsigned long content_length;
 	void *content;
-        unsigned content_buffer_size;
+        unsigned long content_buffer_size;
         req_getMoreContentCallback getMoreContent;
         int haveReadStreamedData;
         int shouldProcessUrl;
@@ -73,7 +73,7 @@ void req_free(HTTPRequest *req);
 /* If allowStreaming is 0, the buffer will be the size specified by content_length. */
 /* If allowStreaming is 1, the buffer may be smaller than content_length. */
 /* Sets content, and content_buffer_size. Either of these should be checked in case the allocation fails. */
-void req_allocateContent(HTTPRequest *req, unsigned content_length, int allowStreaming);
+void req_allocateContent(HTTPRequest *req, unsigned long content_length, int allowStreaming);
 
 /*
  *	convenience for all adaptors, returns error string or null

--- a/Utilities/Adaptors/Adaptor/response.c
+++ b/Utilities/Adaptors/Adaptor/response.c
@@ -234,7 +234,7 @@ HTTPResponse *resp_getResponseHeaders(WOConnection *instanceConnection, WOInstan
          //                 int value = resp->content_length;
          //             can be found in the adaptor source code.  Therefore, we
          //             should better use INT_MAX!
-         resp->content_length = INT_MAX;
+         resp->content_length = LONG_MAX;
          WOLog(WO_WARN, "Response doesn't specify a content-length: assuming %lu bytes!",
                resp->content_length);
       }

--- a/Utilities/Adaptors/Adaptor/response.h
+++ b/Utilities/Adaptors/Adaptor/response.h
@@ -38,9 +38,9 @@ typedef struct _HTTPResponse {
         String *responseStrings;
         void *content;
         unsigned long content_length;
-        unsigned content_buffer_size;
+        unsigned long content_buffer_size;
         unsigned long content_read; /* total amount of data read from the instance */
-        unsigned content_valid; /* amount of valid data in content buffer */
+        unsigned long content_valid; /* amount of valid data in content buffer */
         int (*getMoreContent)(struct _HTTPResponse *resp, void *buffer, int bufferSize);
         
         WOConnection *instanceConnection;

--- a/Utilities/Adaptors/Apache2.4/Makefile
+++ b/Utilities/Adaptors/Apache2.4/Makefile
@@ -16,7 +16,7 @@ ifeq "MACOS" "${OS}"
 # These are the default settings for OSX.
 CFLAGS += -Wall ${RC_CFLAGS}
 LDARCHS = $(patsubst %, -arch %, ${RC_ARCHS})
-LDFLAGS += ${OPENSSL_LIB_FLAGS} ${LDARCHS} -macosx_version_min 10.5 -lm -module
+LDFLAGS += ${OPENSSL_LIB_FLAGS} ${LDARCHS} -lm -module
 STRIP_FLAGS = -S
 endif
 # End MacOS X Specific Settings


### PR DESCRIPTION
Use long instead of int for everything related to content length. Fix tested on macOS and linux with apache 2.4.