### PR TITLE
[WIP] Replace log4j with slf4j

### DIFF
--- a/Applications/BugTracker/Sources/er/bugtracker/DirectAction.java
+++ b/Applications/BugTracker/Sources/er/bugtracker/DirectAction.java
@@ -78,7 +78,7 @@ public class DirectAction extends ERD2WDirectAction {
             ec.saveChanges();
             result = pageWithName("ERXSuccess");
         } catch (Exception e) {
-            log.error(e);
+            log.error(e.getMessage(), e);
         } finally {
             ERCoreBusinessLogic.setActor(null);
             ec.unlock();

--- a/Examples/Misc/ERIndexingExample/Sources/er/indexing/example/DirectAction.java
+++ b/Examples/Misc/ERIndexingExample/Sources/er/indexing/example/DirectAction.java
@@ -45,15 +45,15 @@ public class DirectAction extends ERD2WDirectAction {
         _EOMutableKnownKeyDictionary vals;
         _EOMutableKnownKeyDictionary.Initializer initializer = new _EOMutableKnownKeyDictionary.Initializer(keys);
         vals = new _EOMutableKnownKeyDictionary(initializer);
-        log.info(vals);
+        log.info(vals.toString());
         vals.setObjectForKey("t1", "test1");
-        log.info(vals);
+        log.info(vals.toString());
         vals.setObjectForKey("t2", "test2");
-        log.info(vals);
+        log.info(vals.toString());
         vals.setObjectForKey("t3", "test3");
-        log.info(vals);
+        log.info(vals.toString());
         vals = new _EOMutableKnownKeyDictionary(initializer, new Object[]{"1", "2"});
-        log.info(vals);
+        log.info(vals.toString());
 //        ERXRemoteNotificationCenter.defaultCenter().postNotification("All", null, dict);
         return pageWithName(Main.class);
     }

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxRemoteLogging.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxRemoteLogging.java
@@ -1,6 +1,7 @@
 package er.ajax;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOAssociation;
@@ -92,11 +93,8 @@ public class AjaxRemoteLogging extends AjaxDynamicElement {
 			}
 			// trigger session loading if present
 			WOSession existing = existingSession();
-			Logger log = Logger.getLogger(logger);
-			if ("fatal".equalsIgnoreCase(level)) {
-				log.fatal(msg);
-			}
-			else if ("error".equalsIgnoreCase(level)) {
+			Logger log = LoggerFactory.getLogger(logger);
+			if ("error".equalsIgnoreCase(level)) {
 				log.error(msg);
 			}
 			else if ("warn".equalsIgnoreCase(level)) {
@@ -107,6 +105,9 @@ public class AjaxRemoteLogging extends AjaxDynamicElement {
 			}
 			else if ("debug".equalsIgnoreCase(level)) {
 				log.debug(msg);
+			}
+			else if ("trace".equalsIgnoreCase(level)) {
+				log.trace(msg);
 			}
 			return new ERXResponse();
 		}

--- a/Frameworks/Ajax/ERJQMobile/Sources/er/jqm/ERJQMobile.java
+++ b/Frameworks/Ajax/ERJQMobile/Sources/er/jqm/ERJQMobile.java
@@ -1,6 +1,7 @@
 package er.jqm;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.ERXFrameworkPrincipal;
 
@@ -13,7 +14,7 @@ public class ERJQMobile extends ERXFrameworkPrincipal
 {
 	public static Class[] REQUIRES = new Class[0];
 
-	public static final Logger log = Logger.getLogger(ERJQMobile.class);
+	public static final Logger log = LoggerFactory.getLogger(ERJQMobile.class);
 
 	public static String frameworkName()
 	{

--- a/Frameworks/Ajax/ERJQueryMobile/Sources/er/jquerymobile/ERJQueryMobile.java
+++ b/Frameworks/Ajax/ERJQueryMobile/Sources/er/jquerymobile/ERJQueryMobile.java
@@ -1,6 +1,7 @@
 package er.jquerymobile;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.ERXExtensions;
 import er.extensions.ERXFrameworkPrincipal;
@@ -40,7 +41,7 @@ public class ERJQueryMobile extends ERXFrameworkPrincipal {
   @Override
   public void finishInitialization() {
     // ログ・サポート
-    _log = Logger.getLogger(ERXExtensions.class);
+    _log = LoggerFactory.getLogger(ERXExtensions.class);
     if(_log.isDebugEnabled())
       _log.debug("doing now " + frameworkName() + ".finishInitialization() for setup the Framework.");
 

--- a/Frameworks/BusinessLogic/ERAttachment/EOTemplates/WonderEntity.java
+++ b/Frameworks/BusinessLogic/ERAttachment/EOTemplates/WonderEntity.java
@@ -2,9 +2,10 @@
 package $entity.packageName;
 
 #end
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public#if (${entity.abstractEntity}) abstract#end class ${entity.classNameWithoutPackage} extends ${entity.prefixClassNameWithOptionalPackage} {
 	@SuppressWarnings("unused")
-	private static Logger log = Logger.getLogger(${entity.classNameWithoutPackage}.class);
+	private static Logger log = LoggerFactory.getLogger(${entity.classNameWithoutPackage}.class);
 }

--- a/Frameworks/BusinessLogic/ERAttachment/EOTemplates/_WonderEntity.java
+++ b/Frameworks/BusinessLogic/ERAttachment/EOTemplates/_WonderEntity.java
@@ -8,7 +8,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -39,7 +40,7 @@ public abstract class ${entity.prefixClassNameWithoutPackage} extends #if ($enti
   public static final String ${relationship.uppercaseUnderscoreName}_KEY = ${relationship.uppercaseUnderscoreName}.key();
 #end
 
-  private static Logger LOG = Logger.getLogger(${entity.prefixClassNameWithoutPackage}.class);
+  private static Logger LOG = LoggerFactory.getLogger(${entity.prefixClassNameWithoutPackage}.class);
 
 #if (!$entity.partialEntitySet)
   public $entity.classNameWithOptionalPackage localInstanceIn(EOEditingContext editingContext) {

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/components/ERAttachmentFlexibleEditor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/components/ERAttachmentFlexibleEditor.java
@@ -1,6 +1,7 @@
 package er.attachment.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOContext;
@@ -83,7 +84,7 @@ public class ERAttachmentFlexibleEditor extends ERXNonSynchronizingComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 	
-	protected final Logger log = Logger.getLogger(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	public static interface Keys {
 		public static final String masterObject = "masterObject";

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERAttachment.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERAttachment.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -51,7 +52,7 @@ public abstract class _ERAttachment extends er.extensions.eof.ERXGenericRecord {
   public static final String CHILDREN_ATTACHMENTS_KEY = CHILDREN_ATTACHMENTS.key();
   public static final String PARENT_ATTACHMENT_KEY = PARENT_ATTACHMENT.key();
 
-  private static Logger LOG = Logger.getLogger(_ERAttachment.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERAttachment.class);
 
   public ERAttachment localInstanceIn(EOEditingContext editingContext) {
     ERAttachment localInstance = (ERAttachment)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERAttachmentData.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERAttachmentData.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -23,7 +24,7 @@ public abstract class _ERAttachmentData extends er.extensions.eof.ERXGenericReco
   public static final String DATA_KEY = DATA.key();
   // Relationships
 
-  private static Logger LOG = Logger.getLogger(_ERAttachmentData.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERAttachmentData.class);
 
   public ERAttachmentData localInstanceIn(EOEditingContext editingContext) {
     ERAttachmentData localInstance = (ERAttachmentData)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERCloudFilesAttachment.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERCloudFilesAttachment.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -53,7 +54,7 @@ public abstract class _ERCloudFilesAttachment extends er.attachment.model.ERAtta
   public static final String CHILDREN_ATTACHMENTS_KEY = CHILDREN_ATTACHMENTS.key();
   public static final String PARENT_ATTACHMENT_KEY = PARENT_ATTACHMENT.key();
 
-  private static Logger LOG = Logger.getLogger(_ERCloudFilesAttachment.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERCloudFilesAttachment.class);
 
   public ERCloudFilesAttachment localInstanceIn(EOEditingContext editingContext) {
     ERCloudFilesAttachment localInstance = (ERCloudFilesAttachment)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERDatabaseAttachment.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERDatabaseAttachment.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -55,7 +56,7 @@ public abstract class _ERDatabaseAttachment extends er.attachment.model.ERAttach
   public static final String CHILDREN_ATTACHMENTS_KEY = CHILDREN_ATTACHMENTS.key();
   public static final String PARENT_ATTACHMENT_KEY = PARENT_ATTACHMENT.key();
 
-  private static Logger LOG = Logger.getLogger(_ERDatabaseAttachment.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERDatabaseAttachment.class);
 
   public ERDatabaseAttachment localInstanceIn(EOEditingContext editingContext) {
     ERDatabaseAttachment localInstance = (ERDatabaseAttachment)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERFileAttachment.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERFileAttachment.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -53,7 +54,7 @@ public abstract class _ERFileAttachment extends er.attachment.model.ERAttachment
   public static final String CHILDREN_ATTACHMENTS_KEY = CHILDREN_ATTACHMENTS.key();
   public static final String PARENT_ATTACHMENT_KEY = PARENT_ATTACHMENT.key();
 
-  private static Logger LOG = Logger.getLogger(_ERFileAttachment.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERFileAttachment.class);
 
   public ERFileAttachment localInstanceIn(EOEditingContext editingContext) {
     ERFileAttachment localInstance = (ERFileAttachment)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERS3Attachment.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/model/_ERS3Attachment.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -53,7 +54,7 @@ public abstract class _ERS3Attachment extends er.attachment.model.ERAttachment {
   public static final String CHILDREN_ATTACHMENTS_KEY = CHILDREN_ATTACHMENTS.key();
   public static final String PARENT_ATTACHMENT_KEY = PARENT_ATTACHMENT.key();
 
-  private static Logger LOG = Logger.getLogger(_ERS3Attachment.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERS3Attachment.class);
 
   public ERS3Attachment localInstanceIn(EOEditingContext editingContext) {
     ERS3Attachment localInstance = (ERS3Attachment)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERAttachmentProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERAttachmentProcessor.java
@@ -5,7 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -52,7 +53,7 @@ import er.extensions.validation.ERXValidationException;
  * @author mschrag
  */
 public abstract class ERAttachmentProcessor<T extends ERAttachment> {
-  public static final Logger log = Logger.getLogger(ERAttachmentProcessor.class);
+  public static final Logger log = LoggerFactory.getLogger(ERAttachmentProcessor.class);
 
   private static final String EXT_VARIABLE = "\\$\\{ext\\}";
   private static final String HASH_VARIABLE = "\\$\\{hash\\}";

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERCloudFilesAttachmentProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERCloudFilesAttachmentProcessor.java
@@ -149,7 +149,7 @@ public class ERCloudFilesAttachmentProcessor extends
 						ERAttachmentRequestHandler.REQUEST_HANDLER_KEY,
 						attachmentUrl, null);
 			} catch (MalformedURLException e) {
-				log.fatal(
+				log.error(
 						"attachment.cfPath() is returning something that isn't a valid URl. This is a bt strange. I'm going to reutrn it in it's raw format which will result in either a 'url cannot be found' error or may result in a 403 from CloudFiles.",
 						e);
 			}

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERS3AttachmentProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/processors/ERS3AttachmentProcessor.java
@@ -143,7 +143,7 @@ public class ERS3AttachmentProcessor extends
 						ERAttachmentRequestHandler.REQUEST_HANDLER_KEY,
 						attachmentUrl, null);
 			} catch (MalformedURLException e) {
-				log.fatal(
+				log.error(
 						"attachment.s3Path() is returning something that isn't a valid URl. This is a bt strange. I'm going to reutrn it in it's raw format which will result in either a 'url cannot be found' error or may result in a 403 from s3.",
 						e);
 			}

--- a/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/thumbnail/ERImageProcessor.java
+++ b/Frameworks/BusinessLogic/ERAttachment/Sources/er/attachment/thumbnail/ERImageProcessor.java
@@ -3,7 +3,8 @@ package er.attachment.thumbnail;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.attachment.utils.ERMimeType;
 import er.attachment.utils.ERMimeTypeManager;
@@ -19,7 +20,7 @@ import er.extensions.foundation.ERXProperties;
  * @author mschrag
  */
 public abstract class ERImageProcessor implements IERImageProcessor {
-  public static final Logger log = Logger.getLogger(ERImageProcessor.class);
+  public static final Logger log = LoggerFactory.getLogger(ERImageProcessor.class);
 
   public static volatile IERImageProcessor _imageProcessor;
 

--- a/Frameworks/BusinessLogic/ERCoreBusinessLogic/Support/TemplateSubclass.eotemplate
+++ b/Frameworks/BusinessLogic/ERCoreBusinessLogic/Support/TemplateSubclass.eotemplate
@@ -8,7 +8,7 @@ import com.webobjects.eocontrol.*;
 public class <$classNameWithoutPackage$> extends _<$classNameWithoutPackage$><$if userInfo.interfaces$> 
     implements <$userInfo.interfaces$><$endif$> {
 
-    private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(<$classNameWithoutPackage$>.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(<$classNameWithoutPackage$>.class);
 
     public static final <$classNameWithoutPackage$>Clazz clazz = new <$classNameWithoutPackage$>Clazz();
     public static class <$classNameWithoutPackage$>Clazz extends _<$classNameWithoutPackage$>._<$classNameWithoutPackage$>Clazz {/* more clazz methods here */}

--- a/Frameworks/BusinessLogic/ERMoviesLogic/EOTemplates/WonderEntity.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/EOTemplates/WonderEntity.java
@@ -2,9 +2,10 @@
 package $entity.packageName;
 
 #end
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public#if (${entity.abstractEntity}) abstract#end class ${entity.classNameWithoutPackage} extends ${entity.prefixClassNameWithOptionalPackage} {
 	@SuppressWarnings("unused")
-	private static Logger log = Logger.getLogger(${entity.classNameWithoutPackage}.class);
+	private static Logger log = LoggerFactory.getLogger(${entity.classNameWithoutPackage}.class);
 }

--- a/Frameworks/BusinessLogic/ERMoviesLogic/EOTemplates/_WonderEntity.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/EOTemplates/_WonderEntity.java
@@ -8,7 +8,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -39,7 +40,7 @@ public abstract class ${entity.prefixClassNameWithoutPackage} extends #if ($enti
   public static final String ${relationship.uppercaseUnderscoreName}_KEY = ${relationship.uppercaseUnderscoreName}.key();
 #end
 
-  private static Logger LOG = Logger.getLogger(${entity.prefixClassNameWithoutPackage}.class);
+  private static Logger LOG = LoggerFactory.getLogger(${entity.prefixClassNameWithoutPackage}.class);
 
 #if (!$entity.partialEntitySet)
   public $entity.classNameWithOptionalPackage localInstanceIn(EOEditingContext editingContext) {

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_AppUser.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_AppUser.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -23,7 +24,7 @@ public abstract class _AppUser extends er.extensions.eof.ERXGenericRecord {
   public static final String USER_NAME_KEY = USER_NAME.key();
   // Relationships
 
-  private static Logger LOG = Logger.getLogger(_AppUser.class);
+  private static Logger LOG = LoggerFactory.getLogger(_AppUser.class);
 
   public AppUser localInstanceIn(EOEditingContext editingContext) {
     AppUser localInstance = (AppUser)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Movie.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Movie.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -49,7 +50,7 @@ public abstract class _Movie extends er.extensions.eof.ERXGenericRecord {
   public static final String STUDIO_KEY = STUDIO.key();
   public static final String VOTING_KEY = VOTING.key();
 
-  private static Logger LOG = Logger.getLogger(_Movie.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Movie.class);
 
   public Movie localInstanceIn(EOEditingContext editingContext) {
     Movie localInstance = (Movie)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_MovieRole.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_MovieRole.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -27,7 +28,7 @@ public abstract class _MovieRole extends er.extensions.eof.ERXGenericRecord {
   public static final String MOVIE_KEY = MOVIE.key();
   public static final String TALENT_KEY = TALENT.key();
 
-  private static Logger LOG = Logger.getLogger(_MovieRole.class);
+  private static Logger LOG = LoggerFactory.getLogger(_MovieRole.class);
 
   public MovieRole localInstanceIn(EOEditingContext editingContext) {
     MovieRole localInstance = (MovieRole)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_PlotSummary.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_PlotSummary.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -25,7 +26,7 @@ public abstract class _PlotSummary extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String MOVIE_KEY = MOVIE.key();
 
-  private static Logger LOG = Logger.getLogger(_PlotSummary.class);
+  private static Logger LOG = LoggerFactory.getLogger(_PlotSummary.class);
 
   public PlotSummary localInstanceIn(EOEditingContext editingContext) {
     PlotSummary localInstance = (PlotSummary)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Review.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Review.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -27,7 +28,7 @@ public abstract class _Review extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String MOVIE_KEY = MOVIE.key();
 
-  private static Logger LOG = Logger.getLogger(_Review.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Review.class);
 
   public Review localInstanceIn(EOEditingContext editingContext) {
     Review localInstance = (Review)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Talent.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Talent.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -31,7 +32,7 @@ public abstract class _Talent extends er.extensions.eof.ERXGenericRecord {
   public static final String PHOTO_KEY = PHOTO.key();
   public static final String ROLES_KEY = ROLES.key();
 
-  private static Logger LOG = Logger.getLogger(_Talent.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Talent.class);
 
   public Talent localInstanceIn(EOEditingContext editingContext) {
     Talent localInstance = (Talent)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_TalentPhoto.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_TalentPhoto.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -25,7 +26,7 @@ public abstract class _TalentPhoto extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String TALENT_KEY = TALENT.key();
 
-  private static Logger LOG = Logger.getLogger(_TalentPhoto.class);
+  private static Logger LOG = LoggerFactory.getLogger(_TalentPhoto.class);
 
   public TalentPhoto localInstanceIn(EOEditingContext editingContext) {
     TalentPhoto localInstance = (TalentPhoto)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Voting.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/common/_Voting.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -27,7 +28,7 @@ public abstract class _Voting extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String MOVIE_KEY = MOVIE.key();
 
-  private static Logger LOG = Logger.getLogger(_Voting.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Voting.class);
 
   public Voting localInstanceIn(EOEditingContext editingContext) {
     Voting localInstance = (Voting)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/server/_Studio.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/movies/server/_Studio.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -27,7 +28,7 @@ public abstract class _Studio extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String MOVIES_KEY = MOVIES.key();
 
-  private static Logger LOG = Logger.getLogger(_Studio.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Studio.class);
 
   public Studio localInstanceIn(EOEditingContext editingContext) {
     Studio localInstance = (Studio)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_CreditCard.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_CreditCard.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -33,7 +34,7 @@ public abstract class _CreditCard extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String CUSTOMER_KEY = CUSTOMER.key();
 
-  private static Logger LOG = Logger.getLogger(_CreditCard.class);
+  private static Logger LOG = LoggerFactory.getLogger(_CreditCard.class);
 
   public CreditCard localInstanceIn(EOEditingContext editingContext) {
     CreditCard localInstance = (CreditCard)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Customer.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Customer.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -41,7 +42,7 @@ public abstract class _Customer extends er.extensions.eof.ERXGenericRecord {
   public static final String CREDIT_CARD_KEY = CREDIT_CARD.key();
   public static final String RENTALS_KEY = RENTALS.key();
 
-  private static Logger LOG = Logger.getLogger(_Customer.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Customer.class);
 
   public Customer localInstanceIn(EOEditingContext editingContext) {
     Customer localInstance = (Customer)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Fee.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Fee.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -29,7 +30,7 @@ public abstract class _Fee extends er.extensions.eof.ERXGenericRecord {
   public static final String FEE_TYPE_KEY = FEE_TYPE.key();
   public static final String RENTAL_KEY = RENTAL.key();
 
-  private static Logger LOG = Logger.getLogger(_Fee.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Fee.class);
 
   public Fee localInstanceIn(EOEditingContext editingContext) {
     Fee localInstance = (Fee)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_FeeType.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_FeeType.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -27,7 +28,7 @@ public abstract class _FeeType extends er.extensions.eof.ERXGenericRecord {
   public static final String ORDER_BY_KEY = ORDER_BY.key();
   // Relationships
 
-  private static Logger LOG = Logger.getLogger(_FeeType.class);
+  private static Logger LOG = LoggerFactory.getLogger(_FeeType.class);
 
   public FeeType localInstanceIn(EOEditingContext editingContext) {
     FeeType localInstance = (FeeType)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Rental.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Rental.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -31,7 +32,7 @@ public abstract class _Rental extends er.extensions.eof.ERXGenericRecord {
   public static final String FEES_KEY = FEES.key();
   public static final String UNIT_KEY = UNIT.key();
 
-  private static Logger LOG = Logger.getLogger(_Rental.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Rental.class);
 
   public Rental localInstanceIn(EOEditingContext editingContext) {
     Rental localInstance = (Rental)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_RentalTerms.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_RentalTerms.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -29,7 +30,7 @@ public abstract class _RentalTerms extends er.extensions.eof.ERXGenericRecord {
   public static final String NAME_KEY = NAME.key();
   // Relationships
 
-  private static Logger LOG = Logger.getLogger(_RentalTerms.class);
+  private static Logger LOG = LoggerFactory.getLogger(_RentalTerms.class);
 
   public RentalTerms localInstanceIn(EOEditingContext editingContext) {
     RentalTerms localInstance = (RentalTerms)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Unit.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Unit.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -31,7 +32,7 @@ public abstract class _Unit extends er.extensions.eof.ERXGenericRecord {
   public static final String RENTALS_KEY = RENTALS.key();
   public static final String VIDEO_KEY = VIDEO.key();
 
-  private static Logger LOG = Logger.getLogger(_Unit.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Unit.class);
 
   public Unit localInstanceIn(EOEditingContext editingContext) {
     Unit localInstance = (Unit)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_User.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_User.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -29,7 +30,7 @@ public abstract class _User extends er.extensions.eof.ERXGenericRecord {
   // Relationships
   public static final String CUSTOMER_KEY = CUSTOMER.key();
 
-  private static Logger LOG = Logger.getLogger(_User.class);
+  private static Logger LOG = LoggerFactory.getLogger(_User.class);
 
   public User localInstanceIn(EOEditingContext editingContext) {
     User localInstance = (User)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Video.java
+++ b/Frameworks/BusinessLogic/ERMoviesLogic/Sources/webobjectsexamples/businesslogic/rentals/common/_Video.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -27,7 +28,7 @@ public abstract class _Video extends er.extensions.eof.ERXGenericRecord {
   public static final String RENTAL_TERMS_KEY = RENTAL_TERMS.key();
   public static final String UNITS_KEY = UNITS.key();
 
-  private static Logger LOG = Logger.getLogger(_Video.class);
+  private static Logger LOG = LoggerFactory.getLogger(_Video.class);
 
   public Video localInstanceIn(EOEditingContext editingContext) {
     Video localInstance = (Video)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/BusinessLogic/ERTaggable/EOTemplates/WonderEntity.java
+++ b/Frameworks/BusinessLogic/ERTaggable/EOTemplates/WonderEntity.java
@@ -2,9 +2,10 @@
 package $entity.packageName;
 
 #end
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public#if (${entity.abstractEntity}) abstract#end class ${entity.classNameWithoutPackage} extends ${entity.prefixClassNameWithOptionalPackage} {
 	@SuppressWarnings("unused")
-	private static Logger log = Logger.getLogger(${entity.classNameWithoutPackage}.class);
+	private static Logger log = LoggerFactory.getLogger(${entity.classNameWithoutPackage}.class);
 }

--- a/Frameworks/BusinessLogic/ERTaggable/EOTemplates/_WonderEntity.java
+++ b/Frameworks/BusinessLogic/ERTaggable/EOTemplates/_WonderEntity.java
@@ -8,7 +8,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -39,7 +40,7 @@ public abstract class ${entity.prefixClassNameWithoutPackage} extends #if ($enti
   public static final String ${relationship.uppercaseUnderscoreName}_KEY = ${relationship.uppercaseUnderscoreName}.key();
 #end
 
-  private static Logger LOG = Logger.getLogger(${entity.prefixClassNameWithoutPackage}.class);
+  private static Logger LOG = LoggerFactory.getLogger(${entity.prefixClassNameWithoutPackage}.class);
 
 #if (!$entity.partialEntitySet)
   public $entity.classNameWithOptionalPackage localInstanceIn(EOEditingContext editingContext) {

--- a/Frameworks/BusinessLogic/ERTaggable/Sources/er/taggable/model/_ERTag.java
+++ b/Frameworks/BusinessLogic/ERTaggable/Sources/er/taggable/model/_ERTag.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -23,7 +24,7 @@ public abstract class _ERTag extends er.extensions.eof.ERXGenericRecord {
   public static final String NAME_KEY = NAME.key();
   // Relationships
 
-  private static Logger LOG = Logger.getLogger(_ERTag.class);
+  private static Logger LOG = LoggerFactory.getLogger(_ERTag.class);
 
   public ERTag localInstanceIn(EOEditingContext editingContext) {
     ERTag localInstance = (ERTag)EOUtilities.localInstanceOfObject(editingContext, this);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WContextDictionary.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WContextDictionary.java
@@ -8,7 +8,8 @@ package er.directtoweb;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.Assignment;
 import com.webobjects.directtoweb.BooleanAssignment;
@@ -46,7 +47,7 @@ import er.extensions.foundation.ERXDictionaryUtilities;
  */
 
 public class ERD2WContextDictionary {
-    private static final Logger log = Logger.getLogger(ERD2WContextDictionary.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WContextDictionary.class);
 
     public static class Configuration {
    		

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WControllerFactory.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WControllerFactory.java
@@ -1,6 +1,7 @@
 package er.directtoweb;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOApplication;
 import com.webobjects.appserver.WOComponent;
@@ -54,7 +55,7 @@ will spare you a lot of work.
 public class ERD2WControllerFactory extends ERD2WFactory {
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WControllerFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WControllerFactory.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WDirectAction.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WDirectAction.java
@@ -8,7 +8,8 @@ package er.directtoweb;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOComponent;
@@ -98,8 +99,8 @@ import er.extensions.foundation.ERXValueUtilities;
 public abstract class ERD2WDirectAction extends ERXDirectAction {
 
     /** logging support */
-    protected static final Logger log = Logger.getLogger(ERD2WDirectAction.class);
-    protected final Logger actionLog = Logger.getLogger(ERD2WDirectAction.class.getName() + ".actions");
+    protected static final Logger log = LoggerFactory.getLogger(ERD2WDirectAction.class);
+    protected final Logger actionLog = LoggerFactory.getLogger(ERD2WDirectAction.class.getName() + ".actions");
 
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WFactory.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WFactory.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOApplication;
 import com.webobjects.appserver.WOComponent;
@@ -98,7 +99,7 @@ public class ERD2WFactory extends D2W {
 	}
 
 	/** logging support */
-    protected static final Logger log = Logger.getLogger(ERD2WFactory.class);
+    protected static final Logger log = LoggerFactory.getLogger(ERD2WFactory.class);
 
     /**
      * Gets the D2W factory cast as an ERD2WFactory objects.

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WModel.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERD2WModel.java
@@ -22,7 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOApplication;
 import com.webobjects.directtoweb.Assignment;
@@ -78,13 +79,13 @@ import er.extensions.localization.ERXLocalizer;
 public class ERD2WModel extends D2WModel {
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WModel.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WModel.class);
 
     /** logs rules being decoded */
-    public static final Logger ruleDecodeLog = Logger.getLogger("er.directtoweb.rules.decode");
+    public static final Logger ruleDecodeLog = LoggerFactory.getLogger("er.directtoweb.rules.decode");
 
     /** main category for enabling or disabling tracing of rules */
-    public static final Logger ruleTraceEnabledLog = Logger.getLogger("er.directtoweb.rules.ERD2WTraceRuleFiringEnabled");
+    public static final Logger ruleTraceEnabledLog = LoggerFactory.getLogger("er.directtoweb.rules.ERD2WTraceRuleFiringEnabled");
 
     //	===========================================================================
     //	Notification Title(s)
@@ -306,8 +307,8 @@ public class ERD2WModel extends D2WModel {
             boolean resetTraceRuleFiring = false;
             Logger ruleFireLog=null;
             if (ruleTraceEnabledLog.isDebugEnabled()) {
-                Logger ruleCandidatesLog = Logger.getLogger("er.directtoweb.rules." + keyPath + ".candidates");
-                ruleFireLog = Logger.getLogger("er.directtoweb.rules." + keyPath + ".fire");
+                Logger ruleCandidatesLog = LoggerFactory.getLogger("er.directtoweb.rules." + keyPath + ".candidates");
+                ruleFireLog = LoggerFactory.getLogger("er.directtoweb.rules." + keyPath + ".fire");
                 if (ruleFireLog.isDebugEnabled() && !NSLog.debugLoggingAllowedForGroups(NSLog.DebugGroupRules)) {
                     NSLog.allowDebugLoggingForGroups(NSLog.DebugGroupRules);
                     //NSLog.setAllowedDebugLevel(NSLog.DebugLevelDetailed);
@@ -340,7 +341,7 @@ public class ERD2WModel extends D2WModel {
             }
         } else {
             if (ruleTraceEnabledLog.isDebugEnabled()) {
-                Logger ruleLog = Logger.getLogger("er.directtoweb.rules." + keyPath + ".cache");
+                Logger ruleLog = LoggerFactory.getLogger("er.directtoweb.rules." + keyPath + ".cache");
                 if (ruleLog.isDebugEnabled())
                 	ruleLog.debug("CACHE: " + keyPath + " for propertyKey: " + context.propertyKey() + " depends on: "  + new NSArray(significantKeys) + " = " + k
                                   + " value: " + (result==NULL_VALUE ? "<NULL>" : (result instanceof EOEntity ? ((EOEntity)result).name() : result)));
@@ -361,7 +362,7 @@ public class ERD2WModel extends D2WModel {
             try {
                 ERXFileUtilities.writeInputStreamToFile(new ByteArrayInputStream(cacheToBytes(_cache)), new File(fileName));
             } catch(IOException ex) {
-                log.error(ex);
+                log.error(ex.getMessage(), ex);
             }
         }
     }
@@ -373,7 +374,7 @@ public class ERD2WModel extends D2WModel {
             try {
                 _cache = cacheFromBytes(ERXFileUtilities.bytesFromFile(new File(fileName)));
             } catch(IOException ex) {
-                log.error(ex);
+                log.error(ex.getMessage(), ex);
             }
         }
     }
@@ -750,7 +751,7 @@ public class ERD2WModel extends D2WModel {
             flushUniqueCache();
             if (uniquedQualifiers > 0)
                 ERXExtensions.forceGC(0);
-            if (log.isDebugEnabled()) 
+            if (log.isDebugEnabled())
               log.debug("Finished Qualifier uniquing, for: " + totalQualifiers
                                                 + " got rid of " + uniquedQualifiers + " duplicate qualifiers, replaced: " + replacedQualifiers);
         }
@@ -1085,7 +1086,7 @@ public class ERD2WModel extends D2WModel {
             ostream.close();
             return ostream.toByteArray();
         } catch(Exception ex) {
-            log.error(ex,ex);
+            log.error(ex.getMessage(),ex);
         }
         return null;
     }
@@ -1109,7 +1110,7 @@ public class ERD2WModel extends D2WModel {
             istream.close();
             return newCache;
         } catch(Exception ex) {
-            log.error(ex,ex);
+            log.error(ex.getMessage(),ex);
         }
         return null;
     }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERDirectToWeb.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/ERDirectToWeb.java
@@ -9,7 +9,8 @@ package er.directtoweb;
 import java.net.URL;
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -66,15 +67,15 @@ public class ERDirectToWeb extends ERXFrameworkPrincipal {
     public final static Class REQUIRES[] = new Class[] {ERXExtensions.class};
     
     /** logging support */
-    public final static Logger log = Logger.getLogger("er.directtoweb.ERDirectToWeb");
+    public final static Logger log = LoggerFactory.getLogger("er.directtoweb.ERDirectToWeb");
     public final static String D2WDEBUGGING_ENABLED_KEY = "ERDirectToWeb_d2wDebuggingEnabled";
     public final static String D2WDISPLAY_COMPONENTNAMES_KEY = "ERDirectToWeb_displayComponentNames";
     public final static String D2WDISPLAY_PROPERTYKEYS_KEY = "ERDirectToWeb_displayPropertyKeys";
     public final static String D2WDISPLAY_PAGE_METRICS_KEY = "ERDirectToWeb_displayPageMetrics";
     public final static String D2WDISPLAY_DETAILED_PAGE_METRICS_KEY = "ERDirectToWeb_displayDetailedPageMetrics";
-    public final static Logger debugLog = Logger.getLogger("er.directtoweb.ERD2WDebugEnabled");
-    public final static Logger componentNameLog = Logger.getLogger("er.directtoweb.ERD2WDebugEnabled.componentName");
-    public final static Logger propertyKeyLog = Logger.getLogger("er.directtoweb.ERD2WDebugEnabled.propertyKey");
+    public final static Logger debugLog = LoggerFactory.getLogger("er.directtoweb.ERD2WDebugEnabled");
+    public final static Logger componentNameLog = LoggerFactory.getLogger("er.directtoweb.ERD2WDebugEnabled.componentName");
+    public final static Logger propertyKeyLog = LoggerFactory.getLogger("er.directtoweb.ERD2WDebugEnabled.propertyKey");
     public final static NSSelector D2WCONTEXT_SELECTOR = new NSSelector("d2wContext");
 
     static {
@@ -518,7 +519,7 @@ public class ERDirectToWeb extends ERXFrameworkPrincipal {
     private void configureTraceRuleFiringRapidTurnAround() {
         if (trace == null) {
             // otherwise not properly initialized
-            trace = Logger.getLogger("er.directtoweb.rules.D2WTraceRuleFiringEnabled");
+            trace = LoggerFactory.getLogger("er.directtoweb.rules.D2WTraceRuleFiringEnabled");
             // Note: If the configuration file says debug, but the command line parameter doesn't we need to turn
             //   rule tracing on.
             // BOOGIE

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/KeyValueCodingProtectedAccessor.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/KeyValueCodingProtectedAccessor.java
@@ -10,14 +10,15 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.foundation.NSKeyValueCoding;
 
 public class KeyValueCodingProtectedAccessor extends NSKeyValueCoding.ValueAccessor {
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(KeyValueCodingProtectedAccessor.class);
+    public static final Logger log = LoggerFactory.getLogger(KeyValueCodingProtectedAccessor.class);
 
     public KeyValueCodingProtectedAccessor() { super(); }
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/ERDAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/ERDAssignment.java
@@ -9,7 +9,8 @@ package er.directtoweb.assignments;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.Assignment;
 import com.webobjects.directtoweb.D2WContext;
@@ -37,7 +38,7 @@ public abstract class ERDAssignment extends Assignment implements ERDComputingAs
 	private static final long serialVersionUID = 1L;
 
     /** logging supprt */
-    public final static Logger log = Logger.getLogger("er.directtoweb.rules.ERDAssignment");
+    public final static Logger log = LoggerFactory.getLogger("er.directtoweb.rules.ERDAssignment");
 
     /** Cached context class array */
     // MOVEME: ERDConstants

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/ERDImageNameAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/ERDImageNameAssignment.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.assignments;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -25,7 +26,7 @@ public class ERDImageNameAssignment extends ERDAssignment implements ERDLocaliza
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger("er.directtoweb.rules.ERDImageNameAssignment");
+    public static final Logger log = LoggerFactory.getLogger("er.directtoweb.rules.ERDImageNameAssignment");
 
     /** holds the array of keys this assignment depends upon */
     public static final NSArray _DEPENDENT_KEYS=new NSArray(new String[] { "baseImageDirectory", "sectionKey", "tabKey"});

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/ERDLocalizedAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/ERDLocalizedAssignment.java
@@ -2,7 +2,8 @@ package er.directtoweb.assignments;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -32,7 +33,7 @@ public class ERDLocalizedAssignment extends ERDAssignment implements ERDLocaliza
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    static final Logger log = Logger.getLogger(ERDLocalizedAssignment.class);
+    static final Logger log = LoggerFactory.getLogger(ERDLocalizedAssignment.class);
 
     /**
      * Static constructor required by the EOKeyValueUnarchiver

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/defaults/ERDDefaultActionAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/defaults/ERDDefaultActionAssignment.java
@@ -71,7 +71,7 @@ public class ERDDefaultActionAssignment extends ERDAssignment {
      */
     public NSDictionary defaultActions(D2WContext c) {
         NSDictionary actions = new NSDictionary(new Object[] {defaultLeftActions(c), defaultRightActions(c)}, new Object [] {"left", "right"});
-        log.debug(actions);
+        log.debug(actions.toString());
         return actions;
     }
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedExtraQualifierAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedExtraQualifierAssignment.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.assignments.delayed;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOAndQualifier;
@@ -98,7 +99,7 @@ public class ERDDelayedExtraQualifierAssignment extends ERDDelayedAssignment {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERDDelayedExtraQualifierAssignment.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDDelayedExtraQualifierAssignment.class);
 
     /**
      * Static constructor required by the EOKeyValueUnarchiver

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedLocalizedAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedLocalizedAssignment.java
@@ -1,5 +1,6 @@
 package er.directtoweb.assignments.delayed;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -19,7 +20,7 @@ public class ERDDelayedLocalizedAssignment extends ERDDelayedAssignment implemen
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    static final Logger log = Logger.getLogger(ERDDelayedLocalizedAssignment.class);
+    static final Logger log = LoggerFactory.getLogger(ERDDelayedLocalizedAssignment.class);
 
     /**
      * Static constructor required by the EOKeyValueUnarchiver

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedNavigationStateAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedNavigationStateAssignment.java
@@ -1,6 +1,7 @@
 package er.directtoweb.assignments.delayed;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOSession;
 import com.webobjects.directtoweb.D2WContext;
@@ -42,7 +43,7 @@ public class ERDDelayedNavigationStateAssignment extends ERDDelayedAssignment {
     private static final long serialVersionUID = 1L;
 
     /** logging support */
-    static final Logger log = Logger.getLogger(ERDDelayedNavigationStateAssignment.class);
+    static final Logger log = LoggerFactory.getLogger(ERDDelayedNavigationStateAssignment.class);
 
     /**
      * Static constructor required by the EOKeyValueUnarchiver interface. If

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedNonNullConditionalAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedNonNullConditionalAssignment.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.assignments.delayed;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -75,7 +76,7 @@ public class ERDDelayedNonNullConditionalAssignment extends ERDDelayedAssignment
 	private static final ERXKey<String> LOCALIZE = new ERXKey<>("localize");
 
 	/** logging support */
-	public final static Logger log = Logger.getLogger("er.directtoweb.rules.DelayedNonNullConditionalAssigment");
+	public final static Logger log = LoggerFactory.getLogger("er.directtoweb.rules.DelayedNonNullConditionalAssigment");
 
 	/**
 	 * Static constructor required by the EOKeyValueUnarchiver interface. If

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedObjectCreationAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedObjectCreationAssignment.java
@@ -8,7 +8,8 @@ package er.directtoweb.assignments.delayed;
 
 import java.lang.reflect.Constructor;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -49,7 +50,7 @@ public class ERDDelayedObjectCreationAssignment extends ERDDelayedAssignment {
     //	---------------------------------------------------------------------------
     
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERDDelayedObjectCreationAssignment.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDDelayedObjectCreationAssignment.class);
 
     //	===========================================================================
     //	Class method(s)

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedRelationshipFlagAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedRelationshipFlagAssignment.java
@@ -2,7 +2,8 @@ package er.directtoweb.assignments.delayed;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -29,7 +30,7 @@ public class ERDDelayedRelationshipFlagAssignment extends ERDDelayedAssignment {
     }
     
     /** Logging support */
-    public final static Logger log = Logger.getLogger(ERDDelayedRelationshipFlagAssignment.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDDelayedRelationshipFlagAssignment.class);
 
     public ERDDelayedRelationshipFlagAssignment(EOKeyValueUnarchiver u) { super(u); }
     public ERDDelayedRelationshipFlagAssignment(String key, Object value) { super(key,value); }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedRuleAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedRuleAssignment.java
@@ -8,7 +8,8 @@ package er.directtoweb.assignments.delayed;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.directtoweb.Rule;
@@ -36,7 +37,7 @@ public class ERDDelayedRuleAssignment extends ERDDelayedAssignment {
     }
     
     /** Logging support */
-    public final static Logger log = Logger.getLogger(ERDDelayedRuleAssignment.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDDelayedRuleAssignment.class);
 
     public ERDDelayedRuleAssignment(EOKeyValueUnarchiver u) { super(u); }
     public ERDDelayedRuleAssignment(String key, Object value) { super(key,value); }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedSelectorInvocationAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedSelectorInvocationAssignment.java
@@ -4,7 +4,8 @@
 
 package er.directtoweb.assignments.delayed;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.Assignment;
 import com.webobjects.directtoweb.D2WContext;
@@ -74,7 +75,7 @@ public class ERDDelayedSelectorInvocationAssignment extends ERDDelayedAssignment
 
     public static class DefaultImplementation {
 
-        private static final Logger _log = Logger.getLogger(ERDDelayedSelectorInvocationAssignment.class);
+        private static final Logger _log = LoggerFactory.getLogger(ERDDelayedSelectorInvocationAssignment.class);
 
         // we cache 0 - 5 arguments
         private static Class[][] _parameterTypesArrays = new Class[5 + 1][];

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedSwitchAssignment.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/assignments/delayed/ERDDelayedSwitchAssignment.java
@@ -8,7 +8,8 @@ package er.directtoweb.assignments.delayed;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.directtoweb.D2WContext;
 import com.webobjects.eocontrol.EOKeyValueUnarchiver;
@@ -29,7 +30,7 @@ public class ERDDelayedSwitchAssignment extends ERDDelayedAssignment implements 
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public final static Logger log = Logger.getLogger("er.directtoweb.rules.ERDDelayedSwitchAssignment");
+    public final static Logger log = LoggerFactory.getLogger("er.directtoweb.rules.ERDDelayedSwitchAssignment");
 
 
     public static Object decodeWithKeyValueUnarchiver(EOKeyValueUnarchiver eokeyvalueunarchiver)  {

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WCustomComponentWithArgs.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WCustomComponentWithArgs.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WContext;
@@ -36,7 +37,7 @@ public class ERD2WCustomComponentWithArgs extends D2WCustomComponent implements 
     }
     
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERD2WCustomComponentWithArgs.class);
+    public final static Logger log = LoggerFactory.getLogger(ERD2WCustomComponentWithArgs.class);
 
     private Object _extraBindings;
     public Object extraBindings() {

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WCustomQueryComponentWithArgs.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WCustomQueryComponentWithArgs.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -29,6 +30,6 @@ public class ERD2WCustomQueryComponentWithArgs extends ERDCustomQueryComponent i
     }
     
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERD2WCustomQueryComponentWithArgs.class);
+    public final static Logger log = LoggerFactory.getLogger(ERD2WCustomQueryComponentWithArgs.class);
     
 }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WDebugFlags.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WDebugFlags.java
@@ -1,7 +1,5 @@
 package er.directtoweb.components;
 
-import org.apache.log4j.Level;
-
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
 import com.webobjects.woextensions.WOStatsPage;
@@ -44,9 +42,6 @@ public class ERD2WDebugFlags extends WOComponent {
     
     public WOComponent toggleD2WInfo() {    
         boolean currentState = ERDirectToWeb.d2wDebuggingEnabled(session());
-        Level level = currentState ? Level.INFO : Level.DEBUG;
-        ERDirectToWeb.debugLog.setLevel(level);
-        ERD2WModel.ruleTraceEnabledLog.setLevel(level);
         ERDirectToWeb.setD2wDebuggingEnabled(session(), !currentState);
         ERDirectToWeb.setD2wComponentNameDebuggingEnabled(session(), !currentState);
         ERDirectToWeb.setD2wPropertyKeyDebuggingEnabled(session(), !currentState);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WEditOrDefault.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WEditOrDefault.java
@@ -8,7 +8,8 @@ package er.directtoweb.components;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -33,7 +34,7 @@ public class ERD2WEditOrDefault extends D2WComponent {
     public ERD2WEditOrDefault(WOContext context) {super(context);}
     
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WEditOrDefault.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WEditOrDefault.class);
     
     public String radioButtonGroupName() { return name() +"_"+d2wContext().propertyKey(); }
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WFlyOverCustomComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WFlyOverCustomComponent.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WContext;
@@ -27,7 +28,7 @@ public class ERD2WFlyOverCustomComponent extends D2WCustomComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WFlyOverCustomComponent.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WFlyOverCustomComponent.class);
 
     /**
         * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WHead.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WHead.java
@@ -1,5 +1,6 @@
 package er.directtoweb.components;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WContext;
@@ -23,7 +24,7 @@ public class ERD2WHead extends D2WHead {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    static final Logger log = Logger.getLogger(ERD2WHead.class);
+    static final Logger log = LoggerFactory.getLogger(ERD2WHead.class);
 
     protected static D2WContext _d2wContext;
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WPropertyName.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WPropertyName.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -39,7 +40,7 @@ public class ERD2WPropertyName extends ERD2WStatelessComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    public static final Logger log = Logger.getLogger(ERD2WPropertyName.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WPropertyName.class);
 
     protected String _displayNameForProperty;
     protected NSDictionary _contextDictionary;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WSwitchComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERD2WSwitchComponent.java
@@ -8,7 +8,8 @@ package er.directtoweb.components;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOAssociation;
 import com.webobjects.appserver.WOContext;
@@ -47,7 +48,7 @@ public class ERD2WSwitchComponent extends D2WSwitchComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WSwitchComponent.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WSwitchComponent.class);
     
     protected transient NSMutableDictionary<String, Object> extraBindings = new NSMutableDictionary<>(16);
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDActionBar.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDActionBar.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -30,7 +31,7 @@ public class ERDActionBar extends ERDCustomEditComponent implements ERDBranchInt
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDActionBar.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDActionBar.class);
 
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDBannerComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDBannerComponent.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -22,7 +23,7 @@ public class ERDBannerComponent extends ERDCustomComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDBannerComponent.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDBannerComponent.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomComponent.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -61,7 +62,7 @@ public abstract class ERDCustomComponent extends ERXNonSynchronizingComponent im
     }
     
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERDCustomComponent.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDCustomComponent.class);
     
     /** Designated constructor */
     public ERDCustomComponent(WOContext context) {

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomEditComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomEditComponent.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WContext;
@@ -34,7 +35,7 @@ public abstract class ERDCustomEditComponent extends ERDCustomComponent {
 	private static final long serialVersionUID = 2L;
 
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERDCustomEditComponent.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDCustomEditComponent.class);
 
     /** 
      * <span class="en">interface for all the keys used in this pages code</span>

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomQueryComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomQueryComponent.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WODisplayGroup;
@@ -38,7 +39,7 @@ public class ERDCustomQueryComponent extends ERDCustomComponent implements ERXEx
     }
 
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERDCustomQueryComponent.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDCustomQueryComponent.class);
 
     public ERDCustomQueryComponent(WOContext context) {
         super(context);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomQueryComponentWithArgs.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDCustomQueryComponentWithArgs.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -27,5 +28,5 @@ public class ERDCustomQueryComponentWithArgs extends ERDCustomQueryComponent {
     }
     
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERDCustomQueryComponentWithArgs.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDCustomQueryComponentWithArgs.class);
 }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDDebuggingHelp.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDDebuggingHelp.java
@@ -6,8 +6,6 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Level;
-
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOSession;
@@ -19,7 +17,6 @@ import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSMutableDictionary;
 
 import er.directtoweb.ERD2WContextDictionary;
-import er.directtoweb.ERD2WModel;
 import er.directtoweb.ERDirectToWeb;
 import er.directtoweb.pages.ERD2WPage;
 import er.extensions.components.ERXDebugMarker;
@@ -120,9 +117,6 @@ public class ERDDebuggingHelp extends WOComponent implements ERXDebugMarker.Debu
     }
     
     public void toggleRuleTracing() {
-        boolean off = ERD2WModel.ruleTraceEnabledLog.isDebugEnabled();
-        ERDirectToWeb.trace.setLevel(off ? Level.INFO : Level.DEBUG);
-        ERD2WModel.ruleTraceEnabledLog.setLevel(off ? Level.INFO : Level.DEBUG);
         ERDirectToWeb.configureTraceRuleFiring();
     }
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDDefaultCustomComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/ERDDefaultCustomComponent.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -27,7 +28,7 @@ public class ERDDefaultCustomComponent extends WOComponent {
     public ERDDefaultCustomComponent(WOContext context) { super(context); }
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERDDefaultCustomComponent.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDDefaultCustomComponent.class);
 
     @Override
     public boolean isStateless() { return true; }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/bool/ERD2WCustomQueryBoolean.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/bool/ERD2WCustomQueryBoolean.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.bool;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WQueryBoolean;
@@ -38,7 +39,7 @@ public class ERD2WCustomQueryBoolean extends D2WQueryBoolean {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WCustomQueryBoolean.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WCustomQueryBoolean.class);
     protected NSArray<String> _choicesNames;
 	
     /**
@@ -77,7 +78,7 @@ public class ERD2WCustomQueryBoolean extends D2WQueryBoolean {
         } else {
             displayGroup().queryMatch().takeValueForKey(obj, propertyKey());
             if(log.isDebugEnabled())
-              log.debug(obj);
+              log.debug(obj.toString());
         }
     }
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/bool/ERD2WQueryBooleanRadioList.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/bool/ERD2WQueryBooleanRadioList.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.bool;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WQueryBoolean;
@@ -34,7 +35,7 @@ public class ERD2WQueryBooleanRadioList extends D2WQueryBoolean {
 
     /** logging support */
     @SuppressWarnings("unused")
-	private static final Logger log = Logger.getLogger(ERD2WQueryBooleanRadioList.class);
+	private static final Logger log = LoggerFactory.getLogger(ERD2WQueryBooleanRadioList.class);
     protected NSArray<String> _choicesNames;
     
     public ERD2WQueryBooleanRadioList(WOContext context) {

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDActionButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDActionButton.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -31,7 +32,7 @@ public  class ERDActionButton extends ERDCustomComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDActionButton.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDActionButton.class);
 
     public interface Keys {
         public static final String object = "object";

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDControllerButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDControllerButton.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -28,7 +29,7 @@ public class ERDControllerButton extends ERDActionButton implements ERDBranchInt
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDActionBar.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDActionBar.class);
 
     public ERDControllerButton(WOContext context) {
         super(context);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDDeleteButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDDeleteButton.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -33,7 +34,7 @@ public class ERDDeleteButton extends ERDActionButton {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDDeleteButton.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDDeleteButton.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDEditButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDEditButton.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -32,7 +33,7 @@ public class ERDEditButton extends ERDActionButton {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDEditButton.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDEditButton.class);
 
     public ERDEditButton(WOContext context) {super(context);}
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDFilterDisplayGroupButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDFilterDisplayGroupButton.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -39,7 +40,7 @@ public class ERDFilterDisplayGroupButton extends ERDCustomQueryComponent {
 
     public ERDFilterDisplayGroupButton(WOContext context) { super(context); }
 
-    public static final Logger log = Logger.getLogger(ERDFilterDisplayGroupButton.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDFilterDisplayGroupButton.class);
 
     @Override
     public boolean isStateless() { return true; }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDPickIntermediateButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDPickIntermediateButton.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -34,7 +35,7 @@ public class ERDPickIntermediateButton extends ERDActionButton {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDPickIntermediateButton.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDPickIntermediateButton.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDSelectAllButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDSelectAllButton.java
@@ -2,7 +2,8 @@ package er.directtoweb.components.buttons;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -29,7 +30,7 @@ public class ERDSelectAllButton extends ERDActionButton {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDSelectAllButton.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDSelectAllButton.class);
     
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDSelectButton.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/buttons/ERDSelectButton.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.buttons;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -23,7 +24,7 @@ public class ERDSelectButton extends ERDActionButton {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDSelectButton.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDSelectButton.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/dates/ERDEditDateJavascript.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/dates/ERDEditDateJavascript.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.dates;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -33,7 +34,7 @@ public class ERDEditDateJavascript extends ERDCustomEditComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    static final Logger log = Logger.getLogger(ERDEditDateJavascript.class);
+    static final Logger log = LoggerFactory.getLogger(ERDEditDateJavascript.class);
 
     public ERDEditDateJavascript(WOContext context) {super(context);}
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDConfirmMessage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDConfirmMessage.java
@@ -8,7 +8,8 @@ package er.directtoweb.components.misc;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -34,7 +35,7 @@ public class ERDConfirmMessage extends ERDCustomEditComponent {
     public ERDConfirmMessage(WOContext context) { super(context); }
     
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERDConfirmMessage.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDConfirmMessage.class);
     
     public String message;
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDEditFile.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDEditFile.java
@@ -10,7 +10,8 @@ import java.io.OutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOComponent;
@@ -42,7 +43,7 @@ public class ERDEditFile extends ERDCustomEditComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    static final Logger log = Logger.getLogger(ERDEditFile.class);
+    static final Logger log = LoggerFactory.getLogger(ERDEditFile.class);
     // Instance variables for the name and contents of the upload
     public String fileName;
     public String uploadDirectory;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDEditList.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDEditList.java
@@ -8,7 +8,8 @@ package er.directtoweb.components.misc;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -39,7 +40,7 @@ public class ERDEditList extends ERDCustomEditComponent {
 
     public ERDEditList(WOContext context) { super(context); }
 
-    public final static Logger log = Logger.getLogger(ERDEditList.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDEditList.class);
     
     public String choices;
     public String choiceDisplayKey;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDListOrganizer.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDListOrganizer.java
@@ -8,7 +8,8 @@ package er.directtoweb.components.misc;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -39,7 +40,7 @@ public class ERDListOrganizer extends ERDCustomEditComponent {
     public ERDListOrganizer(WOContext context) { super(context); }
     
     /* logging support */
-    public static final Logger log = Logger.getLogger(ERDListOrganizer.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDListOrganizer.class);
 
     public ERXKeyValuePair availableObject;
     public NSMutableArray selectedObjects;   

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDQueryAnyKey.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDQueryAnyKey.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.misc;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.eocontrol.EOQualifier;
@@ -27,7 +28,7 @@ public class ERDQueryAnyKey extends ERDCustomQueryComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDQueryAnyKey.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDQueryAnyKey.class);
     private Object _value; 
     
     /**

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDSavedQueriesComponent.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDSavedQueriesComponent.java
@@ -6,7 +6,8 @@ import java.text.ParseException;
 import java.util.Enumeration;
 
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -61,7 +62,7 @@ public class ERDSavedQueriesComponent extends WOComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 
-	public static final Logger log = Logger.getLogger(ERDSavedQueriesComponent.class);
+	public static final Logger log = LoggerFactory.getLogger(ERDSavedQueriesComponent.class);
 
     public static final EOKeyValueArchiving.Support originalEOKVArchivingTimestampSupport = new EOKeyValueArchiving._TimestampSupport();
     public static final EOKeyValueArchiving.Support newEOKVArchivingTimestampSupport = new ERDSavedQueriesComponent._TimestampSupport();

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDZoomableImage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/misc/ERDZoomableImage.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.misc;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -34,7 +35,7 @@ public class ERDZoomableImage extends ERXStatelessComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    public static final Logger log = Logger.getLogger(ERDZoomableImage.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDZoomableImage.class);
     
     public ERDZoomableImage(WOContext context) {
         super(context);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditSortedToManyFault.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditSortedToManyFault.java
@@ -5,7 +5,8 @@
 // Created by bposokho on Thu Sep 19 2002
 //
 package er.directtoweb.components.relationships;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WContext;
@@ -33,7 +34,7 @@ public class ERD2WEditSortedToManyFault extends D2WEditToManyFault {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    public static final Logger log = Logger.getLogger(ERD2WEditSortedToManyFault.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WEditSortedToManyFault.class);
 
     public ERD2WEditSortedToManyFault(WOContext context) {
         super(context);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToManyFault.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToManyFault.java
@@ -6,7 +6,8 @@
 //
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -30,7 +31,7 @@ public class ERD2WEditToManyFault extends D2WEditToManyFault {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WEditToManyFault.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WEditToManyFault.class);
 
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToManyFaultList.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToManyFaultList.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -31,7 +32,7 @@ public class ERD2WEditToManyFaultList extends D2WEditToManyFault {
 		super(arg0);
 	}
 
-	public static Logger log = Logger.getLogger(ERD2WEditToManyFaultList.class);
+	public static Logger log = LoggerFactory.getLogger(ERD2WEditToManyFaultList.class);
     
     // accessors
     public String addBoxID() {

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToOneFault.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WEditToOneFault.java
@@ -7,7 +7,8 @@
 
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -29,7 +30,7 @@ public class ERD2WEditToOneFault extends D2WEditToOneFault {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WEditToOneFault.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WEditToOneFault.class);
     
     
     public ERD2WEditToOneFault(WOContext context) {

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WList.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WList.java
@@ -6,7 +6,8 @@
 //
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.foundation.NSArray;
@@ -22,7 +23,7 @@ public class ERD2WList extends ERDCustomEditComponent {
 	private static final long serialVersionUID = 1L;
 
     /* logging support */
-    public static final Logger log = Logger.getLogger(ERD2WList.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WList.class);
 
     /** caches the list */
     protected NSArray list;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WQueryToManyRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WQueryToManyRelationship.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -45,7 +46,7 @@ public class ERD2WQueryToManyRelationship extends D2WQueryToManyRelationship {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WQueryToManyRelationship.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WQueryToManyRelationship.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WQueryToOneRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERD2WQueryToOneRelationship.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -49,7 +50,7 @@ public class ERD2WQueryToOneRelationship extends D2WQueryToOneRelationship {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    static final Logger log = Logger.getLogger(ERD2WQueryToOneRelationship.class);
+    static final Logger log = LoggerFactory.getLogger(ERD2WQueryToOneRelationship.class);
 
     public ERD2WQueryToOneRelationship(WOContext context) {
         super(context);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDEditOwnedRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDEditOwnedRelationship.java
@@ -8,7 +8,8 @@ package er.directtoweb.components.relationships;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -82,7 +83,7 @@ public class ERDEditOwnedRelationship extends ERDCustomEditComponent {
 
 
     /** logging support */
-    public final static Logger log = Logger.getLogger("er.directtoweb.components.ERDEditOwnedRelationship");
+    public final static Logger log = LoggerFactory.getLogger("er.directtoweb.components.ERDEditOwnedRelationship");
 
     protected EOEditingContext localContext;
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDEditToManyRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDEditToManyRelationship.java
@@ -2,7 +2,8 @@ package er.directtoweb.components.relationships;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -44,7 +45,7 @@ public class ERDEditToManyRelationship extends ERDCustomEditComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDEditToManyRelationship.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDEditToManyRelationship.class);
 
     public int index;
     public int objectsToAdd = 1;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDLinkToEditObject.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDLinkToEditObject.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -29,7 +30,7 @@ public class ERDLinkToEditObject extends ERDCustomEditComponent {
 	 */
 	private static final long serialVersionUID = 1L;
 
-    public static final Logger log = Logger.getLogger(ERDLinkToEditObject.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDLinkToEditObject.class);
 
     public ERDLinkToEditObject(WOContext context) {
     	super(context);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDLinkToViewList.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDLinkToViewList.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -41,7 +42,7 @@ public class ERDLinkToViewList extends ERDCustomEditComponent {
 
     public ERDLinkToViewList(WOContext context) { super(context); }
     
-    public static final Logger log = Logger.getLogger(ERDLinkToViewList.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDLinkToViewList.class);
 
     @Override
     public boolean isStateless() { return true; }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDList.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDList.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -42,7 +43,7 @@ public class ERDList extends ERDCustomEditComponent {
 	private static final long serialVersionUID = 1L;
 
     /* logging support */
-    static final Logger log = Logger.getLogger(ERDList.class);
+    static final Logger log = LoggerFactory.getLogger(ERDList.class);
     
     protected NSArray list;
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDQueryIsContainedInArray.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDQueryIsContainedInArray.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.eoaccess.EOUtilities;
@@ -35,7 +36,7 @@ public class ERDQueryIsContainedInArray extends ERDCustomQueryComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDQueryIsContainedInArray.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDQueryIsContainedInArray.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDQueryTwoLevelRelationship.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/relationships/ERDQueryTwoLevelRelationship.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.relationships;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.eoaccess.EOUtilities;
@@ -43,7 +44,7 @@ public class ERDQueryTwoLevelRelationship extends ERDCustomQueryComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDQueryTwoLevelRelationship.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDQueryTwoLevelRelationship.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDAttributeRepetition.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDAttributeRepetition.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.repetitions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WOResponse;
@@ -38,7 +39,7 @@ public class ERDAttributeRepetition extends ERDCustomComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDAttributeRepetition.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDAttributeRepetition.class);
 
     public static final String DisplayVariantChanged = "DisplayVariantChanged";
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDGroupingListPageRepetition.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDGroupingListPageRepetition.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.repetitions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
@@ -32,7 +33,7 @@ public class ERDGroupingListPageRepetition extends ERDListPageRepetition {
 	private static final long serialVersionUID = 1L;
 
 	/** logging support */
-	private static final Logger log = Logger.getLogger(ERDGroupingListPageRepetition.class);
+	private static final Logger log = LoggerFactory.getLogger(ERDGroupingListPageRepetition.class);
 	
 	/**
 	 * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDInspectPageRepetition.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDInspectPageRepetition.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.repetitions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
@@ -30,7 +31,7 @@ public class ERDInspectPageRepetition extends ERDAttributeRepetition {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDInspectPageRepetition.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDInspectPageRepetition.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDListPageRepetition.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDListPageRepetition.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.repetitions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WODisplayGroup;
@@ -33,7 +34,7 @@ public class ERDListPageRepetition extends ERDAttributeRepetition {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDListPageRepetition.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDListPageRepetition.class);
 
     protected static final NSDictionary NO_ACTIONS = NSDictionary.EmptyDictionary;
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDQueryPageRepetition.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/repetitions/ERDQueryPageRepetition.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.repetitions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WODisplayGroup;
@@ -34,7 +35,7 @@ public class ERDQueryPageRepetition extends ERDAttributeRepetition {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDQueryPageRepetition.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDQueryPageRepetition.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERD2WQueryStringWithChoices.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERD2WQueryStringWithChoices.java
@@ -2,7 +2,8 @@ package er.directtoweb.components.strings;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.foundation.NSArray;
@@ -25,7 +26,7 @@ public class ERD2WQueryStringWithChoices extends ERD2WQueryStringOperator {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERDEditStringWithChoices.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDEditStringWithChoices.class);
     public ERXKeyValuePair currentChoice;
     public NSArray _choices;
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditPassword.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditPassword.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.strings;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -40,7 +41,7 @@ public class ERDEditPassword extends ERDCustomEditComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDEditPassword.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDEditPassword.class);
 
     public static final String passwordPropertyKey = "ERDEditPassword.propertyKey";
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditPasswordConfirm.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditPasswordConfirm.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.components.strings;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -31,7 +32,7 @@ public class ERDEditPasswordConfirm extends ERDCustomEditComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERDEditPasswordConfirm.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDEditPasswordConfirm.class);
 
     public int length;
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditPasswordConfirmation.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditPasswordConfirmation.java
@@ -1,6 +1,7 @@
 package er.directtoweb.components.strings;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -33,7 +34,7 @@ public class ERDEditPasswordConfirmation extends ERDCustomEditComponent {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERDEditPasswordConfirmation.class);
+    private static final Logger log = LoggerFactory.getLogger(ERDEditPasswordConfirmation.class);
 
     public int length;
     /**

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditStringWithChoices.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/components/strings/ERDEditStringWithChoices.java
@@ -8,7 +8,8 @@ package er.directtoweb.components.strings;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.appserver.WORequest;
@@ -40,7 +41,7 @@ public class ERDEditStringWithChoices extends ERDCustomEditComponent {
     public ERDEditStringWithChoices(WOContext context) {super(context);}
     
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERDEditStringWithChoices.class);
+    public static final Logger log = LoggerFactory.getLogger(ERDEditStringWithChoices.class);
     
     public String entityForReportName;
     public ERXKeyValuePair currentElement;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/delegates/ERDBranchDelegate.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/delegates/ERDBranchDelegate.java
@@ -16,7 +16,8 @@ import java.lang.reflect.Modifier;
 import java.util.Enumeration;
 import java.util.Iterator;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.directtoweb.D2WContext;
@@ -73,7 +74,7 @@ public abstract class ERDBranchDelegate implements ERDBranchDelegateInterface {
 	}
 	
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERDBranchDelegate.class);
+    public final static Logger log = LoggerFactory.getLogger(ERDBranchDelegate.class);
 
     /** holds the WOComponent class array used to lookup branch delegate methods */
     // MOVEME: Should belong in a WO constants class

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/delegates/ERDDeletionDelegate.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/delegates/ERDDeletionDelegate.java
@@ -7,7 +7,8 @@
  */
 package er.directtoweb.delegates;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.directtoweb.D2W;
@@ -39,7 +40,7 @@ import er.extensions.validation.ERXValidationFactory;
 public class ERDDeletionDelegate implements NextPageDelegate {
 
     /** logging support */
-    public final static Logger log = Logger.getLogger("er.directtoweb.delegates.ERDDeletionDelegate");
+    public final static Logger log = LoggerFactory.getLogger("er.directtoweb.delegates.ERDDeletionDelegate");
 
     private EOEnterpriseObject    _object;
     private EODataSource          _dataSource;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/embed/ERD2WQuery.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/embed/ERD2WQuery.java
@@ -1,6 +1,7 @@
 package er.directtoweb.embed;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WQuery;
@@ -23,7 +24,7 @@ public class ERD2WQuery extends D2WQuery {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WQuery.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WQuery.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/embed/ERXD2WQuery.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/embed/ERXD2WQuery.java
@@ -1,6 +1,7 @@
 package er.directtoweb.embed;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.directtoweb.D2WQuery;
@@ -18,7 +19,7 @@ public class ERXD2WQuery extends D2WQuery {
 	private static final long serialVersionUID = 1L;
 
 	/** logging support */
-	private static final Logger log = Logger.getLogger(ERXD2WQuery.class);
+	private static final Logger log = LoggerFactory.getLogger(ERXD2WQuery.class);
 
 	/**
 	 * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WEditSortedManyToManyPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WEditSortedManyToManyPage.java
@@ -9,7 +9,8 @@ package er.directtoweb.pages;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -58,7 +59,7 @@ public class ERD2WEditSortedManyToManyPage extends ERD2WPage implements EditRela
     // d2wContext keys:
     //   indexKey: the key on the join entity that contains sort order info
 
-    public static final Logger log = Logger.getLogger(ERD2WEditSortedManyToManyPage.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WEditSortedManyToManyPage.class);
     
     public ERD2WEditSortedManyToManyPage(WOContext c) {
         super(c);

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WEditableListPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WEditableListPage.java
@@ -8,7 +8,8 @@ package er.directtoweb.pages;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -72,7 +73,7 @@ public class ERD2WEditableListPage extends ERD2WListPage implements ERXException
 	 */
 	private static final long serialVersionUID = 1L;
 
-    public static final Logger log = Logger.getLogger(ERD2WEditableListPage.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WEditableListPage.class);
 
     public ERD2WEditableListPage(WOContext context) {super(context);}
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WGraphVizPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WGraphVizPage.java
@@ -122,9 +122,9 @@ public class ERD2WGraphVizPage extends ERD2WPage {
                     throw new IllegalArgumentException("Only handles 'pdf' and 'svg'");
                 }
             } catch (IOException ex) {
-                log.error(ex, ex);
+                log.error(ex.getMessage(), ex);
             } catch (TimeoutException ex) {
-                log.error(ex, ex);
+                log.error(ex.getMessage(), ex);
             } finally {
                 if(f != null) {
                     f.delete();

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WInspectPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WInspectPage.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.pages;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -70,8 +71,8 @@ public class ERD2WInspectPage extends ERD2WPage implements InspectPageInterface,
     public ERD2WInspectPage(WOContext context) { super(context); }
     
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WInspectPage.class);
-    public static final Logger validationCat = Logger.getLogger(ERD2WInspectPage.class+".validation");
+    public static final Logger log = LoggerFactory.getLogger(ERD2WInspectPage.class);
+    public static final Logger validationCat = LoggerFactory.getLogger(ERD2WInspectPage.class+".validation");
 
 	protected static final String firstResponderContainerName = "FirstResponderContainer";
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WListPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WListPage.java
@@ -13,7 +13,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOActionResults;
 import com.webobjects.appserver.WOComponent;
@@ -101,7 +102,7 @@ public class ERD2WListPage extends ERD2WPage implements ERDListPageInterface, Se
 	private static final long serialVersionUID = 1L;
 
 	/** logging support */
-	public final static Logger log = Logger.getLogger(ERD2WListPage.class);
+	public final static Logger log = LoggerFactory.getLogger(ERD2WListPage.class);
     
     protected boolean _shouldRefetch;
     

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WMessagePage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WMessagePage.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.pages;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -35,7 +36,7 @@ public abstract class ERD2WMessagePage extends ERD2WPage implements ERDMessagePa
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERD2WMessagePage.class);
+    public final static Logger log = LoggerFactory.getLogger(ERD2WMessagePage.class);
     
     protected String _message;
     protected String _title;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPage.java
@@ -16,7 +16,8 @@ import java.util.Enumeration;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.log4j.NDC;
 
 import com.webobjects.appserver.WOActionResults;
@@ -175,9 +176,9 @@ public abstract class ERD2WPage extends D2WPage implements ERXExceptionHolder, E
     }
 
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERD2WPage.class);
+    public final static Logger log = LoggerFactory.getLogger(ERD2WPage.class);
 
-    public static final Logger validationLog = Logger.getLogger("er.directtoweb.validation.ERD2WPage");
+    public static final Logger validationLog = LoggerFactory.getLogger("er.directtoweb.validation.ERD2WPage");
 
     private String _statsKeyPrefix;
 

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPickListPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPickListPage.java
@@ -8,7 +8,8 @@ package er.directtoweb.pages;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -49,7 +50,7 @@ public class ERD2WPickListPage extends ERD2WListPage implements ERDPickPageInter
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WPickListPage.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WPickListPage.class);
 
     /**
      * IE sometimes won't submit the form if it only has checkboxes, we bind

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPickTypePage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WPickTypePage.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.pages;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -55,7 +56,7 @@ public class ERD2WPickTypePage extends ERD2WPage implements ERDPickPageInterface
     }
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WPickTypePage.class);
+    public static final Logger log = LoggerFactory.getLogger(ERD2WPickTypePage.class);
 
     public boolean selectionManditory() {
         return ERXValueUtilities.booleanValue(d2wContext().valueForKey("selectionManditory"));

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WProgressPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WProgressPage.java
@@ -1,6 +1,7 @@
 package er.directtoweb.pages;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -23,7 +24,7 @@ public class ERD2WProgressPage extends ERD2WMessagePage {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WProgressPage.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WProgressPage.class);
 
     /** holds the task */
     protected ERXLongResponseTask _longResponseTask;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WQueryEntitiesPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WQueryEntitiesPage.java
@@ -1,5 +1,6 @@
 package er.directtoweb.pages;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -32,7 +33,7 @@ public class ERD2WQueryEntitiesPage extends ERD2WPage implements QueryAllPageInt
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WQueryEntitiesPage.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WQueryEntitiesPage.class);
 
     protected EODatabaseDataSource queryDataSource;
     protected  WODisplayGroup displayGroup;

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WTabInspectPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WTabInspectPage.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.pages;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -43,8 +44,8 @@ public class ERD2WTabInspectPage extends ERD2WInspectPage implements ERDTabEditP
     }
 
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERD2WTabInspectPage.class);
-    public static final Logger validationLog = Logger.getLogger("er.directtoweb.validation.ERD2WTabInspectPage");
+    public static final Logger log = LoggerFactory.getLogger(ERD2WTabInspectPage.class);
+    public static final Logger validationLog = LoggerFactory.getLogger("er.directtoweb.validation.ERD2WTabInspectPage");
 
 
     public String switchTabActionName() { return isEditing() ? "switchTabAction" : null; }

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WWizardCreationPage.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/ERD2WWizardCreationPage.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.pages;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOComponent;
 import com.webobjects.appserver.WOContext;
@@ -35,7 +36,7 @@ public class ERD2WWizardCreationPage extends ERD2WTabInspectPage {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    public static final Logger log = Logger.getLogger("er.directtoweb.templates.ERWizardCreationPageTemplate");
+    public static final Logger log = LoggerFactory.getLogger("er.directtoweb.templates.ERWizardCreationPageTemplate");
 
     // Notification titles
     // FIXME: This is silly now that we have validationKeys.  Once all referenecs are removed will delete.

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/templates/ERD2WProgressPageTemplate.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/pages/templates/ERD2WProgressPageTemplate.java
@@ -1,6 +1,7 @@
 package er.directtoweb.pages.templates;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 
@@ -25,7 +26,7 @@ public class ERD2WProgressPageTemplate extends ERD2WProgressPage {
 	private static final long serialVersionUID = 1L;
 
     /** logging support */
-    private static final Logger log = Logger.getLogger(ERD2WProgressPageTemplate.class);
+    private static final Logger log = LoggerFactory.getLogger(ERD2WProgressPageTemplate.class);
 	
     /**
      * Public constructor

--- a/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/xml/ERD2WGroupingListXMLPageTemplate.java
+++ b/Frameworks/Core/ERDirectToWeb/Sources/er/directtoweb/xml/ERD2WGroupingListXMLPageTemplate.java
@@ -6,7 +6,8 @@
  * included with this distribution in the LICENSE.NPL file.  */
 package er.directtoweb.xml;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
@@ -43,7 +44,7 @@ public class ERD2WGroupingListXMLPageTemplate extends ERD2WGroupingListPage {
     public ERD2WGroupingListXMLPageTemplate(WOContext context) {super(context);}
     
     /** logging support */
-    public final static Logger log = Logger.getLogger(ERD2WGroupingListXMLPageTemplate.class);
+    public final static Logger log = LoggerFactory.getLogger(ERD2WGroupingListXMLPageTemplate.class);
 
     private final static String NULL="N/A";
     

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/ERXExtensions.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/ERXExtensions.java
@@ -22,7 +22,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOApplication;
 import com.webobjects.appserver.WOSession;
@@ -267,7 +268,7 @@ public class ERXExtensions extends ERXFrameworkPrincipal {
         // name and port are resolved via WOApplication.application()
         // ERXLogger.configureLoggingWithSystemProperties();
         
-        _log = Logger.getLogger(ERXExtensions.class);
+        _log = LoggerFactory.getLogger(ERXExtensions.class);
 		ERXProperties.pathsForUserAndBundleProperties(true);
 
 		try {
@@ -722,9 +723,9 @@ public class ERXExtensions extends ERXFrameworkPrincipal {
     public static void configureAdaptorContextRapidTurnAround(Object anObserver) {
         if (!_isConfigureAdaptorContextRapidTurnAround) {
             // This allows enabling from the log4j system.
-            adaptorLogger = Logger.getLogger("er.transaction.adaptor.EOAdaptorDebugEnabled");
+            adaptorLogger = LoggerFactory.getLogger("er.transaction.adaptor.EOAdaptorDebugEnabled");
             
-            sharedEOadaptorLogger = Logger.getLogger("er.transaction.adaptor.EOSharedEOAdaptorDebugEnabled");
+            sharedEOadaptorLogger = LoggerFactory.getLogger("er.transaction.adaptor.EOSharedEOAdaptorDebugEnabled");
             if ((adaptorLogger.isDebugEnabled() 
             		&& !NSLog.debugLoggingAllowedForGroups(NSLog.DebugGroupSQLGeneration|NSLog.DebugGroupDatabaseAccess))
             		|| ERXProperties.booleanForKey("EOAdaptorDebugEnabled")) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/ERXFrameworkPrincipal.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/ERXFrameworkPrincipal.java
@@ -8,7 +8,8 @@ package er.extensions;
 
 import java.lang.reflect.Field;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.foundation.NSForwardException;
 import com.webobjects.foundation.NSMutableArray;
@@ -43,7 +44,7 @@ import er.extensions.foundation.ERXStringUtilities;
  * Here is an example:<pre><code>
  * public class ExampleFrameworkPrincipal extends ERXFrameworkPrincipal {
  * 
- *     public static final Logger log = Logger.getLogger(ExampleFrameworkPrincipal.class);
+ *     public static final Logger log = LoggerFactory.getLogger(ExampleFrameworkPrincipal.class);
  * 
  *     protected static ExampleFrameworkPrincipal sharedInstance;
  *     
@@ -77,7 +78,7 @@ import er.extensions.foundation.ERXStringUtilities;
 public abstract class ERXFrameworkPrincipal {
 
     /** logging support */
-    protected final Logger log = Logger.getLogger(getClass());
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /** holds the mapping between framework principals classes and ERXFrameworkPrincipal objects */
     protected static final NSMutableDictionary<String, ERXFrameworkPrincipal> initializedFrameworks = new NSMutableDictionary<>();

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -40,7 +40,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.log4j.Appender;
 import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -159,16 +160,16 @@ import er.extensions.statistics.ERXStats;
  */
 public abstract class ERXApplication extends ERXAjaxApplication implements ERXGracefulShutdown.GracefulApplication {
 	/** logging support */
-	public static final Logger log = Logger.getLogger(ERXApplication.class);
+	public static final Logger log = LoggerFactory.getLogger(ERXApplication.class);
 
 	/** request logging support */
-	public static final Logger requestHandlingLog = Logger.getLogger("er.extensions.ERXApplication.RequestHandling");
+	public static final Logger requestHandlingLog = LoggerFactory.getLogger("er.extensions.ERXApplication.RequestHandling");
 
 	/** statistic logging support */
-	public static final Logger statsLog = Logger.getLogger("er.extensions.ERXApplication.Statistics");
+	public static final Logger statsLog = LoggerFactory.getLogger("er.extensions.ERXApplication.Statistics");
 
 	/** startup logging support */
-	public static final Logger startupLog = Logger.getLogger("er.extensions.ERXApplication.Startup");
+	public static final Logger startupLog = LoggerFactory.getLogger("er.extensions.ERXApplication.Startup");
 
 	private static boolean wasERXApplicationMainInvoked = false;
 
@@ -1179,7 +1180,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 		}
 		// ak: telling Log4J to re-init the Console appenders so we get logging
 		// into WOOutputPath again
-		for (Enumeration e = Logger.getRootLogger().getAllAppenders(); e.hasMoreElements();) {
+		for (Enumeration e = org.apache.log4j.Logger.getRootLogger().getAllAppenders(); e.hasMoreElements();) {
 			Appender appender = (Appender) e.nextElement();
 			if (appender instanceof ConsoleAppender) {
 				ConsoleAppender app = (ConsoleAppender) appender;
@@ -1626,16 +1627,16 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 			success = true;
 		}
 		catch (SecurityException e) {
-			log.error(e, e);
+			log.error(e.getMessage(), e);
 		}
 		catch (NoSuchFieldException e) {
-			log.error(e, e);
+			log.error(e.getMessage(), e);
 		}
 		catch (IllegalArgumentException e) {
-			log.error(e, e);
+			log.error(e.getMessage(), e);
 		}
 		catch (IllegalAccessException e) {
-			log.error(e, e);
+			log.error(e.getMessage(), e);
 		}
 		if(!success) {
 			super.refuseNewSessions(value);
@@ -1924,8 +1925,8 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 				// state.
 				if (shouldQuit) {
 					NSLog.err.appendln("Ran out of memory, killing this instance");
-					log.fatal("Ran out of memory, killing this instance");
-					log.fatal("Ran out of memory, killing this instance", throwable);
+					log.error("Ran out of memory, killing this instance");
+					log.error("Ran out of memory, killing this instance", throwable);
 				}
 			}
 			else {
@@ -2066,7 +2067,7 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 	public WOResponse dispatchRequestImmediately(WORequest request) {
 		WOResponse response;
 		if (ERXApplication.requestHandlingLog.isDebugEnabled()) {
-			ERXApplication.requestHandlingLog.debug(request);
+			ERXApplication.requestHandlingLog.debug(request.toString());
 		}
 
 		try {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXComponentActionRedirector.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXComponentActionRedirector.java
@@ -36,7 +36,7 @@ import er.extensions.foundation.ERXThreadStorage;
  *  then Main could be implemented something like this:
  * <pre><code>
  *  public class Main extends WOComponent implements ERXComponentActionRedirector.Restorable {
- *      static Logger log = Logger.getLogger(Main.class);
+ *      static Logger log = LoggerFactory.getLogger(Main.class);
  * 
  *      public Integer someValue = Integer.valueOf(10);
  * 

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXDynamicElement.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/ERXDynamicElement.java
@@ -2,7 +2,8 @@ package er.extensions.components;
 
 import java.util.Stack;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOAssociation;
 import com.webobjects.appserver.WOComponent;
@@ -30,7 +31,7 @@ import er.extensions.appserver.ERXWOContext;
  * @author jw
  */
 public abstract class ERXDynamicElement extends WODynamicGroup {
-	protected Logger log = Logger.getLogger(getClass());
+	protected Logger log = LoggerFactory.getLogger(getClass());
 	private final NSDictionary<String, WOAssociation> _associations;
 
 	public ERXDynamicElement(String name, NSDictionary<String, WOAssociation> associations, WOElement template) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/concurrency/ERXLongResponseTask.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/concurrency/ERXLongResponseTask.java
@@ -3,7 +3,8 @@
  */
 package er.extensions.concurrency;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOApplication;
 import com.webobjects.appserver.WOComponent;
@@ -94,7 +95,7 @@ public interface ERXLongResponseTask extends Runnable {
 
 		
 		/** logging support */
-		public Logger log = Logger.getLogger(ERXUtilities.class);
+		public Logger log = LoggerFactory.getLogger(ERXUtilities.class);
 		
 		/** Refresh page that controls this task */
 		protected ERXLongResponse _longResponse;
@@ -122,7 +123,7 @@ public interface ERXLongResponseTask extends Runnable {
 		 */
 		public DefaultImplementation() {
 			_finishInitialization();
-			log = Logger.getLogger(getClass().getName());
+			log = LoggerFactory.getLogger(getClass().getName());
 			_thread = null;
 		}
 		

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXCustomObject.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXCustomObject.java
@@ -8,7 +8,8 @@ package er.extensions.eof;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eoaccess.EOEntity;
 import com.webobjects.eoaccess.EOUtilities;
@@ -108,7 +109,7 @@ public class ERXCustomObject extends EOCustomObject implements ERXGuardedObjectI
         Logger classLog = classLogs.objectForKey(getClass());
         if ( classLog == null) {
             synchronized(classLogs) {
-                classLog = Logger.getLogger(getClass());
+                classLog = LoggerFactory.getLogger(getClass());
                 classLogs.setObjectForKey(classLog, getClass());
             }
         }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXDatabaseContextDelegate.java
@@ -9,7 +9,8 @@ package er.extensions.eof;
 import java.util.Enumeration;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eoaccess.EOAccessArrayFaultHandler;
 import com.webobjects.eoaccess.EOAdaptor;
@@ -95,13 +96,13 @@ public class ERXDatabaseContextDelegate {
     }
 	
     /** Basic logging support */
-    public final static Logger log = Logger.getLogger(ERXDatabaseContextDelegate.class);
+    public final static Logger log = LoggerFactory.getLogger(ERXDatabaseContextDelegate.class);
     /** Faulting logging support, logging category: <b>er.transaction.adaptor.FaultFiring</b> */
-    public final static Logger dbLog = Logger.getLogger("er.transaction.adaptor.FaultFiring");
+    public final static Logger dbLog = LoggerFactory.getLogger("er.transaction.adaptor.FaultFiring");
     /** Faulting logging support, logging category: <b>er.transaction.adaptor.Exceptions</b> */
-    public final static Logger exLog = Logger.getLogger("er.transaction.adaptor.Exceptions");
+    public final static Logger exLog = LoggerFactory.getLogger("er.transaction.adaptor.Exceptions");
     /** Faulting logging support, logging category: <b>er.transaction.adaptor.Batching</b> */
-    public final static Logger batchLog = Logger.getLogger("er.transaction.adaptor.Batching");
+    public final static Logger batchLog = LoggerFactory.getLogger("er.transaction.adaptor.Batching");
 
     /** Holds onto the singleton of the default delegate */
     private static ERXDatabaseContextDelegate _defaultDelegate = new ERXDatabaseContextDelegate();
@@ -252,9 +253,9 @@ public class ERXDatabaseContextDelegate {
     		EOAdaptor adaptor=dbc.adaptorContext().adaptor();
     		boolean shouldHandleConnection = false;
     		if(e instanceof EOGeneralAdaptorException)
-    			log.error(((EOGeneralAdaptorException)e).userInfo());
+    			log.error(((EOGeneralAdaptorException)e).userInfo().toString());
     		else
-    			log.error(e);
+    			log.error(e.getMessage(), e);
     		if (adaptor.isDroppedConnectionException(e))
     			shouldHandleConnection = true;
     		// FIXME: Should provide api to extend the list of bad exceptions.
@@ -265,7 +266,7 @@ public class ERXDatabaseContextDelegate {
     			shouldHandleConnection = false;
     		} else {
     			if(e instanceof EOGeneralAdaptorException)
-    				log.info(((EOGeneralAdaptorException)e).userInfo());
+    				log.info(((EOGeneralAdaptorException)e).userInfo().toString());
     			throw e;
     		}
         	return shouldHandleConnection;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOAccessUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEOAccessUtilities.java
@@ -13,8 +13,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOSession;
 import com.webobjects.eoaccess.EOAdaptorChannel;
@@ -83,8 +83,8 @@ import er.extensions.statistics.ERXStats.Group;
  */
 public class ERXEOAccessUtilities {
     /** logging support */
-    public static final Logger log = Logger.getLogger(ERXEOAccessUtilities.class);
-    
+    public static final Logger log = LoggerFactory.getLogger(ERXEOAccessUtilities.class);
+
     /** SQL logger */
     private static Logger sqlLoggingLogger = null;
 
@@ -170,8 +170,8 @@ public class ERXEOAccessUtilities {
             if (possibleEntities.count() > 0) {
                 result = (EOEntity) possibleEntities.lastObject();
             }
-            
-            if (log.isEnabledFor(Level.WARN) && possibleEntities.count() > 1) 
+
+            if (log.isWarnEnabled() && possibleEntities.count() > 1)
                 log.warn("Found multiple entities: " + possibleEntities.valueForKey("name") + " for table name: " + tableName);
 
             if (log.isDebugEnabled())
@@ -1248,7 +1248,7 @@ public class ERXEOAccessUtilities {
 
     public static void logExpression(EOAdaptorChannel channel, EOSQLExpression expression, long startTime) {
         if (sqlLoggingLogger == null) {
-            sqlLoggingLogger = Logger.getLogger("er.extensions.ERXAdaptorChannelDelegate.sqlLogging");
+            sqlLoggingLogger = LoggerFactory.getLogger("er.extensions.ERXAdaptorChannelDelegate.sqlLogging");
         }
         // sqlLoggingLogger.setLevel(Level.DEBUG);
         String entityMatchPattern = ERXProperties.stringForKeyWithDefault(
@@ -2056,7 +2056,7 @@ public class ERXEOAccessUtilities {
               e.removeSharedObjectFetchSpecificationByName((String)fetchSpecNameObjectEnumerator.nextElement());
           } 
       } else if (e == null) {
-          log.warn("makeEditableSharedEntityNamed: unable to find entity named: " + entityName);            
+          log.warn("makeEditableSharedEntityNamed: unable to find entity named: " + entityName);
       } else {
           log.warn("makeEditableSharedEntityNamed: entity already editable: " + entityName);
       }
@@ -2110,7 +2110,7 @@ public class ERXEOAccessUtilities {
 			sourceEntity.setClassProperties(classProperties);
 		}
 		if(log.isDebugEnabled())
-			log.debug(relationship);
+			log.debug(relationship.toString());
 
 		return relationship;
 	}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObject.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXEnterpriseObject.java
@@ -2,7 +2,8 @@ package er.extensions.eof;
 
 import java.util.Enumeration;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eocontrol.EOEditingContext;
 import com.webobjects.eocontrol.EOEnterpriseObject;
@@ -23,7 +24,7 @@ import er.extensions.foundation.ERXSystem;
 public interface ERXEnterpriseObject extends EOEnterpriseObject {
     
     /** logging support for modified objects */
-    public static final Logger logMod = Logger.getLogger("er.transaction.delegate.EREditingContextDelegate.modifiedObjects");
+    public static final Logger logMod = LoggerFactory.getLogger("er.transaction.delegate.EREditingContextDelegate.modifiedObjects");
 
     public static final boolean applyRestrictingQualifierOnInsert = ERXProperties.booleanForKey("er.extensions.ERXEnterpriseObject.applyRestrictingQualifierOnInsert");
     
@@ -234,55 +235,55 @@ public interface ERXEnterpriseObject extends EOEnterpriseObject {
     };
  
     /** logging support. Called after an object is successfully inserted */
-    public static final Logger tranLogDidInsert = Logger
+    public static final Logger tranLogDidInsert = LoggerFactory
             .getLogger("er.transaction.eo.did.insert.ERXGenericRecord");
 
     /** logging support. Called after an object is successfully deleted */
-    public static final Logger tranLogDidDelete = Logger
+    public static final Logger tranLogDidDelete = LoggerFactory
             .getLogger("er.transaction.eo.did.delete.ERXGenericRecord");
 
     /** logging support. Called after an object is successfully updated */
-    public static final Logger tranLogDidUpdate = Logger
+    public static final Logger tranLogDidUpdate = LoggerFactory
             .getLogger("er.transaction.eo.did.update.ERXGenericRecord");
 
     /** logging support. Called after an object is reverted. **/
-    public static final Logger tranLogDidRevert = Logger
+    public static final Logger tranLogDidRevert = LoggerFactory
             .getLogger("er.transaction.eo.did.revert.ERXGenericRecord");
 
     /** logging support. Called before an object is deleted */
-    public static final Logger tranLogMightDelete = Logger
+    public static final Logger tranLogMightDelete = LoggerFactory
             .getLogger("er.transaction.eo.might.delete.ERXGenericRecord");
 
     /** logging support. Called before an object is inserted */
-    public static final Logger tranLogWillInsert = Logger
+    public static final Logger tranLogWillInsert = LoggerFactory
             .getLogger("er.transaction.eo.will.insert.ERXGenericRecord");
 
     /** logging support. Called before an object is deleted */
-    public static final Logger tranLogWillDelete = Logger
+    public static final Logger tranLogWillDelete = LoggerFactory
             .getLogger("er.transaction.eo.will.delete.ERXGenericRecord");
 
     /** logging support. Called before an object is updated */
-    public static final Logger tranLogWillUpdate = Logger
+    public static final Logger tranLogWillUpdate = LoggerFactory
             .getLogger("er.transaction.eo.will.update.ERXGenericRecord");
 
     /** logging support. Called before an object is reverted. **/
-    public static final Logger tranLogWillRevert = Logger
+    public static final Logger tranLogWillRevert = LoggerFactory
             .getLogger("er.transaction.eo.will.revert.ERXGenericRecord");
 
     /** logging support for validation information */
-    public static final Logger validation = Logger
+    public static final Logger validation = LoggerFactory
             .getLogger("er.eo.validation.ERXGenericRecord");
 
     /** logging support for validation exceptions */
-    public static final Logger validationException = Logger
+    public static final Logger validationException = LoggerFactory
             .getLogger("er.eo.validationException.ERXGenericRecord");
 
     /** logging support for insertion tracking */
-    public static final Logger insertionTrackingLog = Logger
+    public static final Logger insertionTrackingLog = LoggerFactory
             .getLogger("er.extensions.ERXGenericRecord.insertion");
 
     /** general logging support */
-    public static final Logger log = Logger
+    public static final Logger log = LoggerFactory
             .getLogger("er.eo.ERXGenericRecord");
 
     // DELETEME: Once we get rid of the half baked rule validation here, we can delete this.

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXGenericRecord.java
@@ -8,7 +8,8 @@ package er.extensions.eof;
 
 import java.util.Objects;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eoaccess.EOAttribute;
 import com.webobjects.eoaccess.EOEntity;
@@ -258,7 +259,7 @@ public class ERXGenericRecord extends EOGenericRecord implements ERXGuardedObjec
 		Logger classLog = classLogs.objectForKey(getClass());
 		if (classLog == null) {
 			synchronized (classLogs) {
-				classLog = Logger.getLogger(getClass());
+				classLog = LoggerFactory.getLogger(getClass());
 				classLogs.setObjectForKey(classLog, getClass());
 			}
 		}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinator.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinator.java
@@ -8,7 +8,8 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
@@ -26,7 +27,7 @@ import com.webobjects.foundation.NSMutableDictionary;
  */
 public class ERXObjectStoreCoordinator extends EOObjectStoreCoordinator {
 
-	public static final Logger log = Logger.getLogger(ERXObjectStoreCoordinator.class);
+	public static final Logger log = LoggerFactory.getLogger(ERXObjectStoreCoordinator.class);
 
 	NSMutableDictionary<Thread, NSMutableArray<Exception>> openLockTraces;
 
@@ -130,16 +131,16 @@ public class ERXObjectStoreCoordinator extends EOObjectStoreCoordinator {
 	public void unlock() {
 		boolean tracing = ERXEC.markOpenLocks();
 		if (lockingThread != null && lockingThread != Thread.currentThread()) {
-			log.fatal("Unlocking thread is not locking thread: LOCKING " + lockingThread + " vs UNLOCKING " + Thread.currentThread(), new RuntimeException("UnlockingTrace"));
+			log.error("Unlocking thread is not locking thread: LOCKING " + lockingThread + " vs UNLOCKING " + Thread.currentThread(), new RuntimeException("UnlockingTrace"));
 			if (tracing) {
 				NSMutableArray<Exception> traces = openLockTraces.objectForKey(lockingThread);
 				if (traces != null) {
 					for (Exception trace : traces) {
-						log.fatal("Currenty locking threads: " + lockingThread, trace);
+						log.error("Currenty locking threads: " + lockingThread, trace);
 					}
 				}
 				else {
-					log.fatal("Trace for locking thread is MISSING");
+					log.error("Trace for locking thread is MISSING");
 				}
 			}
 		}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinatorPool.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinatorPool.java
@@ -7,7 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOSession;
 import com.webobjects.eocontrol.EOEditingContext;
@@ -38,7 +39,7 @@ import er.extensions.foundation.ERXThreadStorage;
  * @author David Teran, Frank Caputo @ cluster9
  */
 public class ERXObjectStoreCoordinatorPool {
-    private static final Logger log = Logger.getLogger(ERXObjectStoreCoordinatorPool.class);
+    private static final Logger log = LoggerFactory.getLogger(ERXObjectStoreCoordinatorPool.class);
     
     private static final String THREAD_OSC_KEY = "er.extensions.ERXObjectStoreCoordinatorPool.threadOSC";
     private Map<String, EOObjectStore> _oscForSession;

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinatorSynchronizer.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXObjectStoreCoordinatorSynchronizer.java
@@ -10,7 +10,8 @@ import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOApplication;
 import com.webobjects.eoaccess.EODatabase;
@@ -46,7 +47,7 @@ import er.extensions.remoteSynchronizer.ERXRemoteSynchronizer;
  * manually.
  */
 public class ERXObjectStoreCoordinatorSynchronizer {
-	public static final Logger log = Logger.getLogger(ERXObjectStoreCoordinatorSynchronizer.class);
+	public static final Logger log = LoggerFactory.getLogger(ERXObjectStoreCoordinatorSynchronizer.class);
 
 	public static final String SYNCHRONIZER_KEY = "_synchronizer";
 
@@ -630,7 +631,7 @@ public class ERXObjectStoreCoordinatorSynchronizer {
 					}
 				}
 			} catch (Throwable e) {
-				log.error(e, e);
+				log.error(e.getMessage(), e);
 			}
 		}
 		

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXSequence.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXSequence.java
@@ -7,7 +7,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eoaccess.EOAdaptor;
 import com.webobjects.eoaccess.EOEntity;
@@ -37,7 +38,7 @@ public class ERXSequence {
 	
 	public ERXSequence(String name) {
 		_name = name;
-		log = Logger.getLogger(name);
+		log = LoggerFactory.getLogger(name);
 	}
 
 	public ERXSequence(String name, long initialValue) {
@@ -207,7 +208,7 @@ public class ERXSequence {
 	            		con.setReadOnly(false);
 	            	}
 	            } catch (SQLException e) {
-	                log.error(e, e);
+	                log.error(e.getMessage(), e);
 	            }
 
 	            for(int tries = 0; tries < 5; tries++) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/ERXStats.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/statistics/ERXStats.java
@@ -7,7 +7,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.foundation.NSArray;
 import com.webobjects.foundation.NSMutableArray;
@@ -66,7 +67,7 @@ public class ERXStats {
     public static final String STATS_ENABLED_KEY = "er.extensions.erxStats.enabled";
     public static final String STATS_TRACE_COLLECTING_ENABLED_KEY = "er.extensions.erxStats.traceCollectingEnabled";
 
-    public static final Logger log = Logger.getLogger(ERXStats.class);
+    public static final Logger log = LoggerFactory.getLogger(ERXStats.class);
 
 	public interface Group {
 		public String Default = " ";

--- a/Frameworks/Core/ERExtensions/pom.xml
+++ b/Frameworks/Core/ERExtensions/pom.xml
@@ -85,6 +85,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionDeclarationParser.java
+++ b/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionDeclarationParser.java
@@ -4,8 +4,8 @@ import java.util.Enumeration;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOAssociation;
 import com.webobjects.appserver._private.WOConstantValueAssociation;
@@ -18,17 +18,13 @@ import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation._NSStringUtilities;
 
 public class WOHelperFunctionDeclarationParser {
-	public static Logger log = Logger.getLogger(WOHelperFunctionDeclarationParser.class);
+	public static Logger log = LoggerFactory.getLogger(WOHelperFunctionDeclarationParser.class);
 
 	private NSMutableDictionary _quotedStrings;
 	private static final int STATE_OUTSIDE = 0;
 	private static final int STATE_INSIDE_COMMENT = 2;
 	private static final String ESCAPED_QUOTE_STRING = "_WO_ESCAPED_QUOTE_";
 	private static final String QUOTED_STRING_KEY = "_WODP_";
-
-	static {
-		WOHelperFunctionDeclarationParser.log.setLevel(Level.WARN);
-	}
 
 	public WOHelperFunctionDeclarationParser() {
 		_quotedStrings = new NSMutableDictionary();

--- a/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionHTMLParser.java
+++ b/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionHTMLParser.java
@@ -4,14 +4,14 @@ import java.util.NoSuchElementException;
 import java.util.Stack;
 import java.util.StringTokenizer;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.foundation.NSMutableDictionary;
 import com.webobjects.foundation._NSStringUtilities;
 
 public class WOHelperFunctionHTMLParser {
-	public static Logger log = Logger.getLogger(WOHelperFunctionHTMLParser.class);
+	public static Logger log = LoggerFactory.getLogger(WOHelperFunctionHTMLParser.class);
 
 	private WOHelperFunctionParser _parserDelegate;
 	private String _unparsedTemplate;
@@ -31,10 +31,6 @@ public class WOHelperFunctionHTMLParser {
 
 	private static boolean _parseStandardTags = false;
 	private NSMutableDictionary _stackDict;
-
-	static {
-		WOHelperFunctionHTMLParser.log.setLevel(Level.WARN);
-	}
 
 	public WOHelperFunctionHTMLParser(WOHelperFunctionParser parserDelegate, String unparsedTemplate) {
 		_parserDelegate = parserDelegate;
@@ -153,7 +149,7 @@ public class WOHelperFunctionHTMLParser {
 			while (true);
 		}
 		catch (NoSuchElementException e) {
-			log.error(e);
+			log.error(e.getMessage(), e);
 			didParseText();
 			return;
 		}

--- a/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionTagRegistry.java
+++ b/Frameworks/Core/WOOgnl/Sources/ognl/helperfunction/WOHelperFunctionTagRegistry.java
@@ -1,13 +1,13 @@
 package ognl.helperfunction;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.foundation.NSDictionary;
 import com.webobjects.foundation.NSMutableDictionary;
 
 public class WOHelperFunctionTagRegistry {
-	public static Logger log = Logger.getLogger(WOHelperFunctionTagRegistry.class);
+	public static Logger log = LoggerFactory.getLogger(WOHelperFunctionTagRegistry.class);
 
 	private static NSMutableDictionary _tagShortcutMap = new NSMutableDictionary();
 	private static NSMutableDictionary _tagProcessorMap = new NSMutableDictionary();
@@ -38,8 +38,6 @@ public class WOHelperFunctionTagRegistry {
 	}
 
 	static {
-		WOHelperFunctionTagRegistry.log.setLevel(Level.WARN);
-
 		WOHelperFunctionTagRegistry.registerTagShortcut("ERXLocalizedString", "localized"); // not in 5.4
 
 		WOHelperFunctionTagRegistry.registerTagShortcut("ERXElse", "else");

--- a/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/jdbcadaptor/ERXEnhancedJDBCColumn.java
+++ b/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/jdbcadaptor/ERXEnhancedJDBCColumn.java
@@ -5,7 +5,8 @@ import com.webobjects.eoaccess.EOAttribute;
 import com.webobjects.foundation.NSForwardException;
 import com.webobjects.foundation.NSKeyValueCoding;
 import er.extensions.jdbc.ERXJDBCAdaptor.Channel;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -14,7 +15,7 @@ import java.sql.SQLException;
  * This class extends the {@code ERXJDBCColumn} to add support for custom types.
  */
 public class ERXEnhancedJDBCColumn extends ERXJDBCColumn {
-	private static final Logger log = Logger.getLogger(ERXEnhancedJDBCColumn.class);
+	private static final Logger log = LoggerFactory.getLogger(ERXEnhancedJDBCColumn.class);
 
 	public ERXEnhancedJDBCColumn(EOAttribute attribute, JDBCChannel channel, int column, ResultSet rs) {
 		super(attribute, channel, column, rs);

--- a/Frameworks/EOF/ERAttributeExtension/pom.xml
+++ b/Frameworks/EOF/ERAttributeExtension/pom.xml
@@ -30,10 +30,6 @@
 			<groupId>com.webobjects</groupId>
 			<artifactId>JavaEOAccess</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<sourceDirectory>Sources</sourceDirectory>

--- a/Frameworks/EOF/ERIndexing/Sources/er/indexing/ERAutoIndex.java
+++ b/Frameworks/EOF/ERIndexing/Sources/er/indexing/ERAutoIndex.java
@@ -128,7 +128,7 @@ public class ERAutoIndex extends ERIndex {
                 ConfigurationEntry config = configureEntity(entityName, attributeNames());
                 config.active = true;
             }
-            log.info(configuration);
+            log.info(configuration.toString());
         }
 
         /**

--- a/Frameworks/EOF/ERIndexing/Sources/er/indexing/ERIndex.java
+++ b/Frameworks/EOF/ERIndexing/Sources/er/indexing/ERIndex.java
@@ -10,7 +10,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -419,7 +420,7 @@ public class ERIndex {
     private String _store;
     
     protected ERIndex(String name) {
-        log = Logger.getLogger(ERIndex.class.getName() + "." + name);
+        log = LoggerFactory.getLogger(ERIndex.class.getName() + "." + name);
        _name = name;
         indices.setObjectForKey(this, name);
     }

--- a/Frameworks/Excel/ExcelGenerator/pom.xml
+++ b/Frameworks/Excel/ExcelGenerator/pom.xml
@@ -23,14 +23,6 @@
 			<artifactId>JavaWebObjects</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.webobjects</groupId>
-			<artifactId>JavaXML</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
 		</dependency>

--- a/Frameworks/Misc/ERDistribution/Sources/er/distribution/ERDistributionContext.java
+++ b/Frameworks/Misc/ERDistribution/Sources/er/distribution/ERDistributionContext.java
@@ -2,7 +2,8 @@ package er.distribution;
 
 import java.lang.reflect.Field;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.appserver.WOSession;
 import com.webobjects.eocontrol.EOEditingContext;
@@ -23,7 +24,7 @@ import er.distribution.common.ERReferenceRecordingCoder;
 @SuppressWarnings("deprecation")
 public class ERDistributionContext extends EODistributionContext {
 
-	public static final Logger log = Logger.getLogger(ERDistributionContext.class);
+	public static final Logger log = LoggerFactory.getLogger(ERDistributionContext.class);
 
 	public ERDistributionContext(WOSession session) {
 		super(session);

--- a/Frameworks/Misc/ERDistribution/Sources/er/distribution/client/ERClientApplication.java
+++ b/Frameworks/Misc/ERDistribution/Sources/er/distribution/client/ERClientApplication.java
@@ -3,7 +3,8 @@ package er.distribution.client;
 import java.io.IOException;
 import java.util.prefs.Preferences;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eocontrol.EOClassDescription;
 import com.webobjects.eodistribution.client.EODistributionChannel;
@@ -21,7 +22,7 @@ import er.extensions.logging.ERXLogger;
 
 public abstract class ERClientApplication {
 
-	private static final Logger log = Logger.getLogger(ERClientApplication.class);
+	private static final Logger log = LoggerFactory.getLogger(ERClientApplication.class);
 
 	private Preferences userDefaults;
 	private ERDistributedObjectStore remoteObjectStore;

--- a/Frameworks/Misc/ERDistribution/Sources/er/distribution/client/ERDistributedObjectStore.java
+++ b/Frameworks/Misc/ERDistribution/Sources/er/distribution/client/ERDistributedObjectStore.java
@@ -2,7 +2,8 @@ package er.distribution.client;
 
 import java.lang.reflect.Field;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eocontrol.EOGlobalID;
 import com.webobjects.eodistribution.client.EODistributedObjectStore;
@@ -19,7 +20,7 @@ import er.distribution.common.ERReferenceRecordingCoder;
  */
 public class ERDistributedObjectStore extends EODistributedObjectStore {
 
-	private static final Logger log = Logger.getLogger(ERDistributedObjectStore.class);
+	private static final Logger log = LoggerFactory.getLogger(ERDistributedObjectStore.class);
 
 	public ERDistributedObjectStore(EODistributionChannel channel) {
 		super(channel);

--- a/Frameworks/Misc/ERDistribution/Sources/er/distribution/client/ERHTTPChannel.java
+++ b/Frameworks/Misc/ERDistribution/Sources/er/distribution/client/ERHTTPChannel.java
@@ -13,7 +13,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.swing.SwingUtilities;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eodistribution.client.EOHTTPChannel;
 import com.webobjects.foundation.NSCoder;
@@ -38,7 +39,7 @@ import er.extensions.foundation.ERXProperties;
  */
 public class ERHTTPChannel extends EOHTTPChannel {
 
-	private static final Logger log = Logger.getLogger(ERHTTPChannel.class);
+	private static final Logger log = LoggerFactory.getLogger(ERHTTPChannel.class);
 
 	private String url;
 	

--- a/Frameworks/Misc/ERDistribution/Sources/er/distribution/common/ERReferenceRecordingCoder.java
+++ b/Frameworks/Misc/ERDistribution/Sources/er/distribution/common/ERReferenceRecordingCoder.java
@@ -6,7 +6,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eocontrol.EOKeyValueQualifier;
 import com.webobjects.eocontrol.EOQualifier;
@@ -43,7 +44,7 @@ public class ERReferenceRecordingCoder extends _EOReferenceRecordingCoder {
 		}
 	}
 	
- 	private static final Logger log = Logger.getLogger(ERReferenceRecordingCoder.class);
+ 	private static final Logger log = LoggerFactory.getLogger(ERReferenceRecordingCoder.class);
 	
 	private NSData sourceMessage;
 	private int sourceSize;

--- a/Frameworks/Misc/ERPDFGeneration/Sources/er/pdf/ERPDFWrapper.java
+++ b/Frameworks/Misc/ERPDFGeneration/Sources/er/pdf/ERPDFWrapper.java
@@ -115,7 +115,7 @@ public class ERPDFWrapper extends ERXDynamicElement implements WOActionResults {
 	      ERPDFMerge.concatPDFs(pdfs, output, false);
 	      data = new NSData(output.toByteArray());
 	    } catch (Exception e) {
-	      log.error(e, e);
+	      log.error(e.getMessage(), e);
 	    }
 	  }
 	  return data;

--- a/Frameworks/Misc/ERPDFGeneration/Sources/er/pdf/components/ERFOPWrapper.java
+++ b/Frameworks/Misc/ERPDFGeneration/Sources/er/pdf/components/ERFOPWrapper.java
@@ -44,7 +44,7 @@ public class ERFOPWrapper extends ERPDFWrapper {
 			data = ERPDFUtilities.xml2Fop2Pdf(response.contentString(), xml2fopxsl, config);
 			data = appendPDFs(data, context);
 		} catch (Throwable e) {
-			log.error(e, e);
+			log.error(e.getMessage(), e);
 		}
 		
 		return data;

--- a/Frameworks/Misc/ERPersistentSessionStorage/Sources/er/persistentsessionstorage/model/eogen/_ERSessionInfo.java
+++ b/Frameworks/Misc/ERPersistentSessionStorage/Sources/er/persistentsessionstorage/model/eogen/_ERSessionInfo.java
@@ -6,7 +6,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -32,7 +33,7 @@ public abstract class _ERSessionInfo extends  ERXGenericRecord {
     /* more clazz methods here */
   }
 
-  private static final Logger LOG = Logger.getLogger(_ERSessionInfo.class);
+  private static final Logger LOG = LoggerFactory.getLogger(_ERSessionInfo.class);
 
   public er.persistentsessionstorage.model.ERSessionInfo.ERSessionInfoClazz clazz() {
     return er.persistentsessionstorage.model.ERSessionInfo.clazz;

--- a/Frameworks/Misc/ERPersistentSessionStorage/Templates/WonderEntity.java
+++ b/Frameworks/Misc/ERPersistentSessionStorage/Templates/WonderEntity.java
@@ -2,13 +2,14 @@
 package $entity.packageName;
 
 #end
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.webobjects.eocontrol.EOEditingContext;
 
 public#if (${entity.abstractEntity}) abstract#end class ${entity.classNameWithoutPackage} extends ${entity.prefixClassNameWithOptionalPackage} {
 	@SuppressWarnings("unused")
-	private static final Logger log = Logger.getLogger(${entity.classNameWithoutPackage}.class);
+	private static final Logger log = LoggerFactory.getLogger(${entity.classNameWithoutPackage}.class);
 
     public static final ${entity.classNameWithoutPackage}Clazz<${entity.classNameWithoutPackage}> clazz = new ${entity.classNameWithoutPackage}Clazz<${entity.classNameWithoutPackage}>();
     public static class ${entity.classNameWithoutPackage}Clazz<T extends ${entity.classNameWithoutPackage}> extends ${entity.prefixClassNameWithOptionalPackage}.${entity.prefixClassNameWithoutPackage}Clazz<T> {

--- a/Frameworks/Misc/ERPersistentSessionStorage/Templates/_WonderEntity.java
+++ b/Frameworks/Misc/ERPersistentSessionStorage/Templates/_WonderEntity.java
@@ -8,7 +8,8 @@ import com.webobjects.eocontrol.*;
 import com.webobjects.foundation.*;
 import java.math.*;
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import er.extensions.eof.*;
 import er.extensions.foundation.*;
@@ -45,7 +46,7 @@ public abstract class ${entity.prefixClassNameWithoutPackage} extends #if ($enti
     /* more clazz methods here */
   }
 
-  private static final Logger LOG = Logger.getLogger(${entity.prefixClassNameWithoutPackage}.class);
+  private static final Logger LOG = LoggerFactory.getLogger(${entity.prefixClassNameWithoutPackage}.class);
 
   public ${entity.classNameWithOptionalPackage}.${entity.classNameWithoutPackage}Clazz clazz() {
     return ${entity.classNameWithOptionalPackage}.clazz;

--- a/Frameworks/Misc/ERQuartzScheduler/Sources/main/er/quartzscheduler/foundation/ERQSAbstractJob.java
+++ b/Frameworks/Misc/ERQuartzScheduler/Sources/main/er/quartzscheduler/foundation/ERQSAbstractJob.java
@@ -1,6 +1,7 @@
 package er.quartzscheduler.foundation;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -13,7 +14,7 @@ import er.quartzscheduler.util.ERQSSchedulerServiceFrameworkPrincipal;
 
 public class ERQSAbstractJob implements Job
 {
-	protected static final Logger log = Logger.getLogger(ERQSJobSupervisor.class);
+	protected static final Logger log = LoggerFactory.getLogger(ERQSJobSupervisor.class);
 	private EOEditingContext editingContext = null;
 	private ERQSSchedulerServiceFrameworkPrincipal schedulerFPInstance;
 	private JobExecutionContext jobContext;

--- a/Frameworks/Misc/ERQuartzScheduler/Sources/main/er/quartzscheduler/foundation/ERQSAbstractListener.java
+++ b/Frameworks/Misc/ERQuartzScheduler/Sources/main/er/quartzscheduler/foundation/ERQSAbstractListener.java
@@ -1,6 +1,7 @@
 package er.quartzscheduler.foundation;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.quartz.JobExecutionContext;
 
 import com.webobjects.eocontrol.EOEditingContext;
@@ -18,7 +19,7 @@ import er.quartzscheduler.util.ERQSSchedulerServiceFrameworkPrincipal;
  */
 public abstract class ERQSAbstractListener 
 {
-	protected static final Logger log = Logger.getLogger(ERQSAbstractListener.class);
+	protected static final Logger log = LoggerFactory.getLogger(ERQSAbstractListener.class);
 	private final ERQSSchedulerServiceFrameworkPrincipal schedulerFPInstance;
 	private EOEditingContext editingContext;
 

--- a/Frameworks/Reporting/DRGrouping/pom.xml
+++ b/Frameworks/Reporting/DRGrouping/pom.xml
@@ -22,10 +22,6 @@
 			<groupId>com.webobjects</groupId>
 			<artifactId>JavaWebObjects</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<sourceDirectory>Sources</sourceDirectory>

--- a/Frameworks/Reporting/ERJasperReports/pom.xml
+++ b/Frameworks/Reporting/ERJasperReports/pom.xml
@@ -27,10 +27,6 @@
 			<artifactId>JavaEOControl</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
 		</dependency>

--- a/Frameworks/Reporting/ERPlot/pom.xml
+++ b/Frameworks/Reporting/ERPlot/pom.xml
@@ -26,10 +26,6 @@
 			<groupId>com.google.code.jofc2</groupId>
 			<artifactId>jofc2</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<sourceDirectory>Sources</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -410,12 +410,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
+                <version>1.7.36</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.25</version>
+                <version>1.7.36</version>
             </dependency>
             <dependency>
                 <groupId>ognl</groupId>


### PR DESCRIPTION
As promised, I'm replacing the log4j dependency with slf4j in Wonder. It's still a work in progress. Anyway, I'd like to share my findings and hear from the community.

## 1. What have I done so far?

- 1.1) Most references to `org.apache.log4j.Logger` were replaced by `org.slf4j.Logger`.
- 1.2) All `fatal` log messages were replaced by `error`.
- 1.3) The `AjaxRemoteLogging` component doesn't support the log level `fatal` anymore. In contrast, `trace` was added as an option.
- 1.4) The log level configuration was removed from the`WOHelperFunctionDeclarationParser`, `WOHelperFunctionHTMLParser` and `WOHelperFunctionTagRegistry` classes. `slf4j` doesn't support configuring the log level in runtime.
- 1.5) For the same reason, I removed the ability to change the log level in runtime from the `ERD2WDebugFlags.toggleD2WInfo` and `ERDDebuggingHelp.toggleRuleTracing` methods. I'm not entirely satisfied with this change.

## 2. Open Issues

- 2.1) `ERXApplication` re-inits the log4j console appenders, so we get logging into `WOOutputPath` again. Does anybody remember what issue this code fixes?
- 2.2) Wonder has an `ERXLogger` class that works as a facade. I'm still investigating if we can replace it with the slf4j `Logger` class.
- 2.3) Wonder has an `ERXNSLogLog4jBridge` class that works as a bridge between `NSLog` and `log4j`. We can create an `ERXNSLogSlf4jBridge` class to make the bridge between `NSLog` and `slf4j`.
- 2.4) The `ERD2WPage` component on `ERDirectToWeb` uses the `org.apache.log4j.NDC` class. We should migrate it to use the `org.slf4j.MDC` class instead.
- 2.5) The `ImageMagickCommandlineMetadataParser` class on `ERAttachment` uses `org.apache.log4j.lf5.util.StreamUtils`. We can replace it by a more general dependency (commons-io?).
- 2.6) `ERXDirectAction.log4jAction` is an action that opens the `ERXLog4JConfiguration` component and allows to change log4j configuration in runtime. I'm thinking of leaving it as it is. The application will throw a `ClassNotFoundException` if somebody uses it and the log4j library is not in the classpath. Any thoughts?
- 2.7) The `StandaloneRunner` class of the `ERSelenium` uses `log4j` extensively to configure the logging behavior of the selenium runner. I'm thinking of leaving it as it is.
- 2.8) The following classes extend a class from log4j1. We can leave it as it is.
  - `ERXThreadStorageAppender` extends `org.apache.log4j.AppenderSkeleton`.
  - `ERXPatternLayout` extends `org.apache.log4j.PatternLayout`.
  - `ERXMailAppender` extends `org.apache.log4j.AppenderSkeleton`.
  - `ERXConsoleAppender` extends `org.apache.log4j.ConsoleAppender`.
  - `ERXEOFAppender` extends `org.apache.log4j.AppenderSkeleton`.

## 3. Open Questions

- 3.1) Should we include sample/default log configuration files for the most common log libraries? I'm considering log4j2 and logback in addition to the existing log4j1 configuration.

## Considerations

- log4j is now an optional dependency. Users must explicitly declare it on their poms to keep using log4j1.
- Besides that, these changes shouldn't affect projects using log4j1.
- I'm working only on frameworks built by Maven. I didn't touch projects in the following folders:
  - Applications
  - Archives
  - Tests

I would appreciate it if you could look at the proposed changes and help me with the open issues. Your thoughts are always welcome!