### PR TITLE
Fix issue 999

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
@@ -112,7 +112,7 @@ public class ERXStaticResourceRequestHandler extends WORequestHandler {
 			File file = null;
 			StringBuilder sb = new StringBuilder(documentRoot.length() + uri.length());
 			String wodataKey = request.stringFormValueForKey("wodata");
-			if(uri.startsWith(application.cgiAdaptorURL()) && wodataKey != null) {
+			if(uri.startsWith(request.applicationURLPrefix()) && wodataKey != null) {
 				uri = wodataKey;
 				if(uri.startsWith("file:")) {
 					// remove file:/

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXStaticResourceRequestHandler.java
@@ -112,7 +112,7 @@ public class ERXStaticResourceRequestHandler extends WORequestHandler {
 			File file = null;
 			StringBuilder sb = new StringBuilder(documentRoot.length() + uri.length());
 			String wodataKey = request.stringFormValueForKey("wodata");
-			if(uri.startsWith("/cgi-bin") && wodataKey != null) {
+			if(uri.startsWith(application.cgiAdaptorURL()) && wodataKey != null) {
 				uri = wodataKey;
 				if(uri.startsWith("file:")) {
 					// remove file:/


### PR DESCRIPTION
When a static resources, from a jar, is accessed in an environment with a custom adaptorUrl that do not start with "/cgi-bin" the wodata parameter from request is ignored and the resource is not served.