### PR TITLE
Fix ERXQuery with FrontBase

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
@@ -271,7 +271,7 @@ public class ERXQuery {
 	/** 
 	 * <a href="http://wiki.wocommunity.org/display/documentation/Wonder+Logging">new org.slf4j.Logger</a> 
 	 */
-	private static final Logger log = LoggerFactory.getLogger(ERXQuery.class);
+	static final Logger log = LoggerFactory.getLogger(ERXQuery.class);
 	
 	protected EOEditingContext editingContext;
 	protected EOEntity mainEntity;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
@@ -461,10 +461,11 @@ public class ERXQuery {
 				for (Object e : iterable) {
 					groupBy(e);
 				}
-			} else {
+			} else if (obj != null) {
 				throw new RuntimeException(getClass().getSimpleName() 
 						+ "'s groupBy() does not accept instances of " 
-						+ obj.getClass().getName());
+						+ obj.getClass().getName() + ". Only String, ERXKey, EOAttribute "
+								+ "or collection of them are valid.");
 			}
 		}
 		return this;
@@ -490,10 +491,11 @@ public class ERXQuery {
 				for (Object o : iterable) {
 					orderBy(o);
 				}
-			} else {
+			} else if (obj != null) {
 				throw new RuntimeException(getClass().getSimpleName() 
 						+ "'s orderBy() does not accept instances of " 
-						+ obj.getClass().getName());
+						+ obj.getClass().getName() + ". Only String, ERXKey, EOAttribute "
+						+ "or collection of them are valid.");
 			}
 		}
 		return this;


### PR DESCRIPTION
Fix the SQL generation to support the FB sql92 joins. This fix require the pr896 already merged.

This also fix a problem during relationship substitution with database plugin that does not support operation during an operation like FB that raised the error "no database channel is available".

groupBy and orderBy method where also enhanced to handle null arguments and better report exceptions.

Thank to @rparada for help and tests with his apps.

The generated SQL was 
```
	SELECT COUNT(*), t0."fidProduit" 
	FROM "InventaireProduit" t0, "Produit" T1 
	WHERE "InventaireProduit" t0 INNER JOIN "Produit" T1 ON t0."fidProduit" = T1."idProduit" AND (T1."typeProduit" = 2 AND t0."tsReception" >= TIMESTAMP '2018-12-01 05:00:00.000')
```
The fixed version is 
```
	SELECT COUNT(*), t0."fidProduit" 
	FROM "InventaireProduit" t0 INNER JOIN "Produit" T1 ON t0."fidProduit" = T1."idProduit" 
	WHERE (T1."typeProduit" = 2 AND t0."tsReception" >= TIMESTAMP '2019-01-17 05:00:00.000')
	GROUP BY
		t0."fidProduit"
```