### PR TITLE
Adapted ExcelGenerator and ERExcelLook

### DIFF
--- a/Examples/Misc/ERComponentTour/Components/ExcelGeneratedPage.wo/ExcelGeneratedPage.html
+++ b/Examples/Misc/ERComponentTour/Components/ExcelGeneratedPage.wo/ExcelGeneratedPage.html
@@ -18,6 +18,10 @@
 		<td class="bold">2.2</td>
 		<td cellType="CELL_TYPE_FORMULA" class="bold">sum(A1:A99)</td>
 	</tr>
+	<tr>
+		<td cellType="CELL_TYPE_STRING" class="everythingElse">Foo</td>
+		<td cellType="CELL_TYPE_STRING">Bar</td>
+	</tr>
 </table>
 <table name="Sheet 2" class="default">
 	<tr>

--- a/Examples/Misc/ERComponentTour/Resources/ExcelStyles.plist
+++ b/Examples/Misc/ERComponentTour/Resources/ExcelStyles.plist
@@ -17,12 +17,12 @@ Fonts:
 Styles:
     id="foo"
     font="someFontID"
-    alignment="ALIGN_GENERAL|ALIGN_LEFT|ALIGN_CENTER|ALIGN_RIGHT"
-    verticalAlignment="VERTICAL_TOP|VERTICAL_CENTER|VERTICAL_BOTTOM|VERTICAL_JUSTIFY"
+    alignment="GENERAL|LEFT|CENTER|RIGHT"
+    verticalAlignment="TOP|CENTER|BOTTOM|JUSTIFY"
     borderLeft_borderRight_borderTop_borderBottom=
-            "BORDER_NONE|BORDER_THIN|BORDER_MEDIUM|BORDER_DASHED|BORDER_HAIR|BORDER_DOUBLE|BORDER_DOTTED|
-                    BORDER_MEDIUM_DASHED|BORDER_DASH_DOT|BORDER_MEDIUM_DASH_DOT|BORDER_DASH_DOT_DOT|
-                    BORDER_MEDIUM_DASH_DOT_DOT|BORDER_SLANTED_DASH_DOT"
+            "NONE|THIN|MEDIUM|DASHED|HAIR|DOUBLE|DOTTED|
+                    MEDIUM_DASHED|DASH_DOT|MEDIUM_DASH_DOT|DASH_DOT_DOT|
+                    MEDIUM_DASH_DOT_DOT|SLANTED_DASH_DOT"
     leftBorderColor_rightBorderColor_topBorderColor_bottomBorderColor="0-xx"
     fillPattern="NO_FILL|SOLID_FOREGROUND|FINE_DOTS|ALT_BARS|SPARSE_DOTS|THICK_HORZ_BANDS|THICK_VERT_BANDS|THICK_BACKWARD_DIAG|
             THICK_FORWARD_DIAG|BIG_SPOTS|BRICKS|THIN_HORZ_BANDS|THIN_VERT_BANDS|THIN_BACKWARD_DIAG|THIN_FORWARD_DIAG|SQUARES|DIAMONDS"
@@ -47,11 +47,17 @@ Styles:
     "Styles" = {
         "default" = {
             font="default";
-            alignment="ALIGN_RIGHT";
+            alignment="RIGHT";
         };
         "bold" = {
             font="bold";
-            alignment="ALIGN_LEFT";
+            alignment="LEFT";
+        };
+        "everythingElse" = {
+        	font = "default";
+        	alignment="RIGHT";
+        	fillPattern="SPARSE_DOTS";
+        	borderTop="DASHED";
         };
     };
 }

--- a/Frameworks/Excel/ERExcelLook/Resources/Styles.plist
+++ b/Frameworks/Excel/ERExcelLook/Resources/Styles.plist
@@ -17,12 +17,12 @@ Fonts:
 Styles:
     id="foo"
     font="someFontID"
-    alignment="ALIGN_GENERAL|ALIGN_LEFT|ALIGN_CENTER|ALIGN_RIGHT"
-    verticalAlignment="VERTICAL_TOP|VERTICAL_CENTER|VERTICAL_BOTTOM|VERTICAL_JUSTIFY"
+    alignment="GENERAL|LEFT|CENTER|RIGHT"
+    verticalAlignment="TOP|CENTER|BOTTOM|JUSTIFY"
     borderLeft_borderRight_borderTop_borderBottom=
-            "BORDER_NONE|BORDER_THIN|BORDER_MEDIUM|BORDER_DASHED|BORDER_HAIR|BORDER_DOUBLE|BORDER_DOTTED|
-                    BORDER_MEDIUM_DASHED|BORDER_DASH_DOT|BORDER_MEDIUM_DASH_DOT|BORDER_DASH_DOT_DOT|
-                    BORDER_MEDIUM_DASH_DOT_DOT|BORDER_SLANTED_DASH_DOT"
+            "NONE|THIN|MEDIUM|DASHED|HAIR|DOUBLE|DOTTED|
+                    MEDIUM_DASHED|DASH_DOT|MEDIUM_DASH_DOT|DASH_DOT_DOT|
+                    MEDIUM_DASH_DOT_DOT|SLANTED_DASH_DOT"
     leftBorderColor_rightBorderColor_topBorderColor_bottomBorderColor="0-xx"
     fillPattern="NO_FILL|SOLID_FOREGROUND|FINE_DOTS|ALT_BARS|SPARSE_DOTS|THICK_HORZ_BANDS|THICK_VERT_BANDS|THICK_BACKWARD_DIAG|
             THICK_FORWARD_DIAG|BIG_SPOTS|BRICKS|THIN_HORZ_BANDS|THIN_VERT_BANDS|THIN_BACKWARD_DIAG|THIN_FORWARD_DIAG|SQUARES|DIAMONDS"
@@ -47,11 +47,11 @@ Styles:
     "Styles" = {
         "default" = {
             font="default";
-            alignment="ALIGN_RIGHT";
+            alignment="RIGHT";
         };
         "bold" = {
             font="bold";
-            alignment="ALIGN_LEFT";
+            alignment="LEFT";
             wrapText="true";
         };
     };

--- a/Frameworks/Excel/ExcelGenerator/.classpath
+++ b/Frameworks/Excel/ExcelGenerator/.classpath
@@ -7,7 +7,7 @@
 	<classpathentry exported="true" kind="con" path="WOFramework/JavaWebObjects"/>
 	<classpathentry exported="true" kind="con" path="WOFramework/JavaXML"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry exported="true" kind="lib" path="Libraries/poi-3.17.jar" sourcepath="/var/folders/9g/fbpw8rp13mv3bng8msrzs18w0000gn/T/.org.sf.feeling.decompiler1538989030348/source/poi-3.17-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="Libraries/poi-3.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="Libraries/poi-excelant-3.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="Libraries/poi-ooxml-3.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="Libraries/poi-ooxml-schemas-3.17.jar"/>

--- a/Frameworks/Excel/ExcelGenerator/.classpath
+++ b/Frameworks/Excel/ExcelGenerator/.classpath
@@ -7,7 +7,7 @@
 	<classpathentry exported="true" kind="con" path="WOFramework/JavaWebObjects"/>
 	<classpathentry exported="true" kind="con" path="WOFramework/JavaXML"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry exported="true" kind="lib" path="Libraries/poi-3.17.jar"/>
+	<classpathentry exported="true" kind="lib" path="Libraries/poi-3.17.jar" sourcepath="/var/folders/9g/fbpw8rp13mv3bng8msrzs18w0000gn/T/.org.sf.feeling.decompiler1538989030348/source/poi-3.17-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="Libraries/poi-excelant-3.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="Libraries/poi-ooxml-3.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="Libraries/poi-ooxml-schemas-3.17.jar"/>

--- a/Frameworks/Excel/ExcelGenerator/Documentation/Read Me_ja.txt
+++ b/Frameworks/Excel/ExcelGenerator/Documentation/Read Me_ja.txt
@@ -34,10 +34,10 @@ table はシートになります。後は各エレメントがセルになり�
 			sum(C1:C3)
 	
 alignment
-			alignment = "ALIGN_GENERAL"
-			alignment = "ALIGN_LEFT"
-			alignment = "ALIGN_CENTER"
-			alignment = "ALIGN_RIGHT"
+			alignment = "GENERAL"
+			alignment = "LEFT"
+			alignment = "CENTER"
+			alignment = "RIGHT"
 	
 borderLeft
 borderTop
@@ -83,11 +83,11 @@ fillPattern
 class="default"		
             name="Arial";
             fontHeightInPoints="10";
-            alignment="ALIGN_RIGHT";
+            alignment="RIGHT";
             
 class="bold"
             name="Arial Black";
-            alignment="ALIGN_LEFT";
+            alignment="LEFT";
 
 次には画面で確認が完了されているページを Excel に出力するには EGWrapper で囲みます。
 

--- a/Frameworks/Excel/ExcelGenerator/Resources/Codes.plist
+++ b/Frameworks/Excel/ExcelGenerator/Resources/Codes.plist
@@ -30,76 +30,76 @@
     
     style = {
         alignment = (
-            ALIGN_GENERAL,
-            ALIGN_LEFT,
-            ALIGN_CENTER,
-            ALIGN_RIGHT
+            GENERAL,
+            LEFT,
+            CENTER,
+            RIGHT
         );
         verticalAligment = (
-            VERTICAL_TOP,
-            VERTICAL_CENTER,
-            VERTICAL_BOTTOM,
-            VERTICAL_JUSTIFY
+            TOP,
+            CENTER,
+            BOTTOM,
+            JUSTIFY
         );
         borderLeft = (
-            BORDER_NONE,
-            BORDER_THIN,
-            BORDER_MEDIUM,
-            BORDER_DASHED,
-            BORDER_HAIR,
-            BORDER_DOUBLE,
-            BORDER_DOTTED,
-            BORDER_MEDIUM_DASHED,
-            BORDER_DASH_DOT,
-            BORDER_MEDIUM_DASH_DOT,
-            BORDER_DASH_DOT_DOT,
-            BORDER_MEDIUM_DASH_DOT_DOT,
-            BORDER_SLANTED_DASH_DOT
+            NONE,
+            THIN,
+            MEDIUM,
+            DASHED,
+            HAIR,
+            DOUBLE,
+            DOTTED,
+            MEDIUM_DASHED,
+            DASH_DOT,
+            MEDIUM_DASH_DOT,
+            DASH_DOT_DOT,
+            MEDIUM_DASH_DOT_DOT,
+            SLANTED_DASH_DOT
         );
         borderTop = (
-            BORDER_NONE,
-            BORDER_THIN,
-            BORDER_MEDIUM,
-            BORDER_DASHED,
-            BORDER_HAIR,
-            BORDER_DOUBLE,
-            BORDER_DOTTED,
-            BORDER_MEDIUM_DASHED,
-            BORDER_DASH_DOT,
-            BORDER_MEDIUM_DASH_DOT,
-            BORDER_DASH_DOT_DOT,
-            BORDER_MEDIUM_DASH_DOT_DOT,
-            BORDER_SLANTED_DASH_DOT
+            NONE,
+            THIN,
+            MEDIUM,
+            DASHED,
+            HAIR,
+            DOUBLE,
+            DOTTED,
+            MEDIUM_DASHED,
+            DASH_DOT,
+            MEDIUM_DASH_DOT,
+            DASH_DOT_DOT,
+            MEDIUM_DASH_DOT_DOT,
+            SLANTED_DASH_DOT
         );
         borderRight = (
-            BORDER_NONE,
-            BORDER_THIN,
-            BORDER_MEDIUM,
-            BORDER_DASHED,
-            BORDER_HAIR,
-            BORDER_DOUBLE,
-            BORDER_DOTTED,
-            BORDER_MEDIUM_DASHED,
-            BORDER_DASH_DOT,
-            BORDER_MEDIUM_DASH_DOT,
-            BORDER_DASH_DOT_DOT,
-            BORDER_MEDIUM_DASH_DOT_DOT,
-            BORDER_SLANTED_DASH_DOT
+            NONE,
+            THIN,
+            MEDIUM,
+            DASHED,
+            HAIR,
+            DOUBLE,
+            DOTTED,
+            MEDIUM_DASHED,
+            DASH_DOT,
+            MEDIUM_DASH_DOT,
+            DASH_DOT_DOT,
+            MEDIUM_DASH_DOT_DOT,
+            SLANTED_DASH_DOT
         );
         borderBottom= (
-            BORDER_NONE,
-            BORDER_THIN,
-            BORDER_MEDIUM,
-            BORDER_DASHED,
-            BORDER_HAIR,
-            BORDER_DOUBLE,
-            BORDER_DOTTED,
-            BORDER_MEDIUM_DASHED,
-            BORDER_DASH_DOT,
-            BORDER_MEDIUM_DASH_DOT,
-            BORDER_DASH_DOT_DOT,
-            BORDER_MEDIUM_DASH_DOT_DOT,
-            BORDER_SLANTED_DASH_DOT
+            NONE,
+            THIN,
+            MEDIUM,
+            DASHED,
+            HAIR,
+            DOUBLE,
+            DOTTED,
+            MEDIUM_DASHED,
+            DASH_DOT,
+            MEDIUM_DASH_DOT,
+            DASH_DOT_DOT,
+            MEDIUM_DASH_DOT_DOT,
+            SLANTED_DASH_DOT
         );
         fillPattern = (
             NO_FILL,

--- a/Frameworks/Excel/ExcelGenerator/Sources/er/excel/EGSimpleTableParser.java
+++ b/Frameworks/Excel/ExcelGenerator/Sources/er/excel/EGSimpleTableParser.java
@@ -18,13 +18,17 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFRichTextString;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.DataFormat;
+import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.VerticalAlignment;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,8 +51,8 @@ import er.extensions.foundation.ERXKeyValueCodingUtilities;
 
 
 /**
- * Parses an input stream for tables and converts them into excel 
- * sheets. You must have a surrounding element as there is only one 
+ * Parses an input stream for tables and converts them into excel
+ * sheets. You must have a surrounding element as there is only one
  * root element in XML allowed.
  * <blockquote>
  * Eg:<code>&lt;div&gt;&lt;table 1&gt;&lt;table 2&gt;...&lt;/div&gt;</code>
@@ -59,7 +63,7 @@ import er.extensions.foundation.ERXKeyValueCodingUtilities;
  * font and style dictionaries in the constructor or via &lt;style&gt; and &lt;font&gt; tags.
  * The tags are shown in the example, but mainly the attributes are named the same as the properties
  * of the {@link org.apache.poi.hssf.usermodel.HSSFCellStyle HSSFCellStyle} and {@link org.apache.poi.hssf.usermodel.HSSFFont HSSFFont}
- * objects. The symbolic names from theses classes (eg. <code>ALIGN_RIGHT</code>) are also supported.
+ * objects. The symbolic names from theses classes (eg. <code>HorizontalAlignment.RIGHT</code>) are also supported.
  * In addition, the tags <em>must</em> have an <code>id</code> attribute and can specify an
  * <code>extends</code> attribute that contains the ID of the style that is extended - all properties from this
  * style and it's predecessors are copied to the current style.
@@ -69,10 +73,10 @@ import er.extensions.foundation.ERXKeyValueCodingUtilities;
  * The value is copied as text from the cell's content, so you better take care that it is parsable
  * and matches the <code>cellStyle</code> and <code>cellFormat</code> definition.
  * <p>
- * The parser also supports the <code>some-name</code> attribute names in addition to 
- * <code>someName</code> as using the <b>Reformat</b> command in WOBuilder messes up the case 
- * of the tags. When used in .wod files, the attributes must be enclosed in quotes 
- * (<code>"cell-type"=foo;</code>). Some care must be taken when the attributes in the current node override the ones 
+ * The parser also supports the <code>some-name</code> attribute names in addition to
+ * <code>someName</code> as using the <b>Reformat</b> command in WOBuilder messes up the case
+ * of the tags. When used in .wod files, the attributes must be enclosed in quotes
+ * (<code>"cell-type"=foo;</code>). Some care must be taken when the attributes in the current node override the ones
  * from the parent as this is not thoroughly tested.
  * <p>
  * A client would use this class like:
@@ -142,7 +146,7 @@ public class EGSimpleTableParser {
             if (result == null || result.length() == 0) {
                 result = defaultValue;
             }
-		}    
+		}
 		return result;
 	}
     
@@ -207,7 +211,7 @@ public class EGSimpleTableParser {
         }
 		if(result == null) {
 			result = defaultValue;
-		}    
+		}
 		return result;
 	}
     
@@ -225,18 +229,10 @@ public class EGSimpleTableParser {
     	}
     }
     
-    private void takeClassValueForKey(NSDictionary dict, String key, Object target, String defaultValue) {
-    	String value = dictValueForKey(dict, key, defaultValue);
-    	if(value != null) {
-   			Number number = (Number)ERXKeyValueCodingUtilities.classValueForKey(target.getClass(), value);
-			NSKeyValueCoding.Utility.takeValueForKey(target, number, key);
-    	}
-    }
-    
     private void takeClassValueForKey(NSDictionary dict, String key, Object target, Class source, String defaultValue) {
     	String value = dictValueForKey(dict, key, defaultValue);
     	if(value != null) {
-   			Number number = (Number)ERXKeyValueCodingUtilities.classValueForKey(source, value);
+   			Object number = ERXKeyValueCodingUtilities.classValueForKey(source, value);
 			NSKeyValueCoding.Utility.takeValueForKey(target, number, key);
     	}
     }
@@ -373,7 +369,7 @@ public class EGSimpleTableParser {
     						&& ("td".equals(cellNode.getLocalName().toLowerCase())
     								|| "th".equals(cellNode.getLocalName().toLowerCase()))) {
     					int currentColumnNumber = row.getPhysicalNumberOfCells();
-						Cell cell = row.createCell(currentColumnNumber); 
+						Cell cell = row.createCell(currentColumnNumber);
     					Object value = null;
     					if(cellNode.getFirstChild() != null) {
     	   					value = cellNode.getFirstChild().getNodeValue();
@@ -572,14 +568,14 @@ public class EGSimpleTableParser {
     		takeNumberValueForKey(dict, "indention", cellStyle, null);
     		takeNumberValueForKey(dict, "rotation", cellStyle, null);
     		
-    		takeClassValueForKey(dict, "borderLeft", cellStyle, CellStyle.class, null);
-    		takeClassValueForKey(dict, "borderRight", cellStyle, CellStyle.class, null);
-    		takeClassValueForKey(dict, "borderTop", cellStyle, CellStyle.class, null);
-    		takeClassValueForKey(dict, "borderBottom", cellStyle, CellStyle.class, null);
+    		takeClassValueForKey(dict, "borderLeft", cellStyle, BorderStyle.class, null);
+    		takeClassValueForKey(dict, "borderRight", cellStyle, BorderStyle.class, null);
+    		takeClassValueForKey(dict, "borderTop", cellStyle, BorderStyle.class, null);
+    		takeClassValueForKey(dict, "borderBottom", cellStyle, BorderStyle.class, null);
     		
-    		takeClassValueForKey(dict, "fillPattern", cellStyle, CellStyle.class, null);
-    		takeClassValueForKey(dict, "alignment", cellStyle, CellStyle.class, null);
-    		takeClassValueForKey(dict, "verticalAlignment", cellStyle, CellStyle.class, null);
+    		takeClassValueForKey(dict, "fillPattern", cellStyle, FillPatternType.class, null);
+    		takeClassValueForKey(dict, "alignment", cellStyle, HorizontalAlignment.class, null);
+    		takeClassValueForKey(dict, "verticalAlignment", cellStyle, VerticalAlignment.class, null);
     		
     		String formatString = dictValueForKey(dict, "format", null);
     		if(formatString != null) {


### PR DESCRIPTION
With commit 34b653f40c9407ef3f058234ea5a92e1b74fd944, we updated Apache POI from version 3.14 to 3.17, not realizing that this included the removal of several fields that were deprecated before and now have been removed and reorganized. Those fields are accessed via KVC, so there was no compile error, and the frameworks include no tests to cover this.

This change adapts these two frameworks to use the new constants. Further testing by people that actually use these would be appreciated.