### PR TITLE
Fix accessing static webresources for mavenized builds

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
@@ -158,15 +158,25 @@ public class ERXStaticResourceRequestHandler extends WORequestHandler {
 					path = URLDecoder.decode(path, CharEncoding.UTF_8);
 				}
 
-				URLConnection uc = new URL(path).openConnection();
-				if(uc instanceof JarURLConnection)
+				file = new File(path);
+
+				if(path.startsWith("jar:"))
 				{
-					length = (int)uc.getContentLengthLong();
+					URLConnection uc = new URL(path).openConnection();
+					if(uc instanceof JarURLConnection)
+					{
+						length = (int)uc.getContentLengthLong();
+					} else
+					{
+						length = -1;						
+					}
+					is = uc.getInputStream();
+					
 				} else
 				{
-					length = -1;						
+					length = (int) file.length();
+					is = new FileInputStream(file);
 				}
-				is = uc.getInputStream();
 				
 				contentType = rm.contentTypeForResourceNamed(path);
 				log.debug("Reading file '{}' for uri: {}", file, uri);

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
@@ -4,7 +4,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URL;
 import java.net.URLDecoder;
+import java.net.URLConnection;
 
 import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
@@ -99,7 +102,7 @@ public class ERXStaticResourceRequestHandler extends WORequestHandler {
 	@Override
 	public WOResponse handleRequest(WORequest request) {
 		WOResponse response = null;
-		FileInputStream is = null;
+		InputStream is = null;
 		long length = 0;
 		String contentType = null;
 		String uri = request.uri();
@@ -154,9 +157,16 @@ public class ERXStaticResourceRequestHandler extends WORequestHandler {
 					path = path.replace('+', ' ');
 					path = URLDecoder.decode(path, CharEncoding.UTF_8);
 				}
-				file = new File(path);
-				length = file.length();
-				is = new FileInputStream(file);
+
+				URLConnection uc = new URL(path).openConnection();
+				if(uc instanceof JarURLConnection)
+				{
+					length = (int)uc.getContentLengthLong();
+				} else
+				{
+					length = -1;						
+				}
+				is = uc.getInputStream();
 				
 				contentType = rm.contentTypeForResourceNamed(path);
 				log.debug("Reading file '{}' for uri: {}", file, uri);


### PR DESCRIPTION
As @hugith confirmed in the mailing list, the ERXStaticResourceRequestHandler does not support static resource references to resources inside a jar (as is being used with maven builds).

There is a solution with @hprange as alternative requestHandler, that you would have to register explicitly (JarResourceRequestHandler in https://gist.github.com/hprange/1068523).

This pull request extends the current ERXStaticResourceRequestHandler to be able to serve both (from WebServerResources folder or from within jar)