### PR TITLE
Add null check to observeField() function

### DIFF
--- a/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
+++ b/Frameworks/Ajax/Ajax/WebServerResources/wonder.js
@@ -472,6 +472,10 @@ var AjaxSubmitButton = {
 	},
 	
 	observeField: function(updateContainerID, formFieldID, observeFieldFrequency, partial, observeDelay, options) {
+		if ($(formFieldID) == null) {
+			console.log("observeField can't find '" + formFieldID + "'");
+			return;
+		}
 		var submitFunction;
 		if (partial) {
 			// We need to cheat and make the WOForm that contains the form action appear to have been


### PR DESCRIPTION
Some user interface components switch between view only and editing mode.  When in view mode the form fields are left out of the page.  This results in javascript errors when having AjaxObserveField when the observe element does not exist.  Rather than putting a WOConditional around every AjaxObserveField it seems better to simply add a null check in the observeField() function used by AjaxObserveField.  This simplifies things.

The fix adds a null check at the top and logs a message to the javascript console if the element does not exist rather than resulting in javascript errors which looks pretty bad.