### PR TITLE
Fix FrontBase assembleSelectStatementWithAttributes() with joins

### DIFF
--- a/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
+++ b/Frameworks/PlugIns/FrontBasePlugIn/Sources/com/webobjects/jdbcadaptor/_FrontBasePlugIn.java
@@ -1427,6 +1427,7 @@ public class _FrontBasePlugIn extends JDBCPlugIn {
 			String fieldString;
 			if (_alreadyJoined.count() > 0) {
 				fieldString = joinClauseString();
+				joinClause = null;
 			}
 			else {
 				fieldString = tableList;


### PR DESCRIPTION
Fix a problem when using assembleSelectStatementWithAttributes() with FrontBase with table joins to keep it compatible with other plugins.

If the current code is used, the sql92 join clause generated by assembleJoinClause() passed to assembleSelectStatementWithAttributes() is present in 2 places in the final SQL like this:
```
FROM "InventaireProduit" t0 INNER JOIN "Produit" T1 ON t0."fidProduit" = T1."idProduit"
WHERE "InventaireProduit" t0 INNER JOIN "Produit" T1 ON t0."fidProduit" = T1."idProduit"
```
With this fixe, it is removed from the WHERE part.