### PR TITLE
wotaskd and JavaMonitor don't work on Java 17 without manual editing

### DIFF
--- a/Applications/JavaMonitor/build.properties
+++ b/Applications/JavaMonitor/build.properties
@@ -3,6 +3,7 @@ component.inlineBindingPrefix=$
 component.inlineBindingSuffix=
 component.wellFormedTemplateRequired=false
 customInfoPListContent=
+jvmOptions=--add-exports=java.base/sun.security.action=ALL-UNNAMED
 project.name=JavaMonitor
 project.name.lowercase=javamonitor
 project.principal.class=com.webobjects.monitor.application.Application

--- a/Applications/wotaskd/build.properties
+++ b/Applications/wotaskd/build.properties
@@ -3,6 +3,7 @@ component.inlineBindingPrefix=$
 component.inlineBindingSuffix=
 component.wellFormedTemplateRequired=false
 customInfoPListContent=
+jvmOptions=--add-exports=java.base/sun.security.action=ALL-UNNAMED
 project.name=wotaskd
 project.name.lowercase=wotaskd
 project.principal.class=com.webobjects.monitor.wotaskd.Application


### PR DESCRIPTION
This commit sets the JVM options to add-exports sun.security.action to unnamed module by default. Then wotaskd and JavaMonitor will work with Java 17 without having to manually edit Contents/UNIX/UNIXClassPath.txt or similar files for other OSs.