### PR TITLE
Add observeDescendentFields support in AjaxUpdateContainer 

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxUpdateContainer.api
+++ b/Frameworks/Ajax/Ajax/Components/AjaxUpdateContainer.api
@@ -5,6 +5,7 @@
 		<binding name="elementName"/>
 		<binding name="observeFieldID"/>
 		<binding name="observeFieldFrequency"/>
+		<binding defaults="Boolean" name="observeDescendentFields"/>
 		<binding name="action"/>
 		<binding name="fullSubmit"/>
 		<binding name="skipFunction"/>
@@ -23,12 +24,11 @@
 		<binding name="insertionDuration"/>
 		<binding name="beforeInsertionDuration"/>
 		<binding name="afterInsertionDuration"/>
-
     
-	<binding name="id"/>
-        <binding name="asynchronous"/>
-    <binding defaults="Boolean" name="stopped"/>
-    <binding name="class"/>
-    <binding name="style"/>
+		<binding name="id"/>
+		<binding name="asynchronous"/>
+		<binding defaults="Boolean" name="stopped"/>
+	    <binding name="class"/>
+	    <binding name="style"/>
     </wo>
 </wodefinitions>


### PR DESCRIPTION
to observe all descendant fields. Very useful to create updatable container that observe field using special elements like thead, tbody or tr that does not supports inner or outer div.