### PR TITLE
Add bindings for role and some aria- attributes

### DIFF
--- a/Frameworks/Ajax/Ajax/Components/AjaxUpdateContainer.api
+++ b/Frameworks/Ajax/Ajax/Components/AjaxUpdateContainer.api
@@ -30,5 +30,10 @@
 		<binding defaults="Boolean" name="stopped"/>
 	    <binding name="class"/>
 	    <binding name="style"/>
+        <binding name="aria-relevant"/>
+        <binding name="aria-live"/>
+        <binding name="aria-atomic"/>
+        <binding name="aria-busy"/>
+        <binding name="role"/>
     </wo>
 </wodefinitions>

--- a/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxUpdateContainer.java
+++ b/Frameworks/Ajax/Ajax/Sources/er/ajax/AjaxUpdateContainer.java
@@ -183,6 +183,11 @@ public class AjaxUpdateContainer extends AjaxDynamicElement {
 				appendTagAttributeToResponse(response, "id", id);
 				appendTagAttributeToResponse(response, "class", valueForBinding("class", component));
 				appendTagAttributeToResponse(response, "style", valueForBinding("style", component));
+				appendTagAttributeToResponse(response, "aria-live", valueForBinding("aria-live", component));
+				appendTagAttributeToResponse(response, "aria-relevant", valueForBinding("aria-relevant", component));
+				appendTagAttributeToResponse(response, "aria-atomic", valueForBinding("aria-atomic", component));
+				appendTagAttributeToResponse(response, "aria-busy", valueForBinding("aria-busy", component));
+				appendTagAttributeToResponse(response, "role", valueForBinding("role", component));
 				appendTagAttributeToResponse(response, "data-updateUrl", AjaxUtils.ajaxComponentActionUrl(context));
 				// appendTagAttributeToResponse(response, "woElementID", context.elementID());
 				response.appendContentString(">");


### PR DESCRIPTION
This PR adds some attributes to the html element generated by an AjaxUpdateContainer.  These attributes  are necessary to inform screen reader how to deal with changing content, e.g. error messages or newsfeeds.
