### PR TITLE
Autocomplete with prototype 1.7.3

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxAutoComplete.wo/AjaxAutoComplete.html
+++ b/Frameworks/Ajax/Ajax/Components/AjaxAutoComplete.wo/AjaxAutoComplete.html
@@ -3,7 +3,7 @@
 	<webobject name = "ShowItem">
 		<webobject name = "TextField" />
 		<webobject name = "HasIndicator"><webobject name = "Indicator" /></webobject>
-		<webobject name = "ZIndexContainer"> <webobject name = "AutoCompleteContainer" /> </webobject>
+		<webobject name = "AutoCompleteContainer"><webobject name = "ZIndexContainer" /></webobject>
 		<script>
 			Event.observe(window, 'load', function() {
 				var div = $('<webobject name = "ZIndexContainerName" />');

--- a/Frameworks/Ajax/Ajax/Components/AjaxAutoComplete.wo/AjaxAutoComplete.html
+++ b/Frameworks/Ajax/Ajax/Components/AjaxAutoComplete.wo/AjaxAutoComplete.html
@@ -1,1 +1,16 @@
-<webobject name = "Disabled"><webobject name = "TextField" /></webobject><webobject name = "NotDisabled">  <webobject name = "ShowItem">    <webobject name = "TextField" />    <webobject name="HasIndicator"><webobject name="Indicator"/></webobject>    <webobject name = "ZIndexContainer"> <webobject name = "AutoCompleteContainer"/> </webobject>    <script>      Event.observe(window, 'load', function() {        	    var div = $('<webobject name = "ZIndexContainerName"/>');        	    <webobject name="hasContainerId">        	      document.getElementById('<webobject name="containerId"/>').appendChild(div);        	    </webobject>        	    <webobject name="else">           	      document.getElementsByTagName('body')[0].appendChild(div);           	    </webobject>      });    </script>  </webobject>  <webobject name = "ShowList"><webobject name = "Content" /></webobject></webobject>
+<webobject name = "Disabled"><webobject name = "TextField" /></webobject>
+<webobject name = "NotDisabled">
+	<webobject name = "ShowItem">
+		<webobject name = "TextField" />
+		<webobject name = "HasIndicator"><webobject name = "Indicator" /></webobject>
+		<webobject name = "ZIndexContainer"> <webobject name = "AutoCompleteContainer" /> </webobject>
+		<script>
+			Event.observe(window, 'load', function() {
+				var div = $('<webobject name = "ZIndexContainerName" />');
+				<webobject name = "hasContainerId">document.getElementById('<webobject name = "containerId" />').appendChild(div);</webobject>
+				<webobject name = "else">document.getElementsByTagName('body')[0].appendChild(div);</webobject>
+			});    
+		</script>
+	</webobject>
+	<webobject name = "ShowList"><webobject name = "Content" /></webobject>
+</webobject>


### PR DESCRIPTION
Change nesting of containers in AjaxAutocomplete component so prototype 1.7.3 renders drop-down menu in the correct position. Unfortunately it is not backwardly compatible with old versions of prototype.
Also adds "observe" functionality so AjaxAutocomplete can submit to server when item is selected in drop-down menu (needed because AjaxObserveField doesn't work with AjaxAutocomplete).