### PR TITLE
Make line numbers in ERXExceptionPage clickable, navigating to them in Eclipse

### DIFF
--- a/Frameworks/Core/ERExtensions/Components/ERXExceptionPage.wo/ERXExceptionPage.html
+++ b/Frameworks/Core/ERExtensions/Components/ERXExceptionPage.wo/ERXExceptionPage.html
@@ -83,6 +83,14 @@
 				background-color: rgb(255,150,160);
 			}
 		</style>
+		<script>
+			// For communicating with the WOLips server
+			function invokeURL( url ) {
+				const Http = new XMLHttpRequest();
+				Http.open("GET", url);
+				Http.send();
+			}
+		</script>
 	</head>
 	<body>
 		<div class="container">
@@ -105,7 +113,7 @@
 				<wo:repetition list="$exceptionParser.stackTrace" item="$currentErrorLine">
 					<wo:container elementName="tr" class="$currentRowClass">
 						<td><wo:str value="$currentErrorLine.fileName" /></td>
-						<td><wo:str value="$currentErrorLine.lineNumber" /></td>
+						<td><wo:link href="$currentLineURL" disabled="$currentLineDisabled"><wo:str value="$currentErrorLine.lineNumber" /></wo:link></td>
 						<td><wo:str value="$currentErrorLine.methodName" /></td>
 						<td><wo:str value="$currentErrorLine.packageName" /></td>
 						<td><wo:str value="$currentBundle.name" /></td>


### PR DESCRIPTION
Adds links to line numbers in ERXExceptionPage. Clicking a line number will open the source file and navigate to the line.

This is the client side part of this pull request to WOLips, which adds the required functionality on the WOLips side:

https://github.com/wocommunity/wolips/pull/171