### PR TITLE
Add er.rest.format16BytesDataAsUUID property to encode 16 byte

### DIFF
--- a/Frameworks/EOF/ERRest/Resources/Properties
+++ b/Frameworks/EOF/ERRest/Resources/Properties
@@ -1,3 +1,6 @@
 ##  Properies Info
 er.extensions.load.Properties.framework.ERRest=load
 er.extensions.ERRest.hasLocalization=false
+
+er.rest.rfcDateFormat=rfc822
+er.rest.format16BytesDataAsUUID=true

--- a/Frameworks/EOF/ERRest/Resources/Properties
+++ b/Frameworks/EOF/ERRest/Resources/Properties
@@ -3,4 +3,4 @@ er.extensions.load.Properties.framework.ERRest=load
 er.extensions.ERRest.hasLocalization=false
 
 er.rest.rfcDateFormat=rfc822
-er.rest.format16BytesDataAsUUID=true
+er.rest.format16BytesDataAsUUID=false

--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestUtils.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestUtils.java
@@ -176,7 +176,7 @@ public class ERXRestUtils {
 		}
 		else if (value instanceof NSData) {
 			NSData valueData = (NSData) value;
-			if (valueData.length() == 16 && ERXProperties.booleanForKeyWithDefault("er.rest.format16BytesDataAsUUID", true)) {
+			if (valueData.length() == 16 && ERXProperties.booleanForKeyWithDefault("er.rest.format16BytesDataAsUUID", false)) {
 				formattedValue = UUIDUtilities.encodeAsPrettyString(valueData);
 			}
 			else {

--- a/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestUtils.java
+++ b/Frameworks/EOF/ERRest/Sources/er/rest/ERXRestUtils.java
@@ -28,6 +28,7 @@ import com.webobjects.foundation._NSUtilities;
 import er.extensions.crypting.ERXCryptoString;
 import er.extensions.foundation.ERXProperties;
 import er.extensions.foundation.ERXValueUtilities;
+import er.extensions.foundation.UUIDUtilities;
 
 /**
  * Miscellaneous rest-related utility methods.
@@ -174,13 +175,18 @@ public class ERXRestUtils {
 			formattedValue = NSPropertyListSerialization.stringFromPropertyList(value);
 		}
 		else if (value instanceof NSData) {
-			formattedValue = Base64.getEncoder().encodeToString(((NSData) value).bytes());
+			NSData valueData = (NSData) value;
+			if (valueData.length() == 16 && ERXProperties.booleanForKeyWithDefault("er.rest.format16BytesDataAsUUID", true)) {
+				formattedValue = UUIDUtilities.encodeAsPrettyString(valueData);
+			}
+			else {
+				formattedValue = Base64.getEncoder().encodeToString(((NSData) value).bytes());
+			}
 		}
 		else {
 			formattedValue = value.toString();
 		}
 		return formattedValue;
-
 	}
 
 	// this "spaces" attribute is stupid, i know ... this whole api is stupid.  it's a quick hack for now to accommodate someone very near and dear to my heart ... yes i'm talking to you.


### PR DESCRIPTION
 NSData as pretty uuid string in json. This option only affect exactly 16 bytes data values.

Add er.rest.rfcDateFormat=rfc822 line in the default property file (with the existing defualt value) to make the existence of this property more visible.