### PR TITLE
#1025 Proposed fix for bundleless maven app builds

### DIFF
--- a/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
+++ b/Frameworks/Core/ERExtensions/Sources/er/extensions/appserver/ERXApplication.java
@@ -632,11 +632,11 @@ public abstract class ERXApplication extends ERXAjaxApplication implements ERXGr
 				try {
 					Field ClassPath = NSBundle.class.getDeclaredField("ClassPath");
 					ClassPath.setAccessible(true);
-					if (ClassPath.get(NSBundle.class) != null) {
+//					if (ClassPath.get(NSBundle.class) != null) { // condition disabled on 2025-11-03 in an attempt to get bundleless builds to work 
 						Method init = NSBundle.class.getDeclaredMethod("InitMainBundle");
 						init.setAccessible(true);
 						init.invoke(NSBundle.class);
-					}
+//					}
 				}
 				catch (Exception e) {
 					System.err.println(e);


### PR DESCRIPTION
As seen in #1025. The error occurred because `NSBundle.Classpath` was `null` in the check I disabled, meaning `mainBundle()` skipped bundle initialization and returned null. If the check is disabled, a simple test maven application seemingly runs fine using bundleless builds. Why this check is there, I don't know, why it specifically fails with maven builds I have no idea. Added in this commit:

https://github.com/wocommunity/wonder/commit/c4d9ccfcfc7da57f149a1e8612bdbacf096d4aab

My initial guess is that it's meant to check if the main bundle has been successfully  initialized, so I initially thought bypassing it like this might mean we end up with an incompletely initialized bundle. But I don't see anything wrong with the main bundle when the application is up and running.

Since I don't have any actual complex-ish Wonder apps to do further testing on, someone more capable should probably review this and try it out.