### PR TITLE
Again, get rid of the ~4.3 GB file size limit of WOAdaptor

### DIFF
--- a/Utilities/Adaptors/Adaptor/config.h
+++ b/Utilities/Adaptors/Adaptor/config.h
@@ -57,7 +57,7 @@ typedef int  intptr_t;
 #define CURRENT_WOF_VERSION_MAJOR	4
 #define CURRENT_WOF_VERSION_MINOR	6
 
-#define ADAPTOR_VERSION			"4.6.4"
+#define ADAPTOR_VERSION			"4.6.5"
 
 /* Used to turn the value of a macro into a string literal */
 #define _Str(x) #x

--- a/Utilities/Adaptors/Adaptor/request.c
+++ b/Utilities/Adaptors/Adaptor/request.c
@@ -70,7 +70,7 @@ void req_free(HTTPRequest *req)
    WOFREE(req);
 }
 
-void req_allocateContent(HTTPRequest *req, unsigned long content_length, int allowStreaming)
+void req_allocateContent(HTTPRequest *req, long long content_length, int allowStreaming)
 {
    if (req) {
       req->content_buffer_size = content_length;
@@ -168,7 +168,7 @@ const char *req_AddHeader_common(HTTPRequest *req,const char *key,const char *va
     */
    if ((req->content_length == 0) &&
        ((strcasecmp(key, CONTENT_LENGTH) == 0) || (strcasecmp(key, "content_length") == 0)))	/* get content-length */
-       req->content_length = atol(value);
+       req->content_length = atoll(value);
 
 #ifdef DEBUG
        WOLog(WO_DBG,"(req-hdr) %s: %s",key, value);
@@ -263,8 +263,8 @@ int req_sendRequest(HTTPRequest *req, net_fd socket)
    /* Note that we reuse buffers, and the existing content-data buffer. */
    if (req->content_length > req->content_buffer_size)
    {
-      long total_sent = req->content_buffer_size;
-      long len_read, amount_to_read;
+      long long total_sent = req->content_buffer_size;
+      long long len_read, amount_to_read;
       req->haveReadStreamedData = 1;
       while (total_sent < req->content_length)
       {
@@ -362,8 +362,8 @@ int req_sendRequest(HTTPRequest *req, net_fd socket)
    /* Note that we reuse buffers, and the existing content-data buffer. */
    if (req->content_length > req->content_buffer_size)
    {
-      long total_sent = req->content_buffer_size;
-      long len_read, amount_to_read;
+      long long total_sent = req->content_buffer_size;
+      long long len_read, amount_to_read;
       req->haveReadStreamedData = 1;
       while (total_sent < req->content_length && result == 0)
       {

--- a/Utilities/Adaptors/Adaptor/request.h
+++ b/Utilities/Adaptors/Adaptor/request.h
@@ -51,17 +51,15 @@ typedef struct _HTTPRequest {
 	char *request_str;			/* the http request (includes CRLF) */
 	void *headers;				/* (strtbl *) but you don't need to know */
 	void *api_handle;			/* api specific pointer */
-	unsigned long content_length;
+	long long content_length;
 	void *content;
-        unsigned long content_buffer_size;
-        req_getMoreContentCallback getMoreContent;
-        int haveReadStreamedData;
-        int shouldProcessUrl;
+    long long content_buffer_size;
+    req_getMoreContentCallback getMoreContent;
+    int haveReadStreamedData;
+    int shouldProcessUrl;
 #ifdef IIS
         /* for IIS we have to keep track of how much we have read */
-        // 2009/04/27: IIS is using DWORD in the API layer and a DWORD
-        //             is an "unsigned long" value:
-        unsigned long total_len_read;
+    long long total_len_read;
 #endif
 } HTTPRequest;
 
@@ -73,7 +71,7 @@ void req_free(HTTPRequest *req);
 /* If allowStreaming is 0, the buffer will be the size specified by content_length. */
 /* If allowStreaming is 1, the buffer may be smaller than content_length. */
 /* Sets content, and content_buffer_size. Either of these should be checked in case the allocation fails. */
-void req_allocateContent(HTTPRequest *req, unsigned long content_length, int allowStreaming);
+void req_allocateContent(HTTPRequest *req, long long content_length, int allowStreaming);
 
 /*
  *	convenience for all adaptors, returns error string or null

--- a/Utilities/Adaptors/Adaptor/response.h
+++ b/Utilities/Adaptors/Adaptor/response.h
@@ -37,10 +37,10 @@ typedef struct _HTTPResponse {
         /* These Strings get freed along with the response. */
         String *responseStrings;
         void *content;
-        unsigned long content_length;
-        unsigned long content_buffer_size;
-        unsigned long content_read; /* total amount of data read from the instance */
-        unsigned long content_valid; /* amount of valid data in content buffer */
+        long long content_length;
+        long long content_buffer_size;
+        long long content_read; /* total amount of data read from the instance */
+        long long content_valid; /* amount of valid data in content buffer */
         int (*getMoreContent)(struct _HTTPResponse *resp, void *buffer, int bufferSize);
         
         WOConnection *instanceConnection;

--- a/Utilities/Adaptors/IIS/WebObjects.c
+++ b/Utilities/Adaptors/IIS/WebObjects.c
@@ -200,7 +200,7 @@ static void sendResponse(EXTENSION_CONTROL_BLOCK *p, HTTPResponse *resp)
 
          /* resp->content_valid will be 0 for HEAD requests and empty responses */
          if (resp->content_valid) {
-            long count;
+            long long count;
             while (resp->content_read < resp->content_length &&
                    (resp->flags & RESP_LENGTH_INVALID) != RESP_LENGTH_INVALID &&
                    browserStatus == 0) {
@@ -567,7 +567,7 @@ static int readContentData(HTTPRequest *req, void *dataBuffer, int dataSize, int
        length = (char *)WOMALLOC(32);
        if (length)
        {
-          sprintf(length,"%lu",req->content_length);
+          sprintf(length,"%llu",req->content_length);
           req_addHeader(req, CONTENT_LENGTH, length, STR_FREEVALUE);
        }
        if (p->lpszContentType != NULL)


### PR DESCRIPTION
Under Windows, an unsigned long corresponds to a 32bit integer, leaving us stuck with the limit of 4,294,967,295 bytes. So we have to use signed 'long long' for everything related to the content length to get rid of the limit on all platforms. 
This implementation should now handle file sizes of up to 9,223,372,036 GB. Tested on macOS, Linux (Apache 2.4) and Windows (IIS).