### PR TITLE
Fix incorrect message and HTTP status code when no instance is available

### DIFF
--- a/Utilities/Adaptors/Adaptor/transaction.c
+++ b/Utilities/Adaptors/Adaptor/transaction.c
@@ -402,7 +402,7 @@ HTTPResponse *tr_handleRequest(HTTPRequest *req, const char *url, WOURLComponent
    } else {
       if (ac_authorizeAppListing(wc))
          resp = WOAdaptorInfo(req, wc);
-      else
+      else if (app.error != err_noInstance)
          app.error = err_notFound;
    }
 


### PR DESCRIPTION
This bug has been around for at least 19 years, as described on [this thread](https://webobjects-dev.omnigroup.narkive.com/7gWK5EfH/http-500-error-a-nightmare). The WebObjects adaptor may return an incorrect HTTP status code and message when no instance of an application is available to handle the request. It's fairly easy to reproduce the problem:

1. Set up a WebObjects application with a single instance.
2. Try to access the application from a browser with the instance stopped.

```
GET - /cgi-bin/WebObjects/my-app.woa/wa/default

Status: 500
Message: No instance available
```

3. Reload the browser, and you'll get a different response.

```
GET - /cgi-bin/WebObjects/my-app.woa/wa/default

Status: 404
Message: The requested application was not found on this server
```

When no instance is available, returning a 404 status code is problematic, especially if the URL being accessed is part of a REST API. This fix will ensure that the WebObjects adaptor will return the correct HTTP status code and message for every request when no instance is available.