### PR TITLE
ERMailDelivery.sendMail() does not allow for null returned from Message.getAllRecipients()

### DIFF
--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDelivery.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERMailDelivery.java
@@ -599,7 +599,8 @@ public abstract class ERMailDelivery {
 				mimeMessage().setRecipients(Message.RecipientType.CC, new InternetAddress[0]);
 				mimeMessage().setRecipients(Message.RecipientType.BCC, new InternetAddress[0]);
 			}
-			if (mimeMessage().getAllRecipients().length == 0) {
+			if (mimeMessage().getAllRecipients() == null || mimeMessage().getAllRecipients().length == 0) {
+				log.debug("No recipients, not sending.");
 				return;
 			}
 


### PR DESCRIPTION
The issue here is that `ERMailDelivery.sendMail()` checks for zero recipients by looking at the length of an `Address[]` array:

    if (mimeMessage().getAllRecipients().length == 0) {
        return;
    }

That's fine, except the ultimate origin of that array is a call to `javax.mail.Message.getAllRecipients()`, where the Javadocs explicitly state that "This method returns `null` if none of the recipient headers are present in this message." If that array is `null`, this check obviously throws a `NullPointerException`.

Presumably you could trigger this _on purpose_ by setting no recipients and calling `sendMail()`, but you can run into it simply by using the features of ERJavaMail.framework. Specifically, set the black list to exclude addresses in `example.com`:

    er.javamail.BlackListEmailAddressPatterns=("*@example.com")

And then try to send a message to an address in that domain. The address is correctly excluded from recipients, then you have zero recipients, then you get the `NullPointerException`. My argument is that this blacklist feature should be usable just like this, where I'm just trying to suppress outgoing mail to a domain even for single-recipient messages.

Aside from my use case here, `getAllRecipients()` is documented as potentially returning `null`, so this should be fixed regardless.