### PR TITLE
Add target binding to ERAttachmentViewer

### DIFF
--- a/Frameworks/BusinessLogic/ERAttachment/Components/ERAttachmentDefaultViewer.wo/ERAttachmentDefaultViewer.wod
+++ b/Frameworks/BusinessLogic/ERAttachment/Components/ERAttachmentDefaultViewer.wo/ERAttachmentDefaultViewer.wod
@@ -8,4 +8,5 @@ Image : ERAttachmentIcon {
 	title = ^title;
 	width = ^width;
 	height = ^height;
+	target = ^target;
 }

--- a/Frameworks/BusinessLogic/ERAttachment/Components/ERAttachmentViewer.wo/ERAttachmentViewer.wod
+++ b/Frameworks/BusinessLogic/ERAttachment/Components/ERAttachmentViewer.wo/ERAttachmentViewer.wod
@@ -8,4 +8,5 @@ ViewerSwitch : WOSwitchComponent {
 	width = ^width;
 	height = ^height;
 	title = ^title;
+	target = ^target;
 }

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/components/ERAttachmentViewer.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/components/ERAttachmentViewer.java
@@ -32,6 +32,7 @@ import er.extensions.foundation.ERXProperties;
  * @binding style (optional) the embedded css style
  * @binding width (optional) if displaying an image, sets the image width 
  * @binding height (optional) if displaying an image, sets the image height
+ * @binding target (optional) specifies where to open the linked attachment
  *
  * @property er.attachment.mimeType.[mimeType].viewer the class name of the viewer component for the given mime type
  * @property er.attachment.mimeType.[globMimeType].viewer

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/components/viewers/ERAttachmentDefaultViewer.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/components/viewers/ERAttachmentDefaultViewer.java
@@ -13,6 +13,8 @@ import com.webobjects.appserver.WOContext;
  * @binding style (optional) the embedded css style
  * @binding width (optional) if displaying an image, sets the image width 
  * @binding height (optional) if displaying an image, sets the image height
+ * @binding target (optional) specifies where to open the linked attachment
+
  */
 public class ERAttachmentDefaultViewer extends AbstractERAttachmentViewer {
 	/**


### PR DESCRIPTION
When ERAttachmentViewer shows a binary file, it defines a link. Now we can set a target to this behavior