### PR TITLE
Support get next sequence value from SQL Server database

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXSQLHelper.java
@@ -2626,6 +2626,10 @@ public class ERXSQLHelper {
 			return "CREATE INDEX " + indexName + " ON " + tableName + "(" + columnNames.componentsJoinedByString(",") + ")";
 		}
 
+		@Override
+		protected String sqlForGetNextValFromSequencedNamed(String sequenceName) {
+			return "SELECT NEXT VALUE FOR " + sequenceName;
+		}
 	}
 
 	public static class NoSQLHelper extends ERXSQLHelper {


### PR DESCRIPTION
The `ERXSQLHelper` class has a method to get the next sequence value from the database. Sequence objects were introduced in SQL Server 2012. However, the Microsoft implementation still throws an exception. This commit adds support for SQL Server sequences in the `ERXSQLHelper` class.