### PR TITLE
Origin/fix for 1009

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCConnectionBroker.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCConnectionBroker.java
@@ -402,7 +402,13 @@ public class ERXJDBCConnectionBroker implements ERXJDBCAdaptor.ConnectionBroker 
 
     private Connection createConnection() throws SQLException {
         try {
-            Class.forName(dbDriver);
+        	
+        	// When dbDriver null or blank, the driver is automatically registered via the SPI. 
+        	// Manual loading of the driver class is generally unnecessary.
+            if(dbDriver != null && !dbDriver.isEmpty()) {
+            	Class.forName(dbDriver);
+            }
+            
             Connection conn = DriverManager.getConnection(dbServer, dbLogin, dbPassword);
             return conn;
         } catch (ClassNotFoundException e2) {

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCConnectionBroker.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCConnectionBroker.java
@@ -404,7 +404,7 @@ public class ERXJDBCConnectionBroker implements ERXJDBCAdaptor.ConnectionBroker 
         try {
         	
         	// When dbDriver null or blank, the driver is automatically registered via the SPI. 
-        	// Manual loading of the driver class is generally unnecessary.
+        	// Since JDBC 4.0, manual loading of the driver class is generally unnecessary.
             if(dbDriver != null && !dbDriver.isEmpty()) {
             	Class.forName(dbDriver);
             }

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCUtilities.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/jdbc/ERXJDBCUtilities.java
@@ -159,11 +159,15 @@ public class ERXJDBCUtilities {
 			// Boolean readOnly = (Boolean) dict.objectForKey("readOnly");
 			// boolean ro = readOnly == null ? false : readOnly.booleanValue();
 
-			try {
-				Class.forName(driver);
-			}
-			catch (ClassNotFoundException e) {
-				throw new SQLException("Could not find driver: " + driver);
+        	// When dbDriver null or blank, the driver is automatically registered via the SPI. 
+        	// Since JDBC 4.0, manual loading of the driver class is generally unnecessary.
+			if(driver != null && !driver.isEmpty()) {
+				try {
+					Class.forName(driver);
+				}
+				catch (ClassNotFoundException e) {
+					throw new SQLException("Could not find driver: " + driver);
+				}
 			}
 			Connection con = DriverManager.getConnection(url, username, password);
 			DatabaseMetaData dbmd = con.getMetaData();

--- a/Frameworks/PlugIns/MySQLPlugIn/Sources/com/webobjects/jdbcadaptor/_MySQLPlugIn.java
+++ b/Frameworks/PlugIns/MySQLPlugIn/Sources/com/webobjects/jdbcadaptor/_MySQLPlugIn.java
@@ -36,7 +36,7 @@ import com.webobjects.foundation._NSStringUtilities;
 
 public class _MySQLPlugIn extends JDBCPlugIn {
 
-	private static final String DriverClassName = "com.mysql.jdbc.Driver";
+	private static final String DriverClassName = null;
 
 	private static final String DriverProductName = "MySQL";
 	

--- a/Frameworks/PlugIns/MySQLPlugIn/Sources/er/mysql/MySQLPlugInPrincipal.java
+++ b/Frameworks/PlugIns/MySQLPlugIn/Sources/er/mysql/MySQLPlugInPrincipal.java
@@ -6,5 +6,6 @@ import com.webobjects.jdbcadaptor._MySQLPlugIn;
 public class MySQLPlugInPrincipal {
 	static {
 		JDBCPlugIn.setPlugInNameForSubprotocol(_MySQLPlugIn.class.getName(), "mysql");
+		JDBCPlugIn.setPlugInNameForSubprotocol(_MySQLPlugIn.class.getName(), "mariadb");
 	}
 }


### PR DESCRIPTION
This PR removes the hard-coded DriverClassName and supports now the use of the both the current mysql-connector-java version 8 and the org.mariadb.jdbc mariadb-java-client driver