### PR TITLE
Fix ERJavaMail defaultSession initialization

### DIFF
--- a/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
+++ b/Frameworks/Core/ERJavaMail/Sources/er/javamail/ERJavaMail.java
@@ -351,7 +351,10 @@ public class ERJavaMail extends ERXFrameworkPrincipal {
 	 * Returns a new Session object that is appropriate for the given context.
 	 * 
 	 * If the property <code>er.javamail.sessionConfigViaJNDI</code> is set to <code>true</code> the JNDI is used to lookup the session informations. 
-	 * You may change the default JNDI context with the property <code>er.javamail.jndiSessionContext</code>
+	 * You may change the default JNDI context with the property <code>er.javamail.jndiSessionContext</code> (defaults to <code>java:comp/env/mail</code>).
+	 * If you need a different session configuration depending of the message context, you may overwrite the default jndi context with the
+	 * property <code>er.javamail.jndiSessionContext._content_of_param_contextString_</code>
+	 * 
 	 * 
 	 * @param contextString
 	 *            the message context


### PR DESCRIPTION
When er.javamail.sessionConfigViaJNDI is set to true, the application may not start in Tomcat 9. With lazy loading the defaultSession, this problem will not occur.

