### PR TITLE
Fix error paginating queries containing the DISTINCT clause on SQL Server

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2586,7 +2586,7 @@ public class ERXSQLHelper {
 			}
 			else
 			{
-				String columns = originalSql.substring( originalSql.indexOf(  "select " ) + 7, originalSql.indexOf( " from " ) );
+				String columns = expression.listString();
 
 				orderBy = "order by " + columns.split( "," )[0];
 			}

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2580,7 +2580,7 @@ public class ERXSQLHelper {
 
 			if( indexOfOrderByClause > 0)
 			{
-				orderBy = originalSql.substring( indexOfOrderByClause + 1, originalSql.length() );
+				orderBy = originalSql.substring(indexOfOrderByClause + 1);
 
 				originalSql = originalSql.substring( 0, indexOfOrderByClause );
 			}


### PR DESCRIPTION
The application throws an exception when building queries with pagination for SQL Server if the query has no `ORDER BY` clause and the `DISTINCT` clause is present. This fix takes only the first column name of the query to build an `ORDER BY` clause.