### PR TITLE
AjaxFlickrBatchNavigation needs to override selectBatchSize()

### DIFF
--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlickrBatchNavigation.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxFlickrBatchNavigation.java
@@ -1,5 +1,6 @@
 package er.ajax;
 
+import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOContext;
 
 import er.extensions.batching.ERXFlickrBatchNavigation;
@@ -46,5 +47,16 @@ public class AjaxFlickrBatchNavigation extends ERXFlickrBatchNavigation {
 			updateContainerID = AjaxUpdateContainer.currentUpdateContainerID();
 		}
 		return updateContainerID;
+	}
+
+	/**
+	 * Sets display group batch size from user selection.
+	 * 
+	 * @return {@code null} (Ajax action)
+	 */
+	@Override
+	public WOActionResults selectBatchSize() {
+		displayGroup().setNumberOfObjectsPerBatch(currentBatchSize);
+		return null;
 	}
 }


### PR DESCRIPTION
If you use `AjaxFlickrBatchNavigation`, you may have noticed frequent warnings logged to the console:

    WARN  er.ajax.AjaxUpdateLink - An Ajax request attempted to return the page, which is almost certainly an error.

This happens when the user selects a new batch size from the batch size hyperlinks, e.g. by clicking on "50". What's happening is that `ERXFlickrBatchNavigation.selectBatchSize()` (which isn't overridden in `AjaxFlickrBatchNavigation`) is returning `context().page()`: correct for a regular component, but wrong in the Ajax setting. This pull request simply overrides that method to return `null` instead of the page.