### PR TITLE
Jgroups multicast

### DIFF
--- a/Frameworks/EOF/ERJGroupsSynchronizer/Resources/jgroups-default.xml
+++ b/Frameworks/EOF/ERJGroupsSynchronizer/Resources/jgroups-default.xml
@@ -2,7 +2,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
     <UDP
-         mcast_port="${jgroups.udp.mcast_port:45588}"
+         mcast_addr="${er.extensions.jgroupsSynchronizer.multicastAddress:230.0.0.1}"
+         mcast_port="${er.extensions.jgroupsSynchronizer.multicastPort:9753}"
+         bind_addr="${er.extensions.jgroupsSynchronizer.localBindAddress:SITE_LOCAL}"
          ip_ttl="4"
          tos="8"
          ucast_recv_buf_size="5M"

--- a/Frameworks/EOF/ERJGroupsSynchronizer/Sources/er/jgroups/ERJGroupsSynchronizer.java
+++ b/Frameworks/EOF/ERJGroupsSynchronizer/Sources/er/jgroups/ERJGroupsSynchronizer.java
@@ -31,17 +31,20 @@ import er.extensions.remoteSynchronizer.ERXRemoteSynchronizer;
  * A multicast synchronizer built on top of the JGroups library.  This is a much
  * more robust implementation than the default synchronizer used by ERXObjectStoreCoordinatorSynchronizer.
  * 
+ * See http://www.jgroups.org/manual/index.html#Transport for network transport configuration.
+ * By default in this repositors, jgroups is set up to use multicast with configurable local bind address,
+ * multicast address and multicast port via the jgroups-default.xml file.
+ * 
  * @property er.extensions.ERXObjectStoreCoordinatorPool.maxCoordinators you should set this property to at least "1" to trigger
  *   ERXObjectStoreCoordinatorSynchronizer to turn on
  * @property er.extensions.jgroupsSynchronizer.applicationWillTerminateNotificationName the name of the NSNotification that is sent when
  *   the application is terminating. Leave blank to disable this feature.
  * @property er.extensions.jgroupsSynchronizer.autoReconnect whether to auto reconnect when shunned (defaults to false)
  * @property er.extensions.jgroupsSynchronizer.groupName the JGroups group name to use (defaults to WOApplication.application.name)
- * @property er.extensions.jgroupsSynchronizer.localBindAddress
- * @property er.extensions.jgroupsSynchronizer.multicastAddress the multicast address to use (defaults to 230.0.0.1,
-     and only necessary if you are using multicast)
- * @property er.extensions.jgroupsSynchronizer.multicastPort the multicast port to use (defaults to 9753, and only necessary if you are using multicast)
  * @property er.extensions.jgroupsSynchronizer.properties an XML JGroups configuration file (defaults to jgroups-default.xml in this framework)
+ * @property er.extensions.jgroupsSynchronizer.localBindAddress the local address to bind to when using the provided multicast configuration file (defaults to SITE_LOCAL)
+ * @property er.extensions.jgroupsSynchronizer.multicastAddress the multicast address to use when using the provided multicast configuration file  (defaults to 230.0.0.1)
+ * @property er.extensions.jgroupsSynchronizer.multicastPort the multicast port to use when using the provided multicast configuration file  (defaults to 9753)
  * @property er.extensions.jgroupsSynchronizer.useShutdownHook whether to register a JVM shutdown hook to clean up the JChannel (defaults to true)
  * @property er.extensions.remoteSynchronizer "er.jgroups.ERJGroupsSynchronizer" for this implementation
  * @property er.extensions.remoteSynchronizer.enabled if true, remote synchronization is enabled
@@ -65,15 +68,6 @@ public class ERJGroupsSynchronizer extends ERXRemoteSynchronizer {
 			jgroupsPropertiesFramework = "ERJGroupsSynchronizer";
 		}
 		_groupName = ERXProperties.stringForKeyWithDefault("er.extensions.jgroupsSynchronizer.groupName", WOApplication.application().name());
-
-		String localBindAddressStr = ERXProperties.stringForKey("er.extensions.jgroupsSynchronizer.localBindAddress");
-		if (localBindAddressStr == null) {
-			System.setProperty("bind.address", WOApplication.application().hostAddress().getHostAddress());
-		}
-		else {
-			System.out.println("localBindAddressStr = " + localBindAddressStr);
-			System.setProperty("bind.address", localBindAddressStr);
-		}
 
 		URL propertiesUrl = WOApplication.application().resourceManager().pathURLForResourceNamed(jgroupsPropertiesFile, jgroupsPropertiesFramework, null);
 		_channel = new JChannel(propertiesUrl);

--- a/Frameworks/EOF/ERJGroupsSynchronizer/Sources/er/jgroups/ERJGroupsSynchronizer.java
+++ b/Frameworks/EOF/ERJGroupsSynchronizer/Sources/er/jgroups/ERJGroupsSynchronizer.java
@@ -71,7 +71,7 @@ public class ERJGroupsSynchronizer extends ERXRemoteSynchronizer {
 
 		URL propertiesUrl = WOApplication.application().resourceManager().pathURLForResourceNamed(jgroupsPropertiesFile, jgroupsPropertiesFramework, null);
 		_channel = new JChannel(propertiesUrl);
-		_channel.setDiscardOwnMessages(Boolean.FALSE);
+		_channel.setDiscardOwnMessages(Boolean.TRUE);
 
 		_registerForCleanup();
 	}


### PR DESCRIPTION
Fixes three issues we had with with jgroups multicast after migrating to wonder 7:

1. The Properties used to configure multicast Address and Port were only used in the old configuration file which was replaced during the jgroups 3.6 update. The properties had no effect anymore.
2. The Property ...localBindAddress was used to set the system property bind.address which had no effect on our system. Moved it into the configuration file as well.
3. All messages sent by one instance were received by the the same instance as well (Potentially causing an IllegalStateException - we didn't dig deeper to verify)