### PR TITLE
Fix deadlock in WOAdaptor

### DIFF
--- a/Utilities/Adaptors/Adaptor/config.h
+++ b/Utilities/Adaptors/Adaptor/config.h
@@ -57,7 +57,7 @@ typedef int  intptr_t;
 #define CURRENT_WOF_VERSION_MAJOR	4
 #define CURRENT_WOF_VERSION_MINOR	6
 
-#define ADAPTOR_VERSION			"4.6.5"
+#define ADAPTOR_VERSION			"4.6.6"
 
 /* Used to turn the value of a macro into a string literal */
 #define _Str(x) #x


### PR DESCRIPTION
The locking function in WOAdaptor can run into a deadlock situation. I did observe this happening in Apache 2.4 during shut down (process cycling). 
My proposed fix gives up after 10000 tries. As all callers do check for success on this method, this should be a fair solution to the problem. After fixing this, my Apache installation was running fine, no more dead locks so far.