### PR TITLE
replace blacklist and whitelist with denylist and allowlist in ERJava…

### DIFF
--- a/Frameworks/Core/ERJavaMail/Documentation/README.txt
+++ b/Frameworks/Core/ERJavaMail/Documentation/README.txt
@@ -78,14 +78,14 @@ The X-Mailer header to put into all outgoing mail messages. Defaults to nothing.
 er.javamail.defaultEncoding = UTF-8
 The default character encoding to use for message content.  Defaults to ???.
 
-er.javamail.WhiteListEmailAddressPatterns = 
-A comma-separated list of whitelisted email address patterns.  If set, then only addresses that match one of the whitelisted 
+er.javamail.AllowEmailAddressPatterns = 
+A comma-separated list of allowed email address patterns.  If set, then only addresses that match one of the allowed 
 patterns will delivered to.  Pattern syntax is the same as EOQualifier's caseInsensitiveLike.
 
-er.javamail.BlackListEmailAddressPatterns =
-A comma-separated list of blacklisted email address patterns.  If set, then any email addresses that match a blacklist pattern 
-will not be delivered to.  Pattern syntax is the same as EOQualifier's caseInsensitiveLike. The blacklist filter is processed 
-last, so a blacklist pattern beats a whitelist pattern.
+er.javamail.DenyEmailAddressPatterns =
+A comma-separated list of disallowed email address patterns.  If set, then any email addresses that match a disallowed pattern 
+will not be delivered to.  Pattern syntax is the same as EOQualifier's caseInsensitiveLike. The disallowed filter is processed 
+last, so a disallowed pattern beats a allowed pattern.
 
 CODE SAMPLE
 - - - - - - 
@@ -212,14 +212,14 @@ Don't hesitate to send {postcards, feedback, love letters} to Camille Troillard 
 ## セットされている場合にはホワイト・リストに含まれるメールしか送信されません。
 ## パタン・シンタクスは EOQualifier caseInsensitiveLike 同様
 ## この場合には次の様に追加します：
-@property # er.javamail.WhiteListEmailAddressPatterns=("*@mycompany.com", "somebody@mac.com")
+@property # er.javamail.AllowEmailAddressPatterns=("*@mycompany.com", "somebody@mac.com")
 
 ## 送信したくないアドレスがある場合にはブラック・リストを使用できます。
 ## コンマ区切りされているメールアドレス・パタンのブラック・リスト
 ## セットされているアドレスへはメール送信されません。
 ## パタン・シンタクスは EOQualifier caseInsensitiveLike 同様
 ## ブラック・リスト・パタンは最後に処理されるので、ホワイト・リストよりも優先です。
-@property # er.javamail.BlackListEmailAddressPatterns=("*@baddomain.com", "badperson@mycompany.com")
+@property # er.javamail.DenyEmailAddressPatterns=("*@baddomain.com", "badperson@mycompany.com")
 
 ## SMTP 又は SMTPS を使用するかどうか
 ## 基本的にはここで指定する必要がありません。 

--- a/Frameworks/Core/ERJavaMail/Resources/Properties
+++ b/Frameworks/Core/ERJavaMail/Resources/Properties
@@ -45,14 +45,14 @@ er.javamail.milliSecondsWaitIfSenderOverflowed = 6000
 # Used to set a default X-Mailer
 #er.javamail.mailer.XMailerHeader = 
 
-# White and black email address patterns
+# Allow and deny email address patterns
 # This can be useful in testing when say
 # you only want to allow emails to be sent to *@mycompany.com
 # In this case you would add:
-# er.javamail.WhiteListEmailAddressPatterns=("*@mycompany.com", "somebody@mac.com")
+# er.javamail.AllowEmailAddressPatterns=("*@mycompany.com", "somebody@mac.com")
 
-# To prevent sending mail to certain addresses you can use the black list
-# er.javamail.BlackListEmailAddressPatterns=("*@baddomain.com", "badperson@mycompany.com")
+# To prevent sending mail to certain addresses you can use the deny list
+# er.javamail.DenyEmailAddressPatterns=("*@baddomain.com", "badperson@mycompany.com")
 
 
 # * The port to use with the smtp server, if not set, defaults to 25

--- a/Frameworks/Core/ERJavaMail/Resources/_Properties_ja
+++ b/Frameworks/Core/ERJavaMail/Resources/_Properties_ja
@@ -51,14 +51,14 @@ er.javamail.milliSecondsWaitIfSenderOverflowed = 6000
 ## セットされている場合にはホワイト・リストに含まれるメールしか送信されません。
 ## パタン・シンタクスは EOQualifier caseInsensitiveLike 同様
 ## この場合には次の様に追加します：
-# er.javamail.WhiteListEmailAddressPatterns=("*@mycompany.com", "somebody@mac.com")
+# er.javamail.AllowEmailAddressPatterns=("*@mycompany.com", "somebody@mac.com")
 
 ## 送信したくないアドレスがある場合にはブラック・リストを使用できます。
 ## コンマ区切りされているメールアドレス・パタンのブラック・リスト
 ## セットされているアドレスへはメール送信されません。
 ## パタン・シンタクスは EOQualifier caseInsensitiveLike 同様
 ## ブラック・リスト・パタンは最後に処理されるので、ホワイト・リストよりも優先です。
-# er.javamail.BlackListEmailAddressPatterns=("*@baddomain.com", "badperson@mycompany.com")
+# er.javamail.DenyEmailAddressPatterns=("*@baddomain.com", "badperson@mycompany.com")
 
 ## SMTP 送信ポート
 ## セットされていない場合には 25 が使用されます。

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -841,15 +841,14 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 * 
 	 * @return ブラック・リスト・メールアドレス配列パターン </span>
 	 */
-	@SuppressWarnings("unchecked")
 	public NSArray<String> blackListEmailAddressPatterns() {
 		if (denyEmailAddressPatterns == null) {
 			if (ERXProperties.hasKey("er.javamail.BlackListEmailAddressPatterns") && !ERXProperties.hasKey("er.javamail.DenyEmailAddressPatterns")) {
 				log.warn("Please update your properties settings to use \"er.javamail.DenyEmailAddressPatterns\" instead of \"er.javamail.BlackListEmailAddressPatterns\". blackListEmailAddressPatterns() and associated properties will be removed from future versions.");
-				denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.BlackListEmailAddressPatterns", NSArray.EmptyArray);
+				denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.BlackListEmailAddressPatterns", NSArray.emptyArray());
 			}
 			else {
-				denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.DenyEmailAddressPatterns", NSArray.EmptyArray);
+				denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.DenyEmailAddressPatterns", NSArray.emptyArray());
 			}
 		}
 		return denyEmailAddressPatterns;
@@ -863,10 +862,9 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 *         <span class="ja"> TODO: update Japanese documentation ブラック・リスト・メールアドレス配列パターンを戻します。
 	 * @return ブラック・リスト・メールアドレス配列パターン </span>
 	 */
-	@SuppressWarnings("unchecked")
 	public NSArray<String> denyEmailAddressPatterns() {
 		if (denyEmailAddressPatterns == null) {
-			denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.DenyEmailAddressPatterns", NSArray.EmptyArray);
+			denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.DenyEmailAddressPatterns", NSArray.emptyArray());
 		}
 		return denyEmailAddressPatterns;
 	}

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -736,7 +736,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * <span class="en"> Determines if a list of allowed email address patterns has been specified
 	 * 
-	 * @deprecated hasWhiteList() will be removed in future versions. Pleae use {@link hasAllowList()} instead
+	 * @deprecated hasWhiteList() will be removed in future versions. Pleae use {@link ERJavaMail#hasAllowList()} instead
 	 * @return if the allow list has any elements in it </span>
 	 * 
 	 *         <span class="ja"> ホワイト・リストがあるかどうかを戻します。
@@ -764,7 +764,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * <span class="en"> Determines if a list of email patterns to deny has been specified
 	 * 
-	 * @deprecated hasBlackList() will be removed from future versions. Please use {@link hasDenyList()} instead
+	 * @deprecated hasBlackList() will be removed from future versions. Please use {@link ERJavaMail#hasDenyList()} instead
 	 * @return if the deny list has any elements in it </span>
 	 * 
 	 *         <span class="ja"> ブラック・リストがあるかどうかを戻します。
@@ -792,7 +792,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * <span class="en"> Gets the array of allowed email address patterns.
 	 * 
-	 * @deprecated This method will be removed in future versions. Please use {@link allowEmailAddressPatterns()}
+	 * @deprecated This method will be removed in future versions. Please use {@link ERJavaMail#allowEmailAddressPatterns()}
 	 * @return array of allowed email address patterns </span>
 	 * 
 	 *         <span class="ja"> ホワイト・リスト・メールアドレス配列パターンを戻します。
@@ -834,7 +834,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * <span class="en"> Gets the array of denied email address patterns.
 	 * 
-	 * @deprecated This will be removed from future versions. Please use {@link denyEmailAddressPatterns}
+	 * @deprecated This will be removed from future versions. Please use {@link ERJavaMail#denyEmailAddressPatterns}
 	 * @return array of denied email address patterns </span>
 	 * 
 	 *         <span class="ja"> TODO: update Japanese documentation ブラック・リスト・メールアドレス配列パターンを戻します。
@@ -874,7 +874,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * <span class="en"> {@link EOOrQualifier} qualifier to match any of the patterns in the allow list.
 	 * 
-	 * @deprecated whiteListQualifier() will be removed in future versions. Please use {@link allowListQualifier()}
+	 * @deprecated whiteListQualifier() will be removed in future versions. Please use {@link ERJavaMail#allowQualifier()}
 	 *             instead.
 	 * @return Or qualifier for the allow list </span> <span class="ja"> ホワイト・リスト内でマッチするパタンのホワイト・リスト Or qualifier
 	 * 

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -43,8 +43,8 @@ import er.extensions.validation.ERXValidationFactory;
  * @property mail.[smtpProtocol].password
  * @property mail.smtps.socketFactory.fallback
  * @property er.javamail.emailPattern
- * @property er.javamail.WhiteListEmailAddressPatterns
- * @property er.javamail.BlackListEmailAddressPatterns
+ * @property er.javamail.AllowEmailAddressPatterns
+ * @property er.javamail.DenyEmailAddressPatterns
  * @property er.javamail.sessionConfigViaJNDI
  * @property er.javamail.jndiSessionContext
  * 
@@ -79,8 +79,8 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	}
 
 	/**
-	 * <span class="en"> <code>EMAIL_VALIDATION_PATTERN</code> is a regexp pattern that is used to validate emails.
-	 * </span>
+	 * <span class="en"> <code>EMAIL_VALIDATION_PATTERN</code> is a regexp pattern that is used to validate
+	 * emails. </span>
 	 * 
 	 * <span class="ja"> <code>EMAIL_VALIDATION_PATTERN</code> はメールアドレスの検証のための Regex パタン </span>
 	 */
@@ -346,8 +346,9 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	/**
 	 * Returns a new Session object that is appropriate for the given context.
 	 * 
-	 * If the property <code>er.javamail.sessionConfigViaJNDI</code> is set to <code>true</code> the JNDI is used to lookup the session informations. 
-	 * You may change the default JNDI context with the property <code>er.javamail.jndiSessionContext</code>
+	 * If the property <code>er.javamail.sessionConfigViaJNDI</code> is set to <code>true</code> the JNDI is used to
+	 * lookup the session informations. You may change the default JNDI context with the property
+	 * <code>er.javamail.jndiSessionContext</code>
 	 * 
 	 * @param contextString
 	 *            the message context
@@ -355,22 +356,24 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 */
 	protected javax.mail.Session newSessionForContext(String contextString) {
 		javax.mail.Session session = null;
-		
+
 		boolean jndiLookup = ERXProperties.booleanForKeyWithDefault("er.javamail.sessionConfigViaJNDI", false);
-		if(jndiLookup) {
+		if (jndiLookup) {
 			String jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext", "java:comp/env/mail");
-			if(contextString != null) {
-				jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext."+contextString, jndiContextString);
+			if (contextString != null) {
+				jndiContextString = ERXProperties.stringForKeyWithDefault("er.javamail.jndiSessionContext." + contextString, jndiContextString);
 			}
-			
+
 			try {
-				if(log.isDebugEnabled()) log.debug("try to get javax.mail.Session for JNDI context " + jndiContextString);
+				if (log.isDebugEnabled())
+					log.debug("try to get javax.mail.Session for JNDI context " + jndiContextString);
 				InitialContext ic = new InitialContext();
-				session = (javax.mail.Session)ic.lookup(jndiContextString);
-			} catch (NamingException e) {
+				session = (javax.mail.Session) ic.lookup(jndiContextString);
+			}
+			catch (NamingException e) {
 				log.error("Failed to initialize JavaMail Session: " + e.getMessage());
 			}
-	
+
 		}
 		else {
 			if (contextString == null || contextString.length() == 0) {
@@ -385,7 +388,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 		}
 		return session;
 	}
-	
+
 	/**
 	 * Returns a newly allocated Session object from the given Properties
 	 * 
@@ -698,114 +701,221 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	}
 
 	// ===========================================================================
-	// Black and White list email address filtering support
-	// メール・フィルター：　ホワイト＆ブラック・リスト
+	// Deny and Allow email address filtering support
+	// メール・フィルター： ホワイト＆ブラック・リスト
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * <span class="en"> holds the array of white list email addresses </span>
+	 * <span class="en"> holds the array of allowed email addresses </span>
 	 * 
 	 * <span class="ja"> ホワイト・リスト・メールアドレス配列を保持 </span>
 	 */
-	protected NSArray<String> whiteListEmailAddressPatterns;
+	protected NSArray<String> allowEmailAddressPatterns;
 
 	/**
-	 * <span class="en"> holds the array of black list email addresses </span>
+	 * <span class="en"> holds the array of denied email addresses </span>
 	 * 
 	 * <span class="ja"> ブラック・リスト・メールアドレス配列を保持 </span>
 	 */
-	protected NSArray<String> blakListEmailAddressPatterns;
+	protected NSArray<String> denyEmailAddressPatterns;
 
 	/**
-	 * <span class="en"> holds the white list qualifier </span>
+	 * <span class="en"> holds the allow list qualifier </span>
 	 * 
 	 * <span class="ja"> ホワイト・リスト qualifier を保持 </span>
 	 */
-	protected EOOrQualifier whiteListQualifier;
+	protected EOOrQualifier allowQualifier;
 
 	/**
-	 * <span class="en"> holds the black list qualifier </span>
+	 * <span class="en"> holds the deny list qualifier </span>
 	 * 
 	 * <span class="ja"> ブラック・リスト qualifier を保持 </span>
 	 */
-	protected EOOrQualifier blackListQualifier;
+	protected EOOrQualifier denyQualifier;
 
 	/**
-	 * <span class="en"> Determines if a white list has been specified
+	 * <span class="en"> Determines if a list of allowed email address patterns has been specified
 	 * 
-	 * @return if the white list has any elements in it </span>
+	 * @deprecated hasWhiteList() will be removed in future versions. Pleae use {@link hasAllowList()} instead
+	 * @return if the allow list has any elements in it </span>
 	 * 
 	 *         <span class="ja"> ホワイト・リストがあるかどうかを戻します。
 	 * 
 	 * @return ホワイト・リストがある場合には true が戻ります。 </span>
 	 */
+	@Deprecated
 	public boolean hasWhiteList() {
-		return whiteListEmailAddressPatterns().count() > 0;
+		return hasAllowList();
 	}
 
 	/**
-	 * <span class="en"> Determines if a black list has been specified
+	 * <span class="en"> Determines if a list of allowed email address patterns has been specified
 	 * 
-	 * @return if the black list has any elements in it </span>
+	 * @return if the allow list has any elements in it </span>
+	 * 
+	 *         <span class="ja"> ホワイト・リストがあるかどうかを戻します。
+	 * 
+	 * @return ホワイト・リストがある場合には true が戻ります。 </span>
+	 */
+	public boolean hasAllowList() {
+		return allowEmailAddressPatterns().count() > 0;
+	}
+
+	/**
+	 * <span class="en"> Determines if a list of email patterns to deny has been specified
+	 * 
+	 * @deprecated hasBlackList() will be removed from future versions. Please use {@link hasDenyList()} instead
+	 * @return if the deny list has any elements in it </span>
 	 * 
 	 *         <span class="ja"> ブラック・リストがあるかどうかを戻します。
 	 * 
 	 * @return ブラック・リストがある場合には true が戻ります。 </span>
 	 */
+	@Deprecated
 	public boolean hasBlackList() {
-		return blackListEmailAddressPatterns().count() > 0;
+		return hasDenyList();
 	}
 
 	/**
-	 * <span class="en"> Gets the array of white list email address patterns.
+	 * <span class="en"> Determines if a list of email patterns to deny has been specified
 	 * 
-	 * @return array of white list email address patterns </span>
+	 * @return if the deny list has any elements in it </span>
+	 * 
+	 *         <span class="ja"> ブラック・リストがあるかどうかを戻します。
+	 * 
+	 * @return ブラック・リストがある場合には true が戻ります。 </span>
+	 */
+	public boolean hasDenyList() {
+		return denyEmailAddressPatterns().count() > 0;
+	}
+
+	/**
+	 * <span class="en"> Gets the array of allowed email address patterns.
+	 * 
+	 * @deprecated This method will be removed in future versions. Please use {@link allowEmailAddressPatterns()}
+	 * @return array of allowed email address patterns </span>
 	 * 
 	 *         <span class="ja"> ホワイト・リスト・メールアドレス配列パターンを戻します。
 	 * 
 	 * @return ホワイト・リスト・メールアドレス配列パターン </span>
 	 */
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	public NSArray<String> whiteListEmailAddressPatterns() {
-		if (whiteListEmailAddressPatterns == null) {
-			whiteListEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.WhiteListEmailAddressPatterns", NSArray.EmptyArray);
+		if (allowEmailAddressPatterns == null) {
+			if (ERXProperties.hasKey("er.javamail.WhiteListEmailAddressPatterns") && !ERXProperties.hasKey("er.javamail.AllowEmailAddressPatterns")) {
+				log.warn("Please update your properties settings to use \"er.javamail.AllowEmailAddressPatterns\" instead of \"er.javamail.WhiteListEmailAddressPatterns\". whiteListEmailAddressPatterns() and associated properties will be removed from future versions.");
+				allowEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.WhiteListEmailAddressPatterns", NSArray.EmptyArray);
+			}
+			else {
+				allowEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.AllowEmailAddressPatterns", NSArray.EmptyArray);
+			}
 		}
-		return whiteListEmailAddressPatterns;
+		return allowEmailAddressPatterns;
 	}
 
 	/**
-	 * <span class="en"> Gets the array of black list email address patterns.
+	 * <span class="en"> Gets the array of allowed email address patterns.
 	 * 
-	 * @return array of black list email address patterns </span>
+	 * @return array of allowed email address patterns </span>
 	 * 
-	 *         <span class="ja"> ブラック・リスト・メールアドレス配列パターンを戻します。
+	 *         <span class="ja"> TODO: update the japanese documentation ホワイト・リスト・メールアドレス配列パターンを戻します。
+	 * 
+	 * @return ホワイト・リスト・メールアドレス配列パターン </span>
+	 */
+	@SuppressWarnings("unchecked")
+	public NSArray<String> allowEmailAddressPatterns() {
+		if (allowEmailAddressPatterns == null) {
+			allowEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.AllowEmailAddressPatterns", NSArray.EmptyArray);
+		}
+		return allowEmailAddressPatterns;
+	}
+
+	/**
+	 * <span class="en"> Gets the array of denied email address patterns.
+	 * 
+	 * @deprecated This will be removed from future versions. Please use {@link denyEmailAddressPatterns}
+	 * @return array of denied email address patterns </span>
+	 * 
+	 *         <span class="ja"> TODO: update Japanese documentation ブラック・リスト・メールアドレス配列パターンを戻します。
 	 * 
 	 * @return ブラック・リスト・メールアドレス配列パターン </span>
 	 */
 	@SuppressWarnings("unchecked")
 	public NSArray<String> blackListEmailAddressPatterns() {
-		if (blakListEmailAddressPatterns == null) {
-			blakListEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.BlackListEmailAddressPatterns", NSArray.EmptyArray);
+		if (denyEmailAddressPatterns == null) {
+			if (ERXProperties.hasKey("er.javamail.BlackListEmailAddressPatterns") && !ERXProperties.hasKey("er.javamail.DenyEmailAddressPatterns")) {
+				log.warn("Please update your properties settings to use \"er.javamail.DenyEmailAddressPatterns\" instead of \"er.javamail.BlackListEmailAddressPatterns\". blackListEmailAddressPatterns() and associated properties will be removed from future versions.");
+				denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.BlackListEmailAddressPatterns", NSArray.EmptyArray);
+			}
+			else {
+				denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.DenyEmailAddressPatterns", NSArray.EmptyArray);
+			}
 		}
-		return blakListEmailAddressPatterns;
+		return denyEmailAddressPatterns;
 	}
 
 	/**
-	 * <span class="en"> Whilte list Or qualifier to match any of the patterns in the white list.
+	 * <span class="en"> Gets the array of denied email address patterns.
 	 * 
-	 * @return Or qualifier for the white list </span> <span class="ja"> ホワイト・リスト内でマッチするパタンのホワイト・リスト Or qualifier
+	 * @return array of denied email address patterns </span>
+	 * 
+	 *         <span class="ja"> TODO: update Japanese documentation ブラック・リスト・メールアドレス配列パターンを戻します。
+	 * @return ブラック・リスト・メールアドレス配列パターン </span>
+	 */
+	@SuppressWarnings("unchecked")
+	public NSArray<String> denyEmailAddressPatterns() {
+		if (denyEmailAddressPatterns == null) {
+			denyEmailAddressPatterns = ERXProperties.arrayForKeyWithDefault("er.javamail.DenyEmailAddressPatterns", NSArray.EmptyArray);
+		}
+		return denyEmailAddressPatterns;
+	}
+
+	/**
+	 * <span class="en"> {@link EOOrQualifier} qualifier to match any of the patterns in the allow list.
+	 * 
+	 * @deprecated whiteListQualifier() will be removed in future versions. Please use {@link allowListQualifier()}
+	 *             instead.
+	 * @return Or qualifier for the allow list </span> <span class="ja"> ホワイト・リスト内でマッチするパタンのホワイト・リスト Or qualifier
 	 * 
 	 * @return ホワイト・リスト Or qualifier </span>
 	 */
+	@Deprecated
 	public EOOrQualifier whiteListQualifier() {
-		if (whiteListQualifier == null) {
-			whiteListQualifier = qualifierArrayForEmailPatterns(whiteListEmailAddressPatterns());
-		}
-		return whiteListQualifier;
+		return allowQualifier();
 	}
 
 	/**
-	 * <span class="en"> Gets the Or qualifier to match any of the patterns in the black list.
+	 * <span class="en"> {@link EOOrQualifier} qualifier to match any of the patterns in the allow list.
+	 * 
+	 * @return {@link EOOrQualifier} for the allow list </span> <span class="ja"> ホワイト・リスト内でマッチするパタンのホワイト・リスト Or qualifier
+	 * 
+	 * @return ホワイト・リスト Or qualifier </span>
+	 */
+	public EOOrQualifier allowQualifier() {
+		if (allowQualifier == null) {
+			allowQualifier = qualifierArrayForEmailPatterns(allowEmailAddressPatterns());
+		}
+		return allowQualifier;
+	}
+
+	/**
+	 * <span class="en"> Gets the Or qualifier to match any of the patterns in the deny list.
+	 * 
+	 * @deprecated blackListQualifier() will be removed in future versions. Please use {@denyQualifier()}
+	 * @return or qualifier </span>
+	 * 
+	 *         <span class="ja"> ブラック・リスト内でマッチするパタンのブラック・リスト Or qualifier
+	 * 
+	 * @return ブラック・リスト Or qualifier </span>
+	 */
+	@Deprecated
+	public EOOrQualifier blackListQualifier() {
+		return denyQualifier();
+	}
+
+	/**
+	 * <span class="en"> Gets the {@link EOOrQualifier} qualifier to match any of the patterns in the deny list.
 	 * 
 	 * @return or qualifier </span>
 	 * 
@@ -813,11 +923,11 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 * 
 	 * @return ブラック・リスト Or qualifier </span>
 	 */
-	public EOOrQualifier blackListQualifier() {
-		if (blackListQualifier == null) {
-			blackListQualifier = qualifierArrayForEmailPatterns(blackListEmailAddressPatterns());
+	public EOOrQualifier denyQualifier() {
+		if (denyQualifier == null) {
+			denyQualifier = qualifierArrayForEmailPatterns(denyEmailAddressPatterns());
 		}
-		return blackListQualifier;
+		return denyQualifier;
 	}
 
 	/**
@@ -844,7 +954,7 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	}
 
 	/**
-	 * <span class="en"> Filters an array of email addresses by the black and white lists.
+	 * <span class="en"> Filters an array of email addresses by the deny and allow lists.
 	 * 
 	 * @param emailAddresses
 	 *            array of email addresses to be filtered
@@ -859,26 +969,26 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 */
 	public NSArray<String> filterEmailAddresses(NSArray<String> emailAddresses) {
 		NSMutableArray<String> filteredAddresses = null;
-		if ((emailAddresses != null) && (emailAddresses.count() > 0) && (hasWhiteList() || hasBlackList())) {
+		if ((emailAddresses != null) && (emailAddresses.count() > 0) && (hasAllowList() || hasDenyList())) {
 			filteredAddresses = new NSMutableArray<>(emailAddresses);
 
 			if (log.isDebugEnabled()) {
 				log.debug("Filtering email addresses: " + filteredAddresses);
 			}
 
-			if (hasWhiteList()) {
-				EOQualifier.filterArrayWithQualifier(filteredAddresses, whiteListQualifier());
+			if (hasAllowList()) {
+				EOQualifier.filterArrayWithQualifier(filteredAddresses, allowQualifier());
 				if (log.isDebugEnabled()) {
-					log.debug("White list qualifier: " + whiteListQualifier() + " after filtering: " + filteredAddresses);
+					log.debug("Allow qualifier: " + allowQualifier() + " after filtering: " + filteredAddresses);
 				}
 			}
 
-			if (hasBlackList()) {
-				NSArray<String> filteredOutAddresses = EOQualifier.filteredArrayWithQualifier(filteredAddresses, blackListQualifier());
+			if (hasDenyList()) {
+				NSArray<String> filteredOutAddresses = EOQualifier.filteredArrayWithQualifier(filteredAddresses, denyQualifier());
 				if (filteredOutAddresses.count() > 0)
 					filteredAddresses.removeObjectsInArray(filteredOutAddresses);
 				if (log.isDebugEnabled()) {
-					log.debug("Black list qualifier: " + blackListQualifier() + " filtering: " + filteredAddresses);
+					log.debug("Deny qualifier: " + denyQualifier() + " filtering: " + filteredAddresses);
 				}
 			}
 		}

--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDelivery.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDelivery.java
@@ -707,7 +707,7 @@ public abstract class ERMailDelivery {
 	/**
 	 * <div class="en">
 	 * Sets addresses regarding their recipient type in the current message. Has the option to filter the address list
-	 * based on the white and black lists.
+	 * based on the allow and deny lists.
 	 * </div>
 	 * 
 	 * <div class="ja">
@@ -730,7 +730,7 @@ public abstract class ERMailDelivery {
 	/**
 	 * <div class="en">
 	 * Sets addresses regarding their recipient type in the current message. Has the option to filter the address list
-	 * based on the white and black lists.
+	 * based on the allow and deny lists.
 	 * </div>
 	 * 
 	 * <div class="ja">


### PR DESCRIPTION
…Mail classes and documentation

I’ve provided cover methods for the old blacklist/whitelist methods so there can be graceful deprecation of these terms.
This isn’t a change in function at all. There has been renewed discussion in many forums about the use of blacklist and whitelist and the connotations of bad/excluded and good/included. (blacklist addresses you want to exclude and whitelist addresses are those you want to include).  Since this is a symbolic change and the use of “deny/allow” is a more clear indication of the intent and use of the functions, it’s worth making this change to these commonly used terms. Perhaps, over time, the negative associations will fade. Regardless of whether that happens, I think it’s worth using more clear terms here and being conscious of the unintended effects of some common practices.