### PR TITLE
Nullify handling for toMany relationships.

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXCopyable.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXCopyable.java
@@ -1283,7 +1283,11 @@ public interface ERXCopyable<T extends ERXCopyable<T>> extends ERXEnterpriseObje
 				Utility.deepCopyRelationship(copiedObjects, source, destination, relationship);
 				break;
 			case NULLIFY:
-				destination.takeStoredValueForKey(null, relationshipName);
+				if (relationship.isToMany()) {
+					destination.takeStoredValueForKey(new NSMutableArray<>(), relationshipName);
+				} else {
+					destination.takeStoredValueForKey(null, relationshipName);
+				}
 				break;
 			default:
 				handleMissingOrInvalidCopyType(relationship, copyType);


### PR DESCRIPTION
toMany relationships should always have an empty array. There was a bug here where we set that array to null which will surprise people. People expecting to have an empty array will have a null pointer instead without this fix.

Note: It is important to set a Mutable array because that's what it is internally even though the Apple/NeXT API shows immutable getters. If you think about it, this makes sense. They don't want you adding/remove directly from the array but internally the data structure needs to be mutable. 

Signed-off-by: Aaron Rosenzweig <aaron@chatnbike.com>