### PR TITLE
Fix for ERXRequest.isRequestSecure when deployed as servlet

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRequest.java
@@ -331,7 +331,10 @@ public  class ERXRequest extends WORequest {
         	
 	        String serverPort = request.headerForKey("SERVER_PORT");
 	        if (serverPort == null) {
-	          serverPort = request.headerForKey("x-webobjects-server-port");
+	        	serverPort = request.headerForKey("x-webobjects-servlet-server-port");
+	        }
+	        if (serverPort == null) {
+	        	serverPort = request.headerForKey("x-webobjects-server-port");
 	        }
 	
 	        // Apache and some other web servers use this to indicate HTTPS mode.


### PR DESCRIPTION
ERXRequest.isRequestSecure takes care of header key "x-webobjects-servlet-server-port" (see also com.webobjects.jspservlet._WOApplicationWrapper)