### PR TITLE
Fix raw row fetching issue with composite keypaths and custom classes

### DIFF
--- a/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
+++ b/Frameworks/EOF/ERAttributeExtension/Sources/com/webobjects/eoaccess/EOAttribute.java
@@ -1663,8 +1663,9 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 	}
 
 	protected void _setValuesFromTargetAttribute() {
-		if (isFlattened()) {
-			EOAttribute property = (EOAttribute) _definitionArray.lastObject();
+		Object definition = _definitionArray.lastObject();
+		if (definition instanceof EOAttribute) {
+			EOAttribute property = (EOAttribute) definition;
 			setExternalType(property.externalType());
 			setClassName(property.className());
 			setValueType(property.valueType());
@@ -1676,19 +1677,18 @@ public class EOAttribute extends EOProperty implements EOPropertyListEncoding, E
 			setParameterDirection(property.parameterDirection());
 			setUserInfo(property.userInfo());
 			_setInternalInfo(property._internalInfo());
+			setValueFactoryClassName(property.valueFactoryClassName());
+			setValueFactoryMethodName(property.valueFactoryMethodName());
+			setAdaptorValueConversionClassName(property.adaptorValueConversionClassName());
+			setAdaptorValueConversionMethodName(property.adaptorValueConversionMethodName());
+			setFactoryMethodArgumentType(property.factoryMethodArgumentType());
 			int adaptorDataType = property.adaptorValueType();
 			if (adaptorDataType == AdaptorNumberType) {
 				setPrecision(property.precision());
 				setScale(property.scale());
 			}
-			else if (adaptorDataType == AdaptorDateType)
+			else if (adaptorDataType == AdaptorDateType) {
 				setServerTimeZone(property.serverTimeZone());
-			else if (adaptorDataType == AdaptorBytesType) {
-				setValueFactoryClassName(property.valueFactoryClassName());
-				setValueFactoryMethodName(property.valueFactoryMethodName());
-				setAdaptorValueConversionClassName(property.adaptorValueConversionClassName());
-				setAdaptorValueConversionMethodName(property.adaptorValueConversionMethodName());
-				setFactoryMethodArgumentType(property.factoryMethodArgumentType());
 			}
 		}
 	}


### PR DESCRIPTION
This pull request addresses an issue that occurs when you attempt to retrieve raw rows using composite keypaths where the last element is associated with a custom class.

To illustrate the problem, consider the following example:

```mermaid
erDiagram
    Post {
        long id
        long fk_author
    }

    User {
        long id
        Enum gender
    }

    Post |{--|| User : author
```

In this scenario, `User` is the target of the `author` relationship defined by `Post`. The `gender` attribute of `User` uses a custom class, such as one defined by the `javaEnum` prototype. 

The issue arises when you use the following code:

```
var fs = new ERXFetchSpecification<Post>(Post.ENTITY_NAME);
fs.setFetchesRawRows(true);
fs.setRawRowKeyPaths(Post.AUTHOR.dot(User.GENDER).key());
fs.fetchObjects(ec);
```

The result of this operation is an `NSArray` of `NSDictionary` where the `"author.gender"` key returns an object of type `NSData`, rather than the expected `Enum` type.

This behavior occurs because the `EOAttribute` constructor is called with the `entity` and `definition` parameters when fetching composite keypaths using raw rows. During `EOAttribute` initialization, the composite keypath is resolved, and the resulting `EOAttribute` behaves as if it were the referenced attribute. However, this only happens if the attribute is flattened. Otherwise, the `EOAttribute` is not fully initialized, and the `JDBCColumn` is unable to convert the returned data from the database to the correct type.

To resolve this issue, I've made changes to ensure that attribute properties are initialized correctly, even if the attribute is not flattened.

I've thoroughly tested this change on a large application, covering both normal and raw rows fetching, and I couldn't find any issues so far. While I don't anticipate any problems arising from these changes, I would appreciate feedback from others on this matter.