### PR TITLE
Fix ERXRedirect problem with component

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRedirect.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRedirect.java
@@ -226,6 +226,9 @@ public class ERXRedirect extends WOComponent {
 	 */
 	public void setComponent(WOComponent component) {
 		_component = component;
+		// Make sure appendToResponse is called before the page is accessed with the generated URL that trigger an invokeAction.
+		// This fix problems when the page need to initialize or refresh internal state, especially for arrays in repetition. 
+		component.generateResponse();
 	}
 
 	/**


### PR DESCRIPTION
Make sure appendToResponse is called before the page is accessed with the generated URL that trigger an invokeAction.

This fix problems when the page need to initialize or refresh internal state, especially for arrays in repetition. In normal usage, append to response is always called in the response before invoke action in the next request but the ERXRedirect behaviour skipped this step.