### PR TITLE
Update Properties

### DIFF
--- a/Examples/Misc/ERPDFExamples/Resources/Properties
+++ b/Examples/Misc/ERPDFExamples/Resources/Properties
@@ -4,6 +4,8 @@ ognl.inlineBindings=true
 
 # Misc
 er.extensions.stackTrace.cleanup=true
+# PDF Generation for languages other than englisch! Otherwise PDF Generation will fail if you use i.e. german "Umlaute".
+er.extensions.ERXApplication.DefaultEncoding=UTF-8
 
 # EOF
 er.extensions.ERXEC.safeLocking=true


### PR DESCRIPTION
PDF Generation for languages other than englisch! Otherwise PDF Generation will fail if you use i.e. german "Umlaute". This will save everybody a lot of time if he tries this example and it fails because the HTML - Page is not proper UTF-8