### PR TITLE
Fix an ERXNumberFormater problem with zero and patterns like 0.00000000

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/formatters/ERXNumberFormatter.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/formatters/ERXNumberFormatter.java
@@ -218,6 +218,9 @@ public class ERXNumberFormatter extends NSNumberFormatter {
         }
         String filteredString = new String(filteredChars, 0, count);
         Object result = super.parseObject(filteredString);
+        if (result instanceof BigDecimal && ((BigDecimal) result).signum() == 0) {
+        	result = BigDecimal.ZERO;
+        }
         if(result instanceof Number && _operator != null) {
         	BigDecimal newValue = null;
         	if(result instanceof BigDecimal) {


### PR DESCRIPTION
Fix a problem where ERXNumberFormater returns a BigDecimal with scientific notation when parsing a zero value using a patterns with multiple zero decimal place like this one "0.00000000" that use tu return "0E-8". The returned value is not usable with the same formater that fail to format it back.

This is very bad using an AJaxInPlaceEditor that parse-format-parse when displaying values, the app stall in an infinite loop.