### PR TITLE
Add convenience factory methods to create NSDictionary, NSArray, and NSSet

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
@@ -1059,48 +1059,48 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 	}
 	
 	/**
-     * Returns an immutable empty {@code NSArray}.
-     *
-     * @param <E>
-     *            the {@code NSArray}'s element type
-     * @return an empty {@code NSArray}
-     */
-    public static <E> NSArray<E> of() {
-        return EmptyArray;
-    }
-    
-    /**
-     * Returns an immutable {@code NSArray} containing one element.
-     *
-     * @param <E>
-     *            the {@code NSArray}'s element type
-     * @param element
-     *            the element to be contained in the array
-     * @return a {@code NSArray} containing the specified element
-     */
-    public static <E> NSArray<E> of(E element) {
-        return new NSArray<>(element);
-    }
-    
-    /**
-     * Returns an immutable {@code NSArray} containing an arbitrary number of elements.
-     *
-     * @param <E>
-     *            the {@code NSArray}'s element type
-     * @param elements
-     *            the elements to be contained in the array
-     * @return a {@code NSArray} containing the specified elements
-     */
-    @SafeVarargs
-    public static <E> NSArray<E> of(E... elements) {
-        if (elements.length == 0) {
-            return EmptyArray;
-        } else if(elements.length == 1) {
-        	return new NSArray(elements[0]);
-        }
+	 * Returns an immutable empty {@code NSArray}.
+	 *
+	 * @param <E>
+	 *            the {@code NSArray}'s element type
+	 * @return an empty {@code NSArray}
+	 */
+	public static <E> NSArray<E> of() {
+		return EmptyArray;
+	}
+	
+	/**
+	 * Returns an immutable {@code NSArray} containing one element.
+	 *
+	 * @param <E>
+	 *            the {@code NSArray}'s element type
+	 * @param element
+	 *            the element to be contained in the array
+	 * @return a {@code NSArray} containing the specified element
+	 */
+	public static <E> NSArray<E> of(E element) {
+		return new NSArray<>(element);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSArray} containing an arbitrary number of elements.
+	 *
+	 * @param <E>
+	 *            the {@code NSArray}'s element type
+	 * @param elements
+	 *            the elements to be contained in the array
+	 * @return a {@code NSArray} containing the specified elements
+	 */
+	@SafeVarargs
+	public static <E> NSArray<E> of(E... elements) {
+		if (elements.length == 0) {
+			return EmptyArray;
+		} else if(elements.length == 1) {
+			return new NSArray(elements[0]);
+		}
 
-        return new NSArray<>(elements);
-    }
+		return new NSArray<>(elements);
+	}
 	
 	static {
 		try {

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSArray.java
@@ -1058,6 +1058,50 @@ public class NSArray<E> implements Cloneable, Serializable, NSCoding, NSKeyValue
 		return EmptyArray;
 	}
 	
+	/**
+     * Returns an immutable empty {@code NSArray}.
+     *
+     * @param <E>
+     *            the {@code NSArray}'s element type
+     * @return an empty {@code NSArray}
+     */
+    public static <E> NSArray<E> of() {
+        return EmptyArray;
+    }
+    
+    /**
+     * Returns an immutable {@code NSArray} containing one element.
+     *
+     * @param <E>
+     *            the {@code NSArray}'s element type
+     * @param element
+     *            the element to be contained in the array
+     * @return a {@code NSArray} containing the specified element
+     */
+    public static <E> NSArray<E> of(E element) {
+        return new NSArray<>(element);
+    }
+    
+    /**
+     * Returns an immutable {@code NSArray} containing an arbitrary number of elements.
+     *
+     * @param <E>
+     *            the {@code NSArray}'s element type
+     * @param elements
+     *            the elements to be contained in the array
+     * @return a {@code NSArray} containing the specified elements
+     */
+    @SafeVarargs
+    public static <E> NSArray<E> of(E... elements) {
+        if (elements.length == 0) {
+            return EmptyArray;
+        } else if(elements.length == 1) {
+        	return new NSArray(elements[0]);
+        }
+
+        return new NSArray<>(elements);
+    }
+	
 	static {
 		try {
 			setOperatorForKey(CountOperatorName, new _CountOperator());

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSDictionary.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSDictionary.java
@@ -506,165 +506,165 @@ public class NSDictionary<K, V> implements Cloneable, Serializable, NSCoding, NS
 	}
 	
 	/**
-     * Returns an immutable {@code NSDictionary} containing zero entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return an empty {@code NSDictionary}
-     */
-    public static <K, V> NSDictionary<K, V> of() {
-        return EmptyDictionary;
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing a single entry.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1) {
-        return dictionaryOfImpl(k1, v1);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing two entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2) {
-        return dictionaryOfImpl(k1, v1, k2, v2);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing three entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing four entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing five entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing six entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing seven entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing eight entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing nine entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
-    }
-    
-    /**
-     * Returns an immutable {@code NSDictionary} containing ten entries.
-     *
-     * @param <K>the
-     *            {@code NSDictionary}'s key type
-     * @param <V>the
-     *            {@code NSDictionary}'s value type
-     * @return a {@code NSDictionary} containing the specified mapping
-     */
-    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
-        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
-    }
-    
-    @SuppressWarnings("unchecked")
-    private static <K, V> NSDictionary<K, V> dictionaryOfImpl(Object... input) {
-    	if(input.length == 2) {
-    		return new NSDictionary<>((V) input[1], (K) input[0]);
-    	}
-    	
-    	int capacity = input.length / 2;
+	 * Returns an immutable {@code NSDictionary} containing zero entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return an empty {@code NSDictionary}
+	 */
+	public static <K, V> NSDictionary<K, V> of() {
+		return EmptyDictionary;
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing a single entry.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1) {
+		return dictionaryOfImpl(k1, v1);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing two entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2) {
+		return dictionaryOfImpl(k1, v1, k2, v2);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing three entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing four entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing five entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing six entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing seven entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing eight entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing nine entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSDictionary} containing ten entries.
+	 *
+	 * @param <K>the
+	 *            {@code NSDictionary}'s key type
+	 * @param <V>the
+	 *            {@code NSDictionary}'s value type
+	 * @return a {@code NSDictionary} containing the specified mapping
+	 */
+	public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
+		return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static <K, V> NSDictionary<K, V> dictionaryOfImpl(Object... input) {
+		if(input.length == 2) {
+			return new NSDictionary<>((V) input[1], (K) input[0]);
+		}
+		
+		int capacity = input.length / 2;
 		Object[] keys = new Object[capacity];
-    	Object[] values = new Object[capacity];
-    	
-        for (int i = 0, j = 0; i < input.length; i += 2, j++) {
-        	keys[j] = input[i];
-            values[j] = input[i + 1];
-        }
+		Object[] values = new Object[capacity];
+		
+		for (int i = 0, j = 0; i < input.length; i += 2, j++) {
+			keys[j] = input[i];
+			values[j] = input[i + 1];
+		}
 
-        return new NSDictionary<>((V[])values, (K[]) keys);
-    }
+		return new NSDictionary<>((V[])values, (K[]) keys);
+	}
 	
 	public static Object decodeObject(NSCoder coder) {
 		int count = coder.decodeInt();

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSDictionary.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSDictionary.java
@@ -505,6 +505,167 @@ public class NSDictionary<K, V> implements Cloneable, Serializable, NSCoding, NS
 		return NSDictionary.EmptyDictionary;
 	}
 	
+	/**
+     * Returns an immutable {@code NSDictionary} containing zero entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return an empty {@code NSDictionary}
+     */
+    public static <K, V> NSDictionary<K, V> of() {
+        return EmptyDictionary;
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing a single entry.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1) {
+        return dictionaryOfImpl(k1, v1);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing two entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2) {
+        return dictionaryOfImpl(k1, v1, k2, v2);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing three entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing four entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing five entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing six entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing seven entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing eight entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing nine entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
+    }
+    
+    /**
+     * Returns an immutable {@code NSDictionary} containing ten entries.
+     *
+     * @param <K>the
+     *            {@code NSDictionary}'s key type
+     * @param <V>the
+     *            {@code NSDictionary}'s value type
+     * @return a {@code NSDictionary} containing the specified mapping
+     */
+    public static <K, V> NSDictionary<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
+        return dictionaryOfImpl(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static <K, V> NSDictionary<K, V> dictionaryOfImpl(Object... input) {
+    	if(input.length == 2) {
+    		return new NSDictionary<>((V) input[1], (K) input[0]);
+    	}
+    	
+    	int capacity = input.length / 2;
+		Object[] keys = new Object[capacity];
+    	Object[] values = new Object[capacity];
+    	
+        for (int i = 0, j = 0; i < input.length; i += 2, j++) {
+        	keys[j] = input[i];
+            values[j] = input[i + 1];
+        }
+
+        return new NSDictionary<>((V[])values, (K[]) keys);
+    }
+	
 	public static Object decodeObject(NSCoder coder) {
 		int count = coder.decodeInt();
 		Object[] keys = new Object[count];

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSSet.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSSet.java
@@ -286,6 +286,50 @@ public class NSSet<E> implements Cloneable, Serializable, NSCoding, _NSFoundatio
 	public static <T> NSSet<T> emptySet() {
 		return (NSSet<T>) EmptySet;
 	}
+	
+	/**
+     * Returns an immutable empty {@code NSSet}.
+     *
+     * @param <E>
+     *            the {@code NSSet}'s element type
+     * @return an empty {@code NSSet}
+     */
+    public static <E> NSSet<E> of() {
+        return EmptySet;
+    }
+    
+    /**
+     * Returns an immutable {@code NSSet} containing one element.
+     *
+     * @param <E>
+     *            the {@code NSSet}'s element type
+     * @param element
+     *            the element to be contained in the array
+     * @return a {@code NSSet} containing the specified element
+     */
+    public static <E> NSSet<E> of(E element) {
+        return new NSSet<>(element);
+    }
+    
+    /**
+     * Returns an immutable {@code NSSet} containing an arbitrary number of elements.
+     *
+     * @param <E>
+     *            the {@code NSSet}'s element type
+     * @param elements
+     *            the elements to be contained in the array
+     * @return a {@code NSSet} containing the specified elements
+     */
+    @SafeVarargs
+    public static <E> NSSet<E> of(E... elements) {
+        if (elements.length == 0) {
+            return EmptySet;
+        } else if(elements.length == 1) {
+        	return new NSSet(elements[0]);
+        }
+
+        return new NSSet<>(elements);
+    }
 
 	@Override
 	public boolean equals(Object object) {

--- a/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSSet.java
+++ b/Frameworks/Core/ERExtensions/Sources/com/webobjects/foundation/NSSet.java
@@ -288,48 +288,48 @@ public class NSSet<E> implements Cloneable, Serializable, NSCoding, _NSFoundatio
 	}
 	
 	/**
-     * Returns an immutable empty {@code NSSet}.
-     *
-     * @param <E>
-     *            the {@code NSSet}'s element type
-     * @return an empty {@code NSSet}
-     */
-    public static <E> NSSet<E> of() {
-        return EmptySet;
-    }
-    
-    /**
-     * Returns an immutable {@code NSSet} containing one element.
-     *
-     * @param <E>
-     *            the {@code NSSet}'s element type
-     * @param element
-     *            the element to be contained in the array
-     * @return a {@code NSSet} containing the specified element
-     */
-    public static <E> NSSet<E> of(E element) {
-        return new NSSet<>(element);
-    }
-    
-    /**
-     * Returns an immutable {@code NSSet} containing an arbitrary number of elements.
-     *
-     * @param <E>
-     *            the {@code NSSet}'s element type
-     * @param elements
-     *            the elements to be contained in the array
-     * @return a {@code NSSet} containing the specified elements
-     */
-    @SafeVarargs
-    public static <E> NSSet<E> of(E... elements) {
-        if (elements.length == 0) {
-            return EmptySet;
-        } else if(elements.length == 1) {
-        	return new NSSet(elements[0]);
-        }
+	 * Returns an immutable empty {@code NSSet}.
+	 *
+	 * @param <E>
+	 *            the {@code NSSet}'s element type
+	 * @return an empty {@code NSSet}
+	 */
+	public static <E> NSSet<E> of() {
+		return EmptySet;
+	}
+	
+	/**
+	 * Returns an immutable {@code NSSet} containing one element.
+	 *
+	 * @param <E>
+	 *            the {@code NSSet}'s element type
+	 * @param element
+	 *            the element to be contained in the array
+	 * @return a {@code NSSet} containing the specified element
+	 */
+	public static <E> NSSet<E> of(E element) {
+		return new NSSet<>(element);
+	}
+	
+	/**
+	 * Returns an immutable {@code NSSet} containing an arbitrary number of elements.
+	 *
+	 * @param <E>
+	 *            the {@code NSSet}'s element type
+	 * @param elements
+	 *            the elements to be contained in the array
+	 * @return a {@code NSSet} containing the specified elements
+	 */
+	@SafeVarargs
+	public static <E> NSSet<E> of(E... elements) {
+		if (elements.length == 0) {
+			return EmptySet;
+		} else if(elements.length == 1) {
+			return new NSSet(elements[0]);
+		}
 
-        return new NSSet<>(elements);
-    }
+		return new NSSet<>(elements);
+	}
 
 	@Override
 	public boolean equals(Object object) {

--- a/Tests/ERXTest/Sources/com/webobjects/foundation/NSArrayTest.java
+++ b/Tests/ERXTest/Sources/com/webobjects/foundation/NSArrayTest.java
@@ -1405,5 +1405,40 @@ public class NSArrayTest extends ERXTestCase {
     } catch (NullPointerException e) {
     }
   }
-
+  
+  public void testCreateNSArrayOfZeroElements() {
+	 NSArray<?> array = NSArray.of();
+	 
+	 assertTrue(array.isEmpty());
+	 assertTrue(NSArray.EmptyArray == array);
+  }
+  
+  public void testCreateNSArrayOfOneElement() {
+	 NSArray<String> array = NSArray.of("e1");
+	 
+	 assertEquals(1, array.size());
+	 assertEquals("e1", array.get(0));
+  }
+  
+  public void testCreateNSArrayOfTwoElements() {
+	 NSArray<String> array = NSArray.of("e1", "e2");
+	 
+	 assertEquals(2, array.size());
+	 assertEquals("e1", array.get(0));
+	 assertEquals("e2", array.get(1));
+  }
+  
+  public void testCreateNSArrayFromEmptyArray() {
+	 NSArray<String> array = NSArray.of(new String[] {});
+	 
+	 assertTrue(array.isEmpty());
+	 assertTrue(NSArray.EmptyArray == array);
+  }
+  
+  public void testCreateNSArrayFromArrayWithOneElement() {
+	 NSArray<String> array = NSArray.of(new String[] { "e1" });
+	 
+	 assertEquals(1, array.size());
+	 assertEquals("e1", array.get(0));
+  }
 }

--- a/Tests/ERXTest/Sources/com/webobjects/foundation/NSDictionaryTest.java
+++ b/Tests/ERXTest/Sources/com/webobjects/foundation/NSDictionaryTest.java
@@ -370,4 +370,180 @@ public class NSDictionaryTest extends ERXTestCase {
 		  fail("Unable to throw unknown key exception");
 		}
 	}
+	
+	public void testCreateNSDictionaryOfZeroEntries() {
+		NSDictionary<?, ?> dict = NSDictionary.of();
+		
+		assertTrue(dict.isEmpty());
+		assertTrue(NSDictionary.EmptyDictionary == dict);
+	}
+	
+	public void testCreateNSDictionaryOfOneEntry() {
+		NSDictionary<String, String> dict = NSDictionary.of("k1", "v1");
+		
+		assertEquals(1, dict.size());
+		assertEquals("v1", dict.get("k1"));
+	}
+	
+	public void testCreateNSDictionaryOfTwoEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1",
+				"k2", "v2");
+		
+		assertEquals(2, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+	}
+	
+	public void testCreateNSDictionaryOfThreeEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3");
+		
+		assertEquals(3, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+	}
+	
+	public void testCreateNSDictionaryOfFourEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4");
+		
+		assertEquals(4, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+	}
+	
+	public void testCreateNSDictionaryOfFiveEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4", 
+				"k5", "v5");
+		
+		assertEquals(5, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+		assertEquals("v5", dict.get("k5"));
+	}
+	
+	public void testCreateNSDictionaryOfSixEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4", 
+				"k5", "v5", 
+				"k6", "v6");
+		
+		assertEquals(6, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+		assertEquals("v5", dict.get("k5"));
+		assertEquals("v6", dict.get("k6"));
+	}
+	
+	public void testCreateNSDictionaryOfSevenEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4", 
+				"k5", "v5", 
+				"k6", "v6", 
+				"k7", "v7");
+		
+		assertEquals(7, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+		assertEquals("v5", dict.get("k5"));
+		assertEquals("v6", dict.get("k6"));
+		assertEquals("v7", dict.get("k7"));
+	}
+	
+	public void testCreateNSDictionaryOfEightEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4", 
+				"k5", "v5", 
+				"k6", "v6", 
+				"k7", "v7", 
+				"k8", "v8");
+		
+		assertEquals(8, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+		assertEquals("v5", dict.get("k5"));
+		assertEquals("v6", dict.get("k6"));
+		assertEquals("v7", dict.get("k7"));
+		assertEquals("v8", dict.get("k8"));
+	}
+	
+	public void testCreateNSDictionaryOfNineEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4", 
+				"k5", "v5", 
+				"k6", "v6", 
+				"k7", "v7", 
+				"k8", "v8", 
+				"k9", "v9");
+		
+		assertEquals(9, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+		assertEquals("v5", dict.get("k5"));
+		assertEquals("v6", dict.get("k6"));
+		assertEquals("v7", dict.get("k7"));
+		assertEquals("v8", dict.get("k8"));
+		assertEquals("v9", dict.get("k9"));
+	}
+	
+	public void testCreateNSDictionaryOfTenEntries() {
+		NSDictionary<String, String> dict = NSDictionary.of(
+				"k1", "v1", 
+				"k2", "v2", 
+				"k3", "v3", 
+				"k4", "v4", 
+				"k5", "v5", 
+				"k6", "v6", 
+				"k7", "v7", 
+				"k8", "v8", 
+				"k9", "v9",
+				"k10", "v10");
+		
+		assertEquals(10, dict.size());
+		assertEquals("v1", dict.get("k1"));
+		assertEquals("v2", dict.get("k2"));
+		assertEquals("v3", dict.get("k3"));
+		assertEquals("v4", dict.get("k4"));
+		assertEquals("v5", dict.get("k5"));
+		assertEquals("v6", dict.get("k6"));
+		assertEquals("v7", dict.get("k7"));
+		assertEquals("v8", dict.get("k8"));
+		assertEquals("v9", dict.get("k9"));
+		assertEquals("v10", dict.get("k10"));
+	}
 }

--- a/Tests/ERXTest/Sources/com/webobjects/foundation/NSSetTest.java
+++ b/Tests/ERXTest/Sources/com/webobjects/foundation/NSSetTest.java
@@ -294,4 +294,40 @@ public class NSSetTest extends ERXTestCase {
 			// test passed
 		}
 	}
+	
+	public void testCreateNSSetOfZeroElements() {
+		NSSet<?> set = NSSet.of();
+		 
+		 assertTrue(set.isEmpty());
+		 assertTrue(NSSet.EmptySet == set);
+	  }
+	  
+	  public void testCreateNSSetOfOneElement() {
+		  NSSet<String> set = NSSet.of("e1");
+		 
+		 assertEquals(1, set.size());
+		 assertTrue(set.contains("e1"));
+	  }
+	  
+	  public void testCreateNSSetOfTwoElements() {
+		  NSSet<String> set = NSSet.of("e1", "e2");
+		 
+		 assertEquals(2, set.size());
+		 assertTrue(set.contains("e1"));
+		 assertTrue(set.contains("e2"));
+	  }
+	  
+	  public void testCreateNSSetFromEmptyArray() {
+		  NSSet<String> set = NSSet.of(new String[] {});
+		 
+		 assertTrue(set.isEmpty());
+		 assertTrue(NSSet.EmptySet == set);
+	  }
+	  
+	  public void testCreateNSSetFromArrayWithOneElement() {
+		  NSSet<String> set = NSSet.of(new String[] { "e1" });
+		 
+		 assertEquals(1, set.size());
+		 assertTrue(set.contains("e1"));
+	  }
 }


### PR DESCRIPTION
As per [JEP 269](https://openjdk.java.net/jeps/269), Java 9 defined library APIs to make it convenient to create instances of collections and maps with small numbers of elements. This pull request introduces a similar concept for `NSDictionary`, `NSArray`, and `NSSet`. It provides convenience factory methods to create NSCollections in a less verbose, concise, and uniform way.

Usage:

```java
NSDictionary<String, String> dict = NSDictionary.of("k1", "v1",
                                                    "k2", "v2");

NSArray<String> array = NSArray.of("e1", "e2", "e3");

NSSet<String> set = NSSet.of("e1", "e2");
```