### PR TITLE
Fix NullPointerException when calling the EOModel.createPrototypeCache method from the wrong EOModel (take 2)

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXModelGroup.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXModelGroup.java
@@ -202,7 +202,7 @@ public class ERXModelGroup extends EOModelGroup {
 				String modelPath = NSPathUtilities.stringByDeletingLastPathComponent(indexPath);
 				String modelName = (NSPathUtilities.stringByDeletingPathExtension(NSPathUtilities.lastPathComponent(modelPath)));
 				EOModel eomodel = modelNamed(modelName);
-				if (eomodel == null) {
+				if (!modelNames.contains(modelName) && eomodel == null) {
 					URL url = nsbundle.pathURLForResourcePath(modelPath);
 					modelNameURLDictionary.setObjectForKey(url, modelName);
 					modelNames.addObject(modelName);


### PR DESCRIPTION
This error was first reported and fixed by the PR https://github.com/wocommunity/wonder/pull/551. One reason for this kind of error is the presence of duplicate `NSBundle`s in the classpath. The previous fix prevented EOModels from the same `NSBundle` from being loaded twice.

There's another scenario, though, where the same issue may arise. If two distinct `NSBundle`s have the same EOModel, the application may not initialize properly, throwing the exception below:

```
java.lang.NullPointerException
	at com.webobjects.eoaccess.EOModel.createPrototypeCache(EOModel.java:631)
	at com.webobjects.eoaccess.EOModel.prototypeAttributeNamed(EOModel.java:699)
	at com.webobjects.eoaccess.ERXModel.prototypeAttributeNamed(ERXModel.java:290)
	at com.webobjects.eoaccess.EOAttribute.<init>(EOAttribute.java:998)
```

This fix prevents EOModels with the same name from being loaded twice.