### PR TITLE
JavaMail session configuration via JNDI

### DIFF
--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -6,6 +6,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
 import com.webobjects.eocontrol.EOEnterpriseObject;
 import com.webobjects.eocontrol.EOOrQualifier;
 import com.webobjects.eocontrol.EOQualifier;
@@ -42,6 +45,8 @@ import er.extensions.validation.ERXValidationFactory;
  * @property er.javamail.emailPattern
  * @property er.javamail.WhiteListEmailAddressPatterns
  * @property er.javamail.BlackListEmailAddressPatterns
+ * @property er.javamail.sessionConfigViaJNDI
+ * @property er.javamail.jndiSessionContext
  * 
  * @author <a href="mailto:tuscland@mac.com">Camille Troillard</a>
  * @author <a href="mailto:maxmuller@mac.com">Max Muller</a>
@@ -315,7 +320,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 * @return <code>javax.mail.Session</code> 値 </span>
 	 */
 	public javax.mail.Session newSession() {
-		return newSession(System.getProperties());
+		return newSessionForContext(null);
 	}
 
 	/**
@@ -341,24 +346,46 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * Returns a new Session object that is appropriate for the given context.
 	 * 
+	 * If the property <code>er.javamail.sessionConfigViaJNDI</code> is set to <code>true</code> the JNDI is used to lookup the session informations. 
+	 * You may change the default JNDI context with the property <code>er.javamail.jndiSessionContext</code>
+	 * 
 	 * @param contextString
 	 *            the message context
 	 * @return a new <code>javax.mail.Session</code> value
 	 */
 	protected javax.mail.Session newSessionForContext(String contextString) {
-		javax.mail.Session session;
-		if (contextString == null || contextString.length() == 0) {
-			session = newSessionForContext(System.getProperties(), contextString);
+		javax.mail.Session session = null;
+		
+		boolean jndiLookup = ERXProperties.booleanForKeyWithDefault("er.javamail.sessionConfigViaJNDI", false);
+		String jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext", "java:comp/env/mail");
+		if(jndiLookup) {
+			if(contextString != null) {
+				jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext."+contextString, jndiContextString);
+			}
+			
+			try {
+				log.info("try to get javax.mail.Session for " + jndiContextString);
+				InitialContext ic = new InitialContext();
+				session = (javax.mail.Session)ic.lookup(jndiContextString);
+			} catch (NamingException e) {
+				log.error("Failed to initialize JavaMail Session: " + e.getMessage());
+			}
+	
 		}
 		else {
-			Properties sessionProperties = new Properties();
-			sessionProperties.putAll(System.getProperties());
-			setupSmtpProperties(sessionProperties, contextString);
-			session = newSessionForContext(sessionProperties, contextString);
+			if (contextString == null || contextString.length() == 0) {
+				session = newSessionForContext(System.getProperties(), contextString);
+			}
+			else {
+				Properties sessionProperties = new Properties();
+				sessionProperties.putAll(System.getProperties());
+				setupSmtpProperties(sessionProperties, contextString);
+				session = newSessionForContext(sessionProperties, contextString);
+			}
 		}
 		return session;
 	}
-
+	
 	/**
 	 * Returns a newly allocated Session object from the given Properties
 	 * 

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -53,12 +53,12 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 		setUpFrameworkPrincipalClass(ERJavaMail.class);
 	}
 
-	/**
-	 * <span class="en"> ERJavaMail class singleton. </span>
-	 * 
-	 * <span class="ja"> シングルトン・クラス </span>
+	/*
+	 * Lazy initialisation, see Effective Java, Item 71
 	 */
-	protected static ERJavaMail sharedInstance;
+	private static class SharedInstanceHolder {
+		private static final ERJavaMail singelton = ERXFrameworkPrincipal.sharedInstance(ERJavaMail.class);
+	}
 
 	/**
 	 * <span class="en"> Accessor to the ERJavaMail singleton.
@@ -69,11 +69,8 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 * 
 	 * @return <code>ERJavaMail</code> インスタンス </span>
 	 */
-	public static synchronized ERJavaMail sharedInstance() {
-		if (sharedInstance == null) {
-			sharedInstance = ERXFrameworkPrincipal.sharedInstance(ERJavaMail.class);
-		}
-		return sharedInstance;
+	public static ERJavaMail sharedInstance() {
+		return SharedInstanceHolder.singelton;
 	}
 
 	/**

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -357,14 +357,14 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 		javax.mail.Session session = null;
 		
 		boolean jndiLookup = ERXProperties.booleanForKeyWithDefault("er.javamail.sessionConfigViaJNDI", false);
-		String jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext", "java:comp/env/mail");
 		if(jndiLookup) {
+			String jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext", "java:comp/env/mail");
 			if(contextString != null) {
 				jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext."+contextString, jndiContextString);
 			}
 			
 			try {
-				log.info("try to get javax.mail.Session for " + jndiContextString);
+				if(log.isDebugEnabled()) log.debug("try to get javax.mail.Session for JNDI context " + jndiContextString);
 				InitialContext ic = new InitialContext();
 				session = (javax.mail.Session)ic.lookup(jndiContextString);
 			} catch (NamingException e) {

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDelivery.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDelivery.java
@@ -4,6 +4,7 @@
 
 package er.javamail;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import javax.activation.DataHandler;
@@ -19,7 +20,6 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMessage.RecipientType;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,7 +111,7 @@ public abstract class ERMailDelivery {
 	private NSDictionary<String, Object> _userInfo;
 	private String _contextString;
 
-	public static final String DefaultCharset = System.getProperty("er.javamail.defaultEncoding", CharEncoding.UTF_8);
+	public static final String DefaultCharset = System.getProperty("er.javamail.defaultEncoding", StandardCharsets.UTF_8.name());
 	public String _charset = DefaultCharset;
 
 	/** Designated constructor */

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDeliveryComponentBased.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDeliveryComponentBased.java
@@ -36,7 +36,7 @@ public abstract class ERMailDeliveryComponentBased extends ERMailDelivery {
 	 * ではセッションが新しく、必要な情報がないことになります。
 	 * </div>
 	 */
-	protected NSDictionary _sessionDictionary = NSDictionary.EmptyDictionary;
+	protected NSDictionary<String, Object> _sessionDictionary = NSDictionary.emptyDictionary();
 
 	/** 
 	 * <div class="en">
@@ -73,12 +73,12 @@ public abstract class ERMailDeliveryComponentBased extends ERMailDelivery {
 	}
 
 	/** Accessor for the sessionDictionary property */
-	public NSDictionary sessionDictionary() {
+	public NSDictionary<String, Object> sessionDictionary() {
 		return _sessionDictionary;
 	}
 
 	/** Accessor for the sessionDictionary property */
-	public void setSessionDictionary(NSDictionary dict) {
+	public void setSessionDictionary(NSDictionary<String, Object> dict) {
 		_sessionDictionary = dict;
 	}
 

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailUtils.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailUtils.java
@@ -79,7 +79,7 @@ public class ERMailUtils {
 	 * @return <div class="en">a newly instantiated <code>WOComponent</code>.</div>
 	 *         <div class="ja">新規のインスタンス済み <code>WOComponent</code></div>
 	 */
-	public static WOComponent instantiatePage(String pageName, NSDictionary sessionDict) {
+	public static WOComponent instantiatePage(String pageName, NSDictionary<String, Object> sessionDict) {
 		WOComponent component = ERXApplication.instantiatePage(pageName);
 		if (sessionDict != null) {
 			setDictionaryValuesInSession(sessionDict, component.session());
@@ -197,14 +197,14 @@ public class ERMailUtils {
 	 * @param session <div class="en">a <code>WOSession</code> value that will receive the values contained in the dict parameter.</div>
 	 *                <div class="ja">ディクショナリー内に設定されている値をセットする <code>WOSession</code></div>
 	 */
-	public static void setDictionaryValuesInSession(NSDictionary dict, WOSession session) {
+	public static void setDictionaryValuesInSession(NSDictionary<String, Object> dict, WOSession session) {
 		if ((dict == null) || (session == null)) {
 			return;
 		}
 
-		Enumeration en = dict.keyEnumerator();
+		Enumeration<String> en = dict.keyEnumerator();
 		while (en.hasMoreElements()) {
-			String key = (String) en.nextElement();
+			String key = en.nextElement();
 			Object object = dict.objectForKey(key);
 			if (object != null) {
 				log.debug("Setting in session dict value '{}' for key '{}'", object, key);
@@ -245,14 +245,14 @@ public class ERMailUtils {
 	 * @exception AddressException <div class="en">if an error occurs</div>
 	 *                             <div class="ja">エラー発生した場合</div>
 	 */
-	public static InternetAddress[] convertNSArrayToInternetAddresses(NSArray addrs) throws AddressException {
+	public static InternetAddress[] convertNSArrayToInternetAddresses(NSArray<String> addrs) throws AddressException {
 		if (addrs == null)
 			return new InternetAddress[0];
 		InternetAddress[] addrArray = new InternetAddress[addrs.count()];
 
-		Enumeration en = addrs.objectEnumerator();
+		Enumeration<String> en = addrs.objectEnumerator();
 		for (int i = 0; en.hasMoreElements(); i++) {
-			String anAddress = (String) en.nextElement();
+			String anAddress = en.nextElement();
 			addrArray[i] = new InternetAddress(anAddress);
 		}
 

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailUtils.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailUtils.java
@@ -37,16 +37,12 @@ import er.extensions.appserver.ERXApplication;
 public class ERMailUtils {
 	private static final Logger log = LoggerFactory.getLogger(ERMailUtils.class);
 
-	/** 
-	 * <div class="en">
-	 * The shared mail deliverer
-	 * </div>
-	 * 
-	 * <div class="ja">
-	 * メール配信の共有インスタンス 
-	 * </div>
+	/*
+	 * Lazy initialisation, see Effective Java, Item 71
 	 */
-	private static ERMailDeliveryHTML sharedDeliverer;
+	private static class ERMailDeliveryHTMLHolder {
+		private static final ERMailDeliveryHTML sharedDeliverer = ERMailDeliveryHTML.newMailDelivery();
+	}
 
 	/**
 	 * <div class="en">
@@ -61,11 +57,7 @@ public class ERMailUtils {
 	 *         <div class="ja"><code>ERMailDeliveryHTML</code> シングルトン</div>
 	 */
 	public static ERMailDeliveryHTML sharedDeliverer() {
-		if (sharedDeliverer == null) {
-			sharedDeliverer = ERMailDeliveryHTML.newMailDelivery();
-		}
-
-		return sharedDeliverer;
+		return ERMailDeliveryHTMLHolder.sharedDeliverer;
 	}
 
 	/**

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERWOMailDelivery.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERWOMailDelivery.java
@@ -48,6 +48,11 @@ import com.webobjects.foundation.NSArray;
  */
 
 public class ERWOMailDelivery {
+	
+	private static class ERWOMailDeliveryHolder {
+		private static final ERWOMailDelivery sharedInstance = new ERWOMailDelivery();
+	}
+
 	/** 
 	 * <div class="en">
 	 * @return The shared instance. 
@@ -58,9 +63,7 @@ public class ERWOMailDelivery {
 	 * </div>
 	 */
 	public static ERWOMailDelivery sharedInstance() {
-		if (_sharedInstance == null)
-			_sharedInstance = new ERWOMailDelivery();
-		return _sharedInstance;
+		return ERWOMailDeliveryHolder.sharedInstance;
 	}
 
 	/** 
@@ -213,7 +216,6 @@ public class ERWOMailDelivery {
 
 	// Private Implementation.
 	private static final Logger log = LoggerFactory.getLogger(ERWOMailDelivery.class);
-	private static ERWOMailDelivery _sharedInstance = null;
 
 	private MimeMessage newMimeMessage(String fromEmailAddress, NSArray<String> toEmailAddresses, NSArray<String> bccEmailAddresses, String subject, String message, String contentType, boolean sendNow) {
 		// /JAssert.notEmpty( fromEmailAddress );


### PR DESCRIPTION
For J2EE deployments, you may now configure the JavaMail session via JNDI. To activate this feature, set the property _er.javamail.sessionConfigViaJNDI_ to _true_.  You may override the property _er.javamail.jndiSessionContext_ to match the mail context defined in the application server.

I also did some code cleanup in ERJavaMail.