### PR TITLE
Log names of unfinished shutdown hooks

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXShutdownHook.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXShutdownHook.java
@@ -3,6 +3,7 @@ package er.extensions.appserver;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.webobjects.foundation.NSKeyValueCoding;
 import com.webobjects.foundation.NSNotification;
@@ -57,7 +58,8 @@ public abstract class ERXShutdownHook extends Thread {
 					synchronized( ALL_HOOKS ) {
 						while( ALL_HOOKS.size() > 0 ) {
 							// Use System.out to minimize dependencies
-							System.out.println( "ShutdownHook waiting for " + ALL_HOOKS.size() + " hook" + (ALL_HOOKS.size() > 1 ? "s" : "") + " to complete" );
+							String names = ALL_HOOKS.stream().map( hook -> hook.name ).collect( Collectors.joining( ", " ) );
+							System.out.println( "ERXShutdownHook waiting for " + ALL_HOOKS.size() + " hook" + (ALL_HOOKS.size() > 1 ? "s" : "") + " to complete: " + names );
 							ALL_HOOKS.wait();
 						}
 
@@ -74,7 +76,7 @@ public abstract class ERXShutdownHook extends Thread {
 		} );
 	}
 	
-	private String name;
+	String name;
 
 	/**
 	 * Call this in your app constructor if you have no other shutdown hooks. If you don't call


### PR DESCRIPTION
If one of the shutdown hooks hangs and won't complete, it is hard to quickly find out which one it is. This change logs the names of uncompleted hooks.