### PR TITLE
Prevent a NPE when using groupBy with an attribute in ERXQuery.

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/eof/ERXQuery.java
@@ -311,6 +311,7 @@ public class ERXQuery {
 		// Set defaults
 		fetchKeys = new NSMutableArray<>();
 		groupingKeys = new NSMutableArray<>();
+		groupingAttributes = new NSMutableArray<>();
 		orderings = new NSMutableArray<>();
 		refreshRefetchedObjects = false;
 		usesDistinct = false;
@@ -1275,7 +1276,6 @@ public class ERXQuery {
 		// Initialize arrays for storing the select attributes, 
 		// grouping attributes and sort orderings
 		selectAttributes = new NSMutableArray<>(20);
-		groupingAttributes = new NSMutableArray<>(20);
 		
 		// This keeps track of EOAttribute objects used
 		attributesByName = new NSMutableDictionary<>();


### PR DESCRIPTION
Fixed by intializing the array in constructor like groupingKeys.