### PR TITLE
Prevent a NPE in javascript if erxToolTip.hide() is called when no

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/ajaxHoverable.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/ajaxHoverable.js
@@ -96,8 +96,10 @@ var erxToolTip=function(){
 		}
 	},
 	hide:function(){
-		clearInterval(tt.timer);
-		tt.timer = setInterval(function(){erxToolTip.fade(-1)},timer);
+		if(tt != null){
+			clearInterval(tt.timer);
+			tt.timer = setInterval(function(){erxToolTip.fade(-1)},timer);
+		}
 	}
 	};
 }();


### PR DESCRIPTION
tooltips has been displayed.