### PR TITLE
Fix for 1007

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
@@ -540,7 +540,7 @@ public class ERXFileUtilities {
      * @param frameworkName name of the framework, <code>null</code> or "app"
      *		for the application bundle
      * @param languages array of languages to get localized resource or <code>null</code>
-     * @return the absolutePath method of of the file object 
+     * @return the absolutePath method off of the file object 
      *         or null if the resource is contained in a jar or doesn't exist.
      */
     public static String pathForResourceNamed(String fileName, String frameworkName, NSArray<String> languages) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
@@ -545,7 +545,7 @@ public class ERXFileUtilities {
      */
     public static String pathForResourceNamed(String fileName, String frameworkName, NSArray<String> languages) {
         String path = null;
-        NSBundle bundle = "app".equals(frameworkName) ? NSBundle.mainBundle() : NSBundle.bundleForName(frameworkName);
+        NSBundle bundle = (frameworkName == null || "app".equals(frameworkName)) ? NSBundle.mainBundle() : NSBundle.bundleForName(frameworkName);
         if(bundle != null && bundle.isJar()) {
             log.debug("Can't get path when run as jar: {} - {}", frameworkName, fileName);
         } else {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/foundation/ERXFileUtilities.java
@@ -540,14 +540,14 @@ public class ERXFileUtilities {
      * @param frameworkName name of the framework, <code>null</code> or "app"
      *		for the application bundle
      * @param languages array of languages to get localized resource or <code>null</code>
-     * @return the absolutePath method off of the
-     *		file object
+     * @return the absolutePath method of of the file object 
+     *         or null if the resource is contained in a jar or doesn't exist.
      */
     public static String pathForResourceNamed(String fileName, String frameworkName, NSArray<String> languages) {
         String path = null;
         NSBundle bundle = "app".equals(frameworkName) ? NSBundle.mainBundle() : NSBundle.bundleForName(frameworkName);
         if(bundle != null && bundle.isJar()) {
-            log.warn("Can't get path when run as jar: {} - {}", frameworkName, fileName);
+            log.debug("Can't get path when run as jar: {} - {}", frameworkName, fileName);
         } else {
         	WOApplication application = WOApplication.application();
         	if (application != null) {


### PR DESCRIPTION
This PR suppresses confusing warnings 'Can't get path when run as jar' during application start emitted by `ERXFileUtilities.pathForResourceNamed`
In addition, if the argument `frameworkName` is null, the resource will be searched in the main bundle.

