### PR TITLE
ERXJavaScript: set the script type attribute via binding or omit it

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRedirect.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXRedirect.java
@@ -10,6 +10,7 @@ import com.webobjects.foundation.NSMutableDictionary;
 
 import er.extensions.appserver.ajax.ERXAjaxApplication;
 import er.extensions.foundation.ERXMutableURL;
+import er.extensions.foundation.ERXProperties;
 
 /**
  * <span class="en">
@@ -364,8 +365,14 @@ public class ERXRedirect extends WOComponent {
 	
 			if (ERXAjaxApplication.isAjaxRequest(context.request())) {
 				boolean hasUpdateContainer = context.request().stringFormValueForKey(ERXAjaxApplication.KEY_UPDATE_CONTAINER_ID) != null;
+				boolean appendDefaultTypeAttribute = ERXProperties.booleanForKeyWithDefault("er.extensions.ERXResponseRewriter.javascriptTypeAttribute", false);
+				
 				if (hasUpdateContainer) {
-					response.appendContentString("<script type=\"text/javascript\">");
+					if(appendDefaultTypeAttribute) {
+						response.appendContentString("<script type=\"text/javascript\">");
+					} else {
+						response.appendContentString("<script>");
+					}
 				}
 				else {
 					response.setHeader("text/javascript", "Content-Type");

--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/components/javascript/ERXJavaScript.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/components/javascript/ERXJavaScript.java
@@ -46,6 +46,7 @@ import er.extensions.foundation.ERXProperties;
  * @binding scriptKey if set, the content will get rendered into an external script src
  * @binding hideInComment boolean that specifies if the script content should
  *   be included in HTML comments, true by default of the script tag contains a script
+ * @binding type defaults to <i>"text/javascript"</i>, if property er.extensions.ERXResponseRewriter.javascriptTypeAttribute is <code>true</code>
  *   
  * @property er.extensions.ERXJavaScript.hideInComment sets globally if the script
  *   content should be included within HTML comments, defaults to <code>true</code>
@@ -86,6 +87,7 @@ public class ERXJavaScript extends WOHTMLDynamicElement {
 	WOAssociation _scriptKey;
 	WOAssociation _hideInComment;
 	WOAssociation _language;
+	WOAssociation _type;
 
 	public ERXJavaScript(String s, NSDictionary<String, WOAssociation> nsdictionary, WOElement woelement) {
 		super("script", nsdictionary, woelement);
@@ -98,6 +100,7 @@ public class ERXJavaScript extends WOHTMLDynamicElement {
 		_hideInComment = _associations.removeObjectForKey("hideInComment");
 		_scriptFramework = _associations.removeObjectForKey("scriptFramework");
 		_framework = _associations.removeObjectForKey("framework");
+		_type = _associations.removeObjectForKey("type");
 		if((_scriptFile != null && _scriptString != null) 
 				|| (_scriptFile != null && (_scriptSource != null || _filename != null)) 
 				|| (_scriptString != null && (_scriptSource != null || _filename != null))) {
@@ -113,8 +116,16 @@ public class ERXJavaScript extends WOHTMLDynamicElement {
 
 	@Override
 	public void appendAttributesToResponse(WOResponse woresponse, WOContext wocontext) {
+		boolean appendDefaultTypeAttribute = ERXProperties.booleanForKeyWithDefault("er.extensions.ERXResponseRewriter.javascriptTypeAttribute", false);
+
 		WOComponent wocomponent = wocontext.component();
-		woresponse._appendContentAsciiString(" type=\"text/javascript\"");
+		
+		if(_type != null) {
+			woresponse._appendContentAsciiString(" type=\""+(String)_type.valueInComponent(wocomponent) +"\"");
+		}
+		else if(appendDefaultTypeAttribute) {
+			woresponse._appendContentAsciiString(" type=\"text/javascript\"");
+		}
 		
 		String framework = null;
 		String scriptName = null;


### PR DESCRIPTION
This PR  is a small fix for #1020.  

In addition, it allows to pass the type attribute via binding to allow the correct embedding of javascript modules