### PR TITLE
Make Wonder go to 11+6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     
     - name: Deploy Snapshots with Maven
       run: mvn -B deploy --file pom.xml -s .maven_settings.xml -DretryFailedDeploymentCount=10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     
     - name: Deploy Snapshots with Maven
       run: mvn -B deploy --file pom.xml -s .maven_settings.xml -DretryFailedDeploymentCount=10

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -18,10 +18,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Deploy snapshots with Maven
         run: mvn -B deploy --file pom.xml -s .maven-settings.xml -DretryFailedDeploymentCount=10

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -18,10 +18,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Deploy snapshots with Maven
         run: mvn -B deploy --file pom.xml -s .maven-settings.xml -DretryFailedDeploymentCount=10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     
     - name: Build and Test with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     
     - name: Build and Test with Maven
       run: mvn -B package --file pom.xml

--- a/Frameworks/Misc/ERProfiling/Sources/er/profiling/classloader/WeavingClassLoader.java
+++ b/Frameworks/Misc/ERProfiling/Sources/er/profiling/classloader/WeavingClassLoader.java
@@ -5,8 +5,8 @@ import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-import sun.misc.Resource;
-import sun.misc.URLClassPath;
+import jdk.internal.loader.Resource;
+import jdk.internal.loader.URLClassPath;
 
 /**
  * The WeavingClassLoader is a custom URLClassLoader that implements the 
@@ -84,7 +84,7 @@ public class WeavingClassLoader extends URLClassLoader {
 		}
 
 		String path = name.replace('.', '/').concat(".class");
-		Resource res = new URLClassPath(getURLs()).getResource(path, false);
+		Resource res = new URLClassPath(getURLs(),null).getResource(path, false);
 		if (res != null) {
 			try {
 				byte[] b = res.getBytes();

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                     <!-- Argument added only for ERProfiling to access URLClassLoader/Resource -->
                     <compilerArgs>
                     	<arg>--add-exports</arg>
@@ -110,7 +110,7 @@
                 <!-- Argument added only so ERXiss's tests run (uses NSTimeZone which currently performs illegal access) -->
                 <configuration>
                 	<argLine>
-                		--illegal-access=permit
+                		--add-exports java.base/sun.security.action=ALL-UNNAMED 
                 	</argLine>
             	</configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,25 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
+                    <!-- Argument added only for ERProfiling to access URLClassLoader/Resource -->
+                    <compilerArgs>
+                    	<arg>--add-exports</arg>
+                    	<arg>java.base/jdk.internal.loader=ALL-UNNAMED</arg>
+                    </compilerArgs>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <!-- Argument added only so ERXiss's tests run (uses NSTimeZone which currently performs illegal access) -->
+                <configuration>
+                	<argLine>
+                		--illegal-access=permit
+                	</argLine>
+            	</configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I've been running this without problems for a couple of days now, a couple of eyes on it wouldn't hurt before it's merged.

I did not upgrade the JDK version in the "release.yml" github action to keep it compatible with 7.2. Or is that perhaps not neccessary? Not sure of the mechanics of how action configuration is handled when building older versions (does the action definiton file/jdk version come from the branch being built?)