### PR TITLE
Added missing break in switch statement for case “oracle”

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
@@ -1861,6 +1861,7 @@ public class ERXQuery {
 		case "oracle":
 			// See http://docs.oracle.com/cd/B19306_01/server.102/b14200/functions183.htm
 			formattedValue = "TO_DATE('" + formattedValue + "', 'YYYY-MM-DD HH24:MI:SS')";
+			break;
 		case "postgresql":
 			// See https://www.postgresql.org/docs/7.4/static/functions-formatting.html
 			formattedValue = "TO_DATE('" + formattedValue + "', 'YYYY-MM-DD HH24:MI:SS')";


### PR DESCRIPTION
ERXQuery fix for formatting of date values for inline use with the ORACLE adaptor.

There was a break missing in the switch statement for case "oracle".  I ran into this bug when testing with ORACLE today and using inline bindings.