### PR TITLE
Add deprecated method back to ERMemoryAdaptorChannel

### DIFF
--- a/Frameworks/EOAdaptors/JavaMemoryAdaptor/Sources/er/memoryadaptor/ERMemoryAdaptorChannel.java
+++ b/Frameworks/EOAdaptors/JavaMemoryAdaptor/Sources/er/memoryadaptor/ERMemoryAdaptorChannel.java
@@ -35,6 +35,19 @@ public class ERMemoryAdaptorChannel extends EOAdaptorChannel {
     super(context);
     _fetchIndex = -1;
   }
+  
+  // HP: Even though this method is deprecated in the superclass {@code EOAdaptorChannel}, it's still referenced
+  // across the WebObjects and Wonder frameworks. For instance, the following methods depend on its implementation:
+  // 
+  // - AdaptorChannel.primaryKeysForNewRowsWithEntity
+  // - ERXEOControlUtilities.newPrimaryKeyDictionaryForEntityNamed
+  // 
+  // It might be tempting to remove a deprecated method, but is this case, please, don't. :) 
+  @Override
+  @Deprecated
+  public NSDictionary primaryKeyForNewRowWithEntity(EOEntity entity) {
+    return adaptorContext()._newPrimaryKey(null, entity);
+  }
 
   @Override
   public ERMemoryAdaptorContext adaptorContext() {


### PR DESCRIPTION
The method `primaryKeyForNewRowWithEntity` was accidentally removed from the `ERMemoryAdaptorChannel` class by the pull request #610. We need to add it back. Otherwise, code that still depends on it will fail.