### PR TITLE
WO Adaptor URL Sanitization Fixes

### DIFF
--- a/Utilities/Adaptors/Adaptor/MoreURLCUtilities.h
+++ b/Utilities/Adaptors/Adaptor/MoreURLCUtilities.h
@@ -57,6 +57,9 @@ and limitations under the License.
 unsigned int SizeURL(WOURLComponents *wc);
 void ComposeURL(char *string, WOURLComponents *wc, int shouldProcessUrl);
 
+// Initial URL sanitization.
+WOURLError WOValidateInitialURL( const char* url );
+
 /*
  *	parses just the application name from the url, returns 0 on 
  *	success & fills in only wc.prefix, wc.webobjectsVersion and

--- a/Utilities/Adaptors/Adaptor/WOURLCUtilities.h
+++ b/Utilities/Adaptors/Adaptor/WOURLCUtilities.h
@@ -88,7 +88,8 @@ typedef enum {
     WOURLInvalidQueryString,
     WOURLInvalidSuffix,
     WOURLInvalidPostData,
-    WOURLNoPostData
+    WOURLNoPostData,
+    WOURLForbiddenCharacter
 } WOURLError;
 
 /*********** WOF dynamic URL functions. ***********/

--- a/Utilities/Adaptors/Adaptor/config.h
+++ b/Utilities/Adaptors/Adaptor/config.h
@@ -67,7 +67,7 @@ typedef int  intptr_t;
 #define WA_MAX_CONFIG_SERVERS		16
 
 #define WA_MAX_APP_NAME_LENGTH 		64	/* maximum length of a WOApplication's name, including a terminating null */
-#define WA_MAX_APP_COUNT		512	/* maximum number of applications the adaptor can keep track of */
+#define WA_MAX_APP_COUNT		256	/* maximum number of applications the adaptor can keep track of */
 #define WA_MAX_APP_INSTANCE_COUNT	128	/* maximum number of instances of a single application the adaptor can keep track of */
 #define WA_MAX_URL_LENGTH		256	/* maximum length of a redirect url in the config, including the null */
 #define WA_MAX_ADDITIONAL_ARGS_LENGTH	0	/* maximum length of the additional args, including the null */

--- a/Utilities/Adaptors/Adaptor/config.h
+++ b/Utilities/Adaptors/Adaptor/config.h
@@ -57,7 +57,7 @@ typedef int  intptr_t;
 #define CURRENT_WOF_VERSION_MAJOR	4
 #define CURRENT_WOF_VERSION_MINOR	6
 
-#define ADAPTOR_VERSION			"4.6.6"
+#define ADAPTOR_VERSION			"4.6.7"
 
 /* Used to turn the value of a macro into a string literal */
 #define _Str(x) #x
@@ -67,7 +67,7 @@ typedef int  intptr_t;
 #define WA_MAX_CONFIG_SERVERS		16
 
 #define WA_MAX_APP_NAME_LENGTH 		64	/* maximum length of a WOApplication's name, including a terminating null */
-#define WA_MAX_APP_COUNT		256	/* maximum number of applications the adaptor can keep track of */
+#define WA_MAX_APP_COUNT		512	/* maximum number of applications the adaptor can keep track of */
 #define WA_MAX_APP_INSTANCE_COUNT	128	/* maximum number of instances of a single application the adaptor can keep track of */
 #define WA_MAX_URL_LENGTH		256	/* maximum length of a redirect url in the config, including the null */
 #define WA_MAX_ADDITIONAL_ARGS_LENGTH	0	/* maximum length of the additional args, including the null */

--- a/Utilities/Adaptors/Adaptor/config.h
+++ b/Utilities/Adaptors/Adaptor/config.h
@@ -81,7 +81,10 @@ typedef int  intptr_t;
 #define WA_MAX_HOST_NAME_LENGTH		64	/* maximum length of a host name, including the null */
 #define WA_MAX_INSTANCE_NUMBER_LENGTH	8	/* maximum length of an instance number, including the null */
 
-   
+// 2022-08-04: Uncomment this option to explicitly DISABLE URL invalid character rejections.
+// Please do not change this unless you are certain about doing so!
+//#define __PRESERVE_UNSAFE_URLS 1
+
 /*
  *	default values for some feature settings
  */

--- a/Utilities/Adaptors/Apache2.2/mod_WebObjects.c
+++ b/Utilities/Adaptors/Apache2.2/mod_WebObjects.c
@@ -668,6 +668,7 @@ int WebObjects_translate(request_rec *r) {
     WebObjects_config *wc;
     WOURLComponents url;
     WOURLError urlerr;
+    WOURLError charcheck;
 
     // get the module configuration (this is the structure created by WebObjects_create_config())
     wc = ap_get_module_config(r->server->module_config, &WebObjects_module);
@@ -679,6 +680,14 @@ int WebObjects_translate(request_rec *r) {
 #else
         memset(&url,0,sizeof(WOURLComponents));
 #endif
+
+        // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
+        charcheck = WOValidateInitialURL( r->uri );
+        if ( charcheck != WOURLOK ) {
+            WOLog(WO_DBG, "WebObjects_translate(): declining request due to forbidden URL characters");
+            return DECLINED;
+        }
+
         urlerr = WOParseApplicationName(&url, r->uri);
         if (urlerr != WOURLOK && !((urlerr == WOURLInvalidApplicationName) && ac_authorizeAppListing(&url))) {
             WOLog(WO_DBG, "<WebObjects Apache Module> translate - DECLINED: %s", r->uri);

--- a/Utilities/Adaptors/Apache2.2/mod_WebObjects.c
+++ b/Utilities/Adaptors/Apache2.2/mod_WebObjects.c
@@ -681,12 +681,14 @@ int WebObjects_translate(request_rec *r) {
         memset(&url,0,sizeof(WOURLComponents));
 #endif
 
+#ifndef __PRESERVE_UNSAFE_URLS
         // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
         charcheck = WOValidateInitialURL( r->uri );
         if ( charcheck != WOURLOK ) {
-            WOLog(WO_DBG, "WebObjects_translate(): declining request due to forbidden URL characters");
+            WOLog(WO_ERR, "WebObjects_translate(): declining request due to forbidden URL characters");
             return DECLINED;
         }
+#endif
 
         urlerr = WOParseApplicationName(&url, r->uri);
         if (urlerr != WOURLOK && !((urlerr == WOURLInvalidApplicationName) && ac_authorizeAppListing(&url))) {

--- a/Utilities/Adaptors/Apache2.4/mod_WebObjects.c
+++ b/Utilities/Adaptors/Apache2.4/mod_WebObjects.c
@@ -668,6 +668,7 @@ int WebObjects_translate(request_rec *r) {
     WebObjects_config *wc;
     WOURLComponents url;
     WOURLError urlerr;
+    WOURLError charcheck;
 
     // get the module configuration (this is the structure created by WebObjects_create_config())
     wc = ap_get_module_config(r->server->module_config, &WebObjects_module);
@@ -679,6 +680,14 @@ int WebObjects_translate(request_rec *r) {
 #else
 		memset(&url,0,sizeof(WOURLComponents));
 #endif
+
+        // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
+        charcheck = WOValidateInitialURL( r->uri );
+        if ( charcheck != WOURLOK ) {
+            WOLog(WO_DBG, "WebObjects_translate(): declining request due to forbidden URL characters");
+            return DECLINED;
+        }
+
         urlerr = WOParseApplicationName(&url, r->uri);
         if (urlerr != WOURLOK && !((urlerr == WOURLInvalidApplicationName) && ac_authorizeAppListing(&url))) {
             WOLog(WO_DBG, "<WebObjects Apache Module> translate - DECLINED: %s", r->uri);

--- a/Utilities/Adaptors/Apache2.4/mod_WebObjects.c
+++ b/Utilities/Adaptors/Apache2.4/mod_WebObjects.c
@@ -681,12 +681,14 @@ int WebObjects_translate(request_rec *r) {
 		memset(&url,0,sizeof(WOURLComponents));
 #endif
 
+#ifndef __PRESERVE_UNSAFE_URLS
         // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
         charcheck = WOValidateInitialURL( r->uri );
         if ( charcheck != WOURLOK ) {
-            WOLog(WO_DBG, "WebObjects_translate(): declining request due to forbidden URL characters");
+            WOLog(WO_ERR, "WebObjects_translate(): declining request due to forbidden URL characters");
             return DECLINED;
         }
+#endif
 
         urlerr = WOParseApplicationName(&url, r->uri);
         if (urlerr != WOURLOK && !((urlerr == WOURLInvalidApplicationName) && ac_authorizeAppListing(&url))) {

--- a/Utilities/Adaptors/CGI/WebObjects.c
+++ b/Utilities/Adaptors/CGI/WebObjects.c
@@ -240,6 +240,7 @@ int doit(int argc, char *argv[], char **envp) {
       const char *script_name, *path_info, *config_url, *username, *password, *config_options;
       const char *reqerr;
       WOURLError urlerr;
+      WOURLError charcheck;
       strtbl *options = NULL;
 
 #ifdef WIN32
@@ -314,7 +315,16 @@ int doit(int argc, char *argv[], char **envp) {
       strcpy(url, script_name);
       strcat(url, path_info);
       WOLog(WO_INFO,"<CGI> new request: %s",url);
-      
+
+      // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
+      charcheck = WOValidateInitialURL( url );
+      if ( charcheck != WOURLOK ) {
+         WOLog(WO_INFO, "Declining request due to forbidden URL characters.");
+         const char* _urlerr;
+         _urlerr = WOURLstrerror( charcheck );
+         die( _urlerr, HTTP_BAD_REQUEST );
+      }
+
       urlerr = WOParseApplicationName(&wc, url);
       if (urlerr != WOURLOK) {
          const char *_urlerr;

--- a/Utilities/Adaptors/CGI/WebObjects.c
+++ b/Utilities/Adaptors/CGI/WebObjects.c
@@ -316,6 +316,7 @@ int doit(int argc, char *argv[], char **envp) {
       strcat(url, path_info);
       WOLog(WO_INFO,"<CGI> new request: %s",url);
 
+#ifndef __PRESERVE_UNSAFE_URLS
       // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
       charcheck = WOValidateInitialURL( url );
       if ( charcheck != WOURLOK ) {
@@ -324,6 +325,7 @@ int doit(int argc, char *argv[], char **envp) {
          _urlerr = WOURLstrerror( charcheck );
          die( _urlerr, HTTP_BAD_REQUEST );
       }
+#endif
 
       urlerr = WOParseApplicationName(&wc, url);
       if (urlerr != WOURLOK) {

--- a/Utilities/Adaptors/FastCGI/WebObjects.c
+++ b/Utilities/Adaptors/FastCGI/WebObjects.c
@@ -290,6 +290,7 @@ int main() {
       const char *script_name, *path_info;
       const char *reqerr;
       WOURLError urlerr;
+      WOURLError charcheck;
       FCGX_ParamArray hdrp_org;
      
       exit_status = FCGX_Accept(&in, &out, &err, &hdrp );
@@ -329,7 +330,18 @@ int main() {
       strcpy(url, script_name);
       strcat(url, path_info);
       WOLog(WO_INFO,"<FastCGI> new request: %s",url);
-      
+
+      // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
+      charcheck = WOValidateInitialURL( url );
+      if ( charcheck != WOURLOK ) {
+         WOLog(WO_INFO, "<FastCGI> Declining request due to forbidden URL characters.");
+         const char* _urlerr;
+         _urlerr = WOURLstrerror( charcheck );
+         prepareAndSendErrorResponse( _urlerr, HTTP_BAD_REQUEST );
+         WOFREE(url);
+         break;
+      }
+
       urlerr = WOParseApplicationName(&wc, url);
       if (urlerr != WOURLOK) {
          const char *_urlerr;

--- a/Utilities/Adaptors/FastCGI/WebObjects.c
+++ b/Utilities/Adaptors/FastCGI/WebObjects.c
@@ -331,6 +331,7 @@ int main() {
       strcat(url, path_info);
       WOLog(WO_INFO,"<FastCGI> new request: %s",url);
 
+#ifndef __PRESERVE_UNSAFE_URLS
       // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
       charcheck = WOValidateInitialURL( url );
       if ( charcheck != WOURLOK ) {
@@ -341,6 +342,7 @@ int main() {
          WOFREE(url);
          break;
       }
+#endif
 
       urlerr = WOParseApplicationName(&wc, url);
       if (urlerr != WOURLOK) {

--- a/Utilities/Adaptors/IIS/WebObjects.c
+++ b/Utilities/Adaptors/IIS/WebObjects.c
@@ -628,6 +628,7 @@ __declspec(dllexport) DWORD __stdcall HttpExtensionProc(EXTENSION_CONTROL_BLOCK 
    WOLog(WO_INFO,"<WebObjects ISAPI> new request: %s", uri);
    WOFREE(script_name);
 
+#ifndef __PRESERVE_UNSAFE_URLS
    // Make sure the URL does not contain forbidden characters (0x0D or 0x0A).
    charcheck = WOValidateInitialURL( uri );
    if ( charcheck != WOURLOK ) {
@@ -636,6 +637,7 @@ __declspec(dllexport) DWORD __stdcall HttpExtensionProc(EXTENSION_CONTROL_BLOCK 
       _urlerr = WOURLstrerror( charcheck );
       return die( p, _urlerr, HTTP_BAD_REQUEST );
    }
+#endif
 
    urlerr = WOParseApplicationName(&wc, uri);
    if (urlerr != WOURLOK) {

--- a/Utilities/Adaptors/NSAPI/WebObjects.c
+++ b/Utilities/Adaptors/NSAPI/WebObjects.c
@@ -224,9 +224,13 @@ int WebObjectsNameTrans(pblock *pb, Session *sn, Request *rq)
                       /*
                        *	make sure this is a valid WebObjects(tm) URL
                        */
+                      if (WOValidateInitialURL( uripath ) != WOURLOK )
+                         return REQ_NOACTION;
+
                       wc = WOURLComponents_Initializer;
                       if (WOParseApplicationName(&wc, uripath) != WOURLOK) /* bail now if something wierd */
                          return REQ_NOACTION;
+
                       pblock_nvinsert(OBJECTNAME,(char *)objName,rq->vars);
 
                       approot = pblock_findval(APPROOT,pb);


### PR DESCRIPTION
Added fix-ups to the `Utilities/Adaptors` subfolders specifically to address a vulnerability in parsing, whereby an adversary can directly inject their own headers and content into the web requests going to the application (WO) servers behind the adaptor.

The new code returns a `404` on any encounter of a `0x0D` (carriage-return) or a `0x0A` (line-feed) character in the adaptor `translate` functions, and the defined forbidden character set is written in such a way as to be expandable later as necessary. This behavior of returning a `404` error mimics Apache's mitigation of the use of `%2f` in request URLs.

**IMPORTANTLY**: This URL cleanliness will not affect content within query strings usually, since those characters are not typically expanded by webserver software before reaching the adaptor interface.

Tested and operating in an active production scenario, filtering arbitrary HTTP header injection or URL-based reflection but maintaining normal operation as expected. The most recent commit addresses enabling the protection by default but provides the option to regress to the previous behavior in situations and deployments where it may be considered safe or necessary.

For more information about the problem being fixed, I will post a separate link to my blog for interested users.