### PR TITLE
Improve EOAttribute's value factory method to accept numeric arguments

### DIFF
--- a/Frameworks/EOF/ERAttributeExtension/Resources/Properties
+++ b/Frameworks/EOF/ERAttributeExtension/Resources/Properties
@@ -3,4 +3,4 @@ er.extensions.load.Properties.framework.ERAttributeExtension=load
 er.extensions.ERAttributeExtension.hasLocalization=false
 
 er.extensions.ERXJDBCAdaptor.className=er.extensions.jdbc.ERXJDBCAdaptor
-er.extensions.ERXJDBCAdaptor.columnClassName=com.webobjects.jdbcadaptor.DateJDBCColumn
+er.extensions.ERXJDBCAdaptor.columnClassName=com.webobjects.jdbcadaptor.ERXEnhancedJDBCColumn

--- a/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
+++ b/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
@@ -3,10 +3,10 @@ package com.webobjects.eoaccess;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TimeZone;
@@ -1028,19 +1028,22 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 			}
 			Number number = (Number)value;
 			//Call the custom factory method
+            Class<?> factoryClass = null;
 			try {
-				if(valueFactoryClass() != null) {
-					Class<?> factoryClass = valueFactoryClass();
+                factoryClass = valueFactoryClass();
+				if(factoryClass != null) {
 					return valueFactoryMethod().invoke(factoryClass, number);
 				}
-				Class<?> c = _NSUtilities.classWithName(className());
-				return valueFactoryMethod().invoke(c, number);
+                factoryClass = _NSUtilities.classWithName(className());
+				return valueFactoryMethod().invoke(factoryClass, number);
 			} catch(IllegalAccessException e) {
 				throw NSForwardException._runtimeExceptionForThrowable(e);
 			} catch(IllegalArgumentException e) {
 				throw NSForwardException._runtimeExceptionForThrowable(e);
 			} catch(NoSuchMethodException e) {
-				throw NSForwardException._runtimeExceptionForThrowable(e);
+				NoSuchMethodException enhancedNsme = new NoSuchMethodException(e.getMessage() + " with parameters " + Arrays.toString(valueFactoryMethod().parameterTypes()));
+				enhancedNsme.setStackTrace(e.getStackTrace());
+				throw NSForwardException._runtimeExceptionForThrowable(enhancedNsme);
 			} catch(InvocationTargetException e) {
 				throw NSForwardException._runtimeExceptionForThrowable(e);
 			}

--- a/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
+++ b/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
@@ -1021,6 +1021,34 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 		}
 	}
 
+	public Object newValueForNumber(Object value) {
+		if (valueFactoryMethod() != null) {
+			if(!(value instanceof Number)) {
+				throw new JDBCAdaptorException(new StringBuilder().append(value).append(" of type ").append(value.getClass().getName()).append(" is not a valid Number type.").toString(), null);
+			}
+			Number number = (Number)value;
+			//Call the custom factory method
+			try {
+				if(valueFactoryClass() != null) {
+					Class<?> factoryClass = valueFactoryClass();
+					return valueFactoryMethod().invoke(factoryClass, number);
+				}
+				Class<?> c = _NSUtilities.classWithName(className());
+				return valueFactoryMethod().invoke(c, number);
+			} catch(IllegalAccessException e) {
+				throw NSForwardException._runtimeExceptionForThrowable(e);
+			} catch(IllegalArgumentException e) {
+				throw NSForwardException._runtimeExceptionForThrowable(e);
+			} catch(NoSuchMethodException e) {
+				throw NSForwardException._runtimeExceptionForThrowable(e);
+			} catch(InvocationTargetException e) {
+				throw NSForwardException._runtimeExceptionForThrowable(e);
+			}
+		}
+
+		return value;
+	}
+
 	public Object newValueForString(String str) {
 		Class stringClass = String.class;
 		Object value = null;
@@ -1337,6 +1365,26 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 			return (new Class[] { Date.class });
 		if (_argumentType == FactoryMethodArgumentIsBytes)
 			return (new Class[] { byte[].class });
+		if (_argumentType == FactoryMethodArgumentIsNumber) {
+			switch (_valueTypeChar()) {
+				case _VTShort:
+					return new Class[] { Short.class };
+				case _VTInteger:
+					return new Class[] { Integer.class };
+				case _VTLong:
+					return new Class[] { Long.class };
+				case _VTFloat:
+					return new Class[] { Float.class };
+				case _VTDouble:
+					return new Class[] { Double.class };
+				case _VTBigDecimal:
+					return new Class[] { BigDecimal.class };
+				case _VTByte:
+					return new Class[] { Byte.class };
+				default:
+					return new Class[] { Number.class };
+			}
+		}
 
 		return null;
 	}

--- a/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
+++ b/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
@@ -1190,6 +1190,8 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 			_adaptorValueType = AdaptorDateType;
 		else if (_argumentType == FactoryMethodArgumentIsBytes)
 			_adaptorValueType = AdaptorBytesType;
+		else if (_argumentType == FactoryMethodArgumentIsNumber)
+			_adaptorValueType = AdaptorNumberType;
 		if (_adaptorValueType == -1)
 			_adaptorValueType = AdaptorBytesType;
 		return _adaptorValueType;
@@ -1551,6 +1553,8 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 			return FactoryMethodArgumentIsString;
 		if (aString.equals(FactoryMethodArgumentIsDateString.toLowerCase()))
 			return FactoryMethodArgumentIsDate;
+		if (aString.equals(FactoryMethodArgumentIsNumberString.toLowerCase()))
+			return FactoryMethodArgumentIsNumber;
 		return !aString.equals("EOFactoryMethodArgumentIsNSString".toLowerCase()) ? FactoryMethodArgumentIsData : FactoryMethodArgumentIsString;
 	}
 
@@ -1567,6 +1571,9 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 
 		case FactoryMethodArgumentIsDate:
 			return FactoryMethodArgumentIsDateString;
+
+		case FactoryMethodArgumentIsNumber:
+			return FactoryMethodArgumentIsNumberString;
 		}
 		return FactoryMethodArgumentIsDataString;
 	}
@@ -1777,6 +1784,7 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 	public static final int FactoryMethodArgumentIsString = 1;
 	public static final int FactoryMethodArgumentIsBytes = 2;
 	public static final int FactoryMethodArgumentIsDate = 3;
+	public static final int FactoryMethodArgumentIsNumber = 4;
 	public static final int AdaptorNumberType = 0;
 	public static final int AdaptorCharactersType = 1;
 	public static final int AdaptorBytesType = 2;
@@ -1856,6 +1864,7 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 	public static final String FactoryMethodArgumentIsStringString = "EOFactoryMethodArgumentIsString";
 	public static final String FactoryMethodArgumentIsDataString = "EOFactoryMethodArgumentIsData";
 	public static final String FactoryMethodArgumentIsDateString = "EOFactoryMethodArgumentIsDate";
+	public static final String FactoryMethodArgumentIsNumberString = "EOFactoryMethodArgumentIsNumber";
 	private Map _overwrittenCharacteristics;
 	private static Class valueClasses[];
 	private static String valueTypeNames[] = { "Number", "Characters", "Bytes", "Date" };

--- a/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/jdbcadaptor/ERXEnhancedJDBCColumn.java
+++ b/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/jdbcadaptor/ERXEnhancedJDBCColumn.java
@@ -1,31 +1,26 @@
 package com.webobjects.jdbcadaptor;
 
 
+import com.webobjects.eoaccess.EOAttribute;
+import com.webobjects.foundation.NSForwardException;
+import com.webobjects.foundation.NSKeyValueCoding;
+import er.extensions.jdbc.ERXJDBCAdaptor.Channel;
+import org.apache.log4j.Logger;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.webobjects.eoaccess.EOAttribute;
-import com.webobjects.foundation.NSForwardException;
-import com.webobjects.foundation.NSKeyValueCoding;
-
-import er.extensions.jdbc.ERXJDBCAdaptor.Channel;
-
 /**
- * @deprecated This class was renamed and may be removed in the future. Use {@link ERXEnhancedJDBCColumn} instead.
+ * This class extends the {@code ERXJDBCColumn} to add support for custom types.
  */
-@Deprecated
-public class DateJDBCColumn extends ERXJDBCColumn {
-	private static final Logger log = LoggerFactory.getLogger(DateJDBCColumn.class);
+public class ERXEnhancedJDBCColumn extends ERXJDBCColumn {
+	private static final Logger log = Logger.getLogger(ERXEnhancedJDBCColumn.class);
 
-	public DateJDBCColumn(EOAttribute attribute, JDBCChannel channel, int column, ResultSet rs) {
+	public ERXEnhancedJDBCColumn(EOAttribute attribute, JDBCChannel channel, int column, ResultSet rs) {
 		super(attribute, channel, column, rs);
 	}
 
-	public DateJDBCColumn(Channel aChannel) {
+	public ERXEnhancedJDBCColumn(Channel aChannel) {
 		super(aChannel);
 	}
 
@@ -64,10 +59,20 @@ public class DateJDBCColumn extends ERXJDBCColumn {
 			
 			return _attribute.newValueForDate(obj);
 		}
+		/*
+		 * Add support for custom number types
+		 */
+		if (_adaptorValueType == EOAttribute.AdaptorNumberType && _customType) {
+			Object value = super._fetchValue(flag);
+			if (value == NSKeyValueCoding.NullValue || value == null) {
+				return value;
+			}
+			return _attribute.newValueForNumber(value);
+		}
 		try {
 			return super._fetchValue(flag);
 		} catch(NSForwardException ex) {
-			log.error("There's an error with this attribute: {}", _attribute);
+			log.error("There's an error with this attribute: " + _attribute);
 			throw ex;
 		}
 	}


### PR DESCRIPTION
When creating custom prototypes, one can configure a factory method to convert the attribute's value from/to a string or byte array. It's not possible to use an integer or a float value as an argument/return type, though, even if you set a value type of integer ("i") or float ("f"). Trying to fetch/save an entity containing an attribute using this prototype will throw the following exception:

```
Error encountered converting value of class MyEnum to type specified in attribute 'myEnumAttribute' of entity 'MyEntity'.
Conversion exception is : EOAttribute adaptorValueByConvertingAttributeValue(Object):
Unable to convert value of class java.lang.Integer for attribute 'enumAttribute' in entity 'MyEntity' to adaptor type EOAttribute.AdaptorBytesType.
Check the signature of the conversion method MyEnum.toInteger().
```

This pull request adds the ability to configure a factory method that receives numeric values as an argument and a conversion method that returns numeric values. For instance, it allows the creation of enum prototypes that translate from/to a number in the database.

<img width="662" alt="Screen Shot 2021-11-12 at 7 02 50 PM" src="https://user-images.githubusercontent.com/225619/141576746-5c56dfd3-40b5-4746-bcbe-a9d7074a3763.png">

I'm testing this change using an Oracle database, and everything has been working fine so far. I'll try to test it on other databases as well.